### PR TITLE
Add Wikidata QIDs, MoM SPARQL bridge, OKW fixes, and process taxonomy improvements

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -5012,7 +5012,7 @@ This module combines the functionality fr...
 - `render_match_summary(match_summary)`
   - Render a compact human-readable line from a structured match summary....
 
-**Internal Dependencies:** 7 imports
+**Internal Dependencies:** 11 imports
 
 ### `src/core/api/routes/okh.py`
 

--- a/.repo-map.md
+++ b/.repo-map.md
@@ -325,6 +325,8 @@ Total Python files: 419
 │   │   │       def get_gcp_credentials()
 │   │   │       def create_storage_config()
 │   │   │       def get_default_storage_config()
+│   │   │       def get_okw_source()
+│   │   │       def get_mom_config()
 │   │   └── validation.py
 │   │           class ConfigurationError
 │   │           class ConfigurationWarning
@@ -1992,7 +1994,7 @@ Args:
 - `config(ctx)`
   - Show current CLI configuration (server URL, output format, LLM flags)....
 
-**Internal Dependencies:** 1 imports
+**Internal Dependencies:** 3 imports
 
 ### `src/core/main.py`
 

--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 418
+Total Python files: 419
 
 ├── deploy/
 │   ├── __init__.py
@@ -1260,6 +1260,7 @@ Total Python files: 418
 │       │   │           class LayerEvaluation
 │       │   ├── matching_service.py
 │       │   │       class MatchingService (__init__, _normalize_req_cap_lists, _normalize_capability_list...)
+│       │   ├── mom_bridge.py
 │       │   ├── okh_service.py
 │       │   │       class OKHService (__init__)
 │       │   ├── okw_service.py
@@ -1952,7 +1953,7 @@ Total Python files: 418
 
 ## Overview
 
-Total files analyzed: 418
+Total files analyzed: 419
 
 ## Entry Points
 
@@ -2248,6 +2249,9 @@ Supports cascade mode (lega...
 Orchestrates direc...
 
 **Internal Dependencies:** 4 imports
+
+### `src/core/services/mom_bridge.py`
+> MoM SPARQL bridge — query Maps of Making for spaces matching an OHM process....
 
 ### `src/core/services/okh_service.py`
 

--- a/.repo-map.md
+++ b/.repo-map.md
@@ -4723,7 +4723,7 @@ These commands help you...
 
 These commands allow you to insp...
 
-**Internal Dependencies:** 2 imports
+**Internal Dependencies:** 6 imports
 
 ### `src/cli/okh.py`
 > OKH (OpenKnowHow) commands for OHM CLI

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -157,6 +157,22 @@ def config(ctx: Context) -> None:
     click.echo(f"  Model: {config.llm_config['llm_model'] or 'default'}")
     click.echo(f"  Quality Level: {config.llm_config['quality_level']}")
     click.echo(f"  Strict Mode: {config.llm_config['strict_mode']}")
+    click.echo()
+    try:
+        from src.config.storage_config import get_mom_config, get_okw_source
+
+        okw_source = get_okw_source()
+        mom_cfg = get_mom_config()
+        click.echo("OKW Facility Source:")
+        click.echo(f"  Source: {okw_source}  (OKW_SOURCE env var, default: storage)")
+        if okw_source == "mom":
+            click.echo(f"  MoM SPARQL Endpoint: {mom_cfg['endpoint']}")
+        else:
+            click.echo(
+                f"  MoM SPARQL Endpoint: {mom_cfg['endpoint']}  (inactive — set OKW_SOURCE=mom to enable)"
+            )
+    except Exception:
+        pass
 
 
 if __name__ == "__main__":

--- a/src/cli/match.py
+++ b/src/cli/match.py
@@ -461,6 +461,18 @@ async def requirements(
 
                 raise httpx.ConnectError("Use fallback for local facility file")
 
+            # MoM as OKW source requires fallback (API route loads from blob storage only)
+            from src.config.storage_config import get_okw_source
+
+            if (okw_source or get_okw_source()) == "mom":
+                cli_ctx.log(
+                    "OKW source is MoM — SPARQL discovery not supported by HTTP API, using fallback",
+                    "info",
+                )
+                import httpx
+
+                raise httpx.ConnectError("Use fallback for MoM OKW source")
+
             # If nested matching with local file, use fallback (BOM file resolution needs manifest path)
             if max_depth > 0 and not is_url:
                 cli_ctx.log(
@@ -519,7 +531,7 @@ async def requirements(
                         "info",
                     )
                 else:
-                    from ...config.storage_config import get_mom_config, get_okw_source
+                    from src.config.storage_config import get_mom_config, get_okw_source
 
                     effective_source = okw_source or get_okw_source()
 
@@ -545,7 +557,7 @@ async def requirements(
 
                         okw_service = await OKWService.get_instance()
                         try:
-                            from ...config.storage_config import (
+                            from src.config.storage_config import (
                                 get_default_storage_config,
                             )
 

--- a/src/cli/match.py
+++ b/src/cli/match.py
@@ -65,6 +65,21 @@ def match_group() -> None:
     help="Local facility file to use for matching (testing/debugging)",
 )
 @click.option(
+    "--okw-source",
+    "okw_source",
+    type=click.Choice(["storage", "mom"]),
+    default=None,
+    envvar="OKW_SOURCE",
+    help=(
+        "Where to load OKW facility candidates from. "
+        "'storage' (default) reads from the configured blob storage backend "
+        "(STORAGE_PROVIDER: local, azure_blob, aws_s3, gcs). "
+        "'mom' queries the Maps of Making public SPARQL endpoint, resolving each "
+        "required process to a Wikidata IRI — no credentials required. "
+        "Override the MoM endpoint with MOM_SPARQL_ENDPOINT."
+    ),
+)
+@click.option(
     "--access-type",
     type=click.Choice(["public", "private", "restricted"]),
     help="Filter by facility access type",
@@ -263,6 +278,7 @@ async def requirements(
     input_file: str,
     domain: Optional[str],
     facility_file: Optional[str],
+    okw_source: Optional[str],
     access_type: Optional[str],
     facility_status: Optional[str],
     location: Optional[str],
@@ -503,36 +519,59 @@ async def requirements(
                         "info",
                     )
                 else:
-                    from ..core.services.okw_service import OKWService
+                    from ...config.storage_config import get_mom_config, get_okw_source
 
-                    okw_service = await OKWService.get_instance()
-                    # Log which storage we're using (helps debug "no facilities" when remote is populated)
-                    try:
-                        from ...config.storage_config import get_default_storage_config
+                    effective_source = okw_source or get_okw_source()
 
-                        cfg = get_default_storage_config()
+                    if effective_source == "mom":
+                        from ..core.services.mom_bridge import (
+                            fetch_mom_facilities_for_manifest,
+                        )
+
+                        mom_cfg = get_mom_config()
                         cli_ctx.log(
-                            f"Loading facilities from storage: provider={cfg.provider}, container/bucket={cfg.bucket_name}",
+                            f"Loading facilities from MoM SPARQL endpoint: {mom_cfg['endpoint']}",
                             "info",
                         )
-                    except Exception:
-                        pass
-                    filter_params = {}
-                    if filters.get("access_type"):
-                        filter_params["access_type"] = filters.get("access_type")
-                    if filters.get("facility_status"):
-                        filter_params["facility_status"] = filters.get(
-                            "facility_status"
+                        facilities = await fetch_mom_facilities_for_manifest(
+                            manifest, endpoint=mom_cfg["endpoint"]
                         )
-                    if filters.get("location"):
-                        filter_params["location"] = filters.get("location")
-                    facilities, _ = await okw_service.list(
-                        filter_params=filter_params if filter_params else None
-                    )
-                    cli_ctx.log(
-                        f"Loaded {len(facilities)} facility(ies) from storage",
-                        "info",
-                    )
+                        cli_ctx.log(
+                            f"Loaded {len(facilities)} facility(ies) from MoM",
+                            "info",
+                        )
+                    else:
+                        from ..core.services.okw_service import OKWService
+
+                        okw_service = await OKWService.get_instance()
+                        try:
+                            from ...config.storage_config import (
+                                get_default_storage_config,
+                            )
+
+                            cfg = get_default_storage_config()
+                            cli_ctx.log(
+                                f"Loading facilities from storage: provider={cfg.provider}, container/bucket={cfg.bucket_name}",
+                                "info",
+                            )
+                        except Exception:
+                            pass
+                        filter_params = {}
+                        if filters.get("access_type"):
+                            filter_params["access_type"] = filters.get("access_type")
+                        if filters.get("facility_status"):
+                            filter_params["facility_status"] = filters.get(
+                                "facility_status"
+                            )
+                        if filters.get("location"):
+                            filter_params["location"] = filters.get("location")
+                        facilities, _ = await okw_service.list(
+                            filter_params=filter_params if filter_params else None
+                        )
+                        cli_ctx.log(
+                            f"Loaded {len(facilities)} facility(ies) from storage",
+                            "info",
+                        )
 
                 # Apply additional filters that aren't supported by okw_service.list()
                 # (e.g., capabilities, materials would need more complex matching logic)

--- a/src/config/storage_config.py
+++ b/src/config/storage_config.py
@@ -204,3 +204,63 @@ def get_default_storage_config() -> StorageConfig:
     """
     provider = _env("STORAGE_PROVIDER") or "local"
     return create_storage_config(provider)
+
+
+# ---------------------------------------------------------------------------
+# OKW facility source (separate from blob storage provider)
+# ---------------------------------------------------------------------------
+
+_MOM_SPARQL_DEFAULT = "https://mapsofmaking.org/sparql/query"
+
+
+def get_okw_source() -> str:
+    """Return the OKW facility data source used during match requests.
+
+    Set the ``OKW_SOURCE`` environment variable to switch at runtime.
+
+    Values
+    ------
+    storage (default)
+        Load facilities from the configured blob storage backend
+        (``STORAGE_PROVIDER``). Supports local, Azure Blob, AWS S3, GCS.
+
+    mom
+        Query the Maps of Making public SPARQL endpoint. No credentials
+        required. Endpoint configured by ``MOM_SPARQL_ENDPOINT``
+        (see :func:`get_mom_config`). OHM translates each OKH process
+        requirement to a Wikidata IRI via the taxonomy and issues a
+        SPARQL query against MoM's Oxigraph store.
+
+    Returns
+    -------
+    str
+        ``"storage"`` or ``"mom"``. Unknown values fall back to
+        ``"storage"`` with a warning log.
+    """
+    source = _env("OKW_SOURCE") or "storage"
+    if source not in ("storage", "mom"):
+        logger.warning(
+            "Unknown OKW_SOURCE value %r — falling back to 'storage'", source
+        )
+        return "storage"
+    return source
+
+
+def get_mom_config() -> Dict[str, str]:
+    """Return Maps of Making (MoM) integration configuration.
+
+    Environment variables
+    ---------------------
+    MOM_SPARQL_ENDPOINT
+        Public SPARQL query endpoint for MoM's Oxigraph triplestore.
+        Default: ``https://mapsofmaking.org/sparql/query``
+        No authentication required.
+
+    Returns
+    -------
+    dict
+        ``{"endpoint": <sparql_url>}``
+    """
+    return {
+        "endpoint": _env("MOM_SPARQL_ENDPOINT") or _MOM_SPARQL_DEFAULT,
+    }

--- a/src/config/taxonomy/processes.yaml
+++ b/src/config/taxonomy/processes.yaml
@@ -55,6 +55,7 @@ processes:
   3d_printing:
     display_name: "3D Printing"
     tsdc_code: "3DP"
+    wikidata_qid: "Q785781"
     aliases:
       - "3dp"
       - "3d printing"
@@ -109,6 +110,7 @@ processes:
   cnc_machining:
     display_name: "CNC Machining"
     tsdc_code: "CNC"
+    wikidata_qid: "Q644395"
     aliases:
       - "cnc"
       - "cnc machining"
@@ -120,6 +122,7 @@ processes:
   cnc_milling:
     display_name: "CNC Milling"
     parent: "cnc_machining"
+    wikidata_qid: "Q179507"
     aliases:
       - "cnc milling"
       - "cnc_milling"
@@ -130,6 +133,7 @@ processes:
   cnc_turning:
     display_name: "CNC Turning"
     parent: "cnc_machining"
+    wikidata_qid: "Q1260093"
     aliases:
       - "cnc turning"
       - "cnc_turning"
@@ -144,6 +148,7 @@ processes:
   laser_cutting:
     display_name: "Laser Cutting"
     tsdc_code: "LAS"
+    wikidata_qid: "Q3062349"
     aliases:
       - "las"
       - "laser"
@@ -158,6 +163,7 @@ processes:
   pcb_fabrication:
     display_name: "PCB Fabrication"
     tsdc_code: "PCB"
+    wikidata_qid: "Q1047286"
     aliases:
       - "pcb"
       - "pcb fabrication"
@@ -200,6 +206,7 @@ processes:
   electronics_assembly:
     display_name: "Electronics Assembly"
     parent: "assembly"
+    wikidata_qid: "Q11650"
     aliases:
       - "electronics assembly"
       - "electronics_assembly"
@@ -222,6 +229,7 @@ processes:
   welding:
     display_name: "Welding"
     tsdc_code: "WEL"
+    wikidata_qid: "Q12544"
     aliases:
       - "wel"
       - "welding"
@@ -436,6 +444,7 @@ processes:
 
   painting:
     display_name: "Painting"
+    wikidata_qid: "Q11629"
     aliases:
       - "painting"
       - "paint"

--- a/src/config/taxonomy/processes.yaml
+++ b/src/config/taxonomy/processes.yaml
@@ -55,7 +55,7 @@ processes:
   3d_printing:
     display_name: "3D Printing"
     tsdc_code: "3DP"
-    wikidata_qid: "Q785781"
+    wikidata_qid: "Q229367"
     aliases:
       - "3dp"
       - "3d printing"
@@ -110,7 +110,7 @@ processes:
   cnc_machining:
     display_name: "CNC Machining"
     tsdc_code: "CNC"
-    wikidata_qid: "Q644395"
+    wikidata_qid: "Q174689"
     aliases:
       - "cnc"
       - "cnc machining"

--- a/src/core/api/models/okw/response.py
+++ b/src/core/api/models/okw/response.py
@@ -28,6 +28,7 @@ class Capability(BaseModel):
 class OKWResponse(SuccessResponse, LLMResponseMixin):
     """Response model for OKW facilities with standardized fields and LLM information"""
 
+    message: str = "OKW facility operation completed successfully"
     id: UUID
     name: str
     location: Dict[str, Any]

--- a/src/core/api/routes/match.py
+++ b/src/core/api/routes/match.py
@@ -264,7 +264,15 @@ async def match_requirements_to_capabilities(
 
         # 3. Get available facilities with filtering
         facilities = await _get_filtered_facilities(
-            storage_service, request, request_id, domain=domain
+            storage_service,
+            request,
+            request_id,
+            domain=domain,
+            okh_manifest=(
+                requirements_data
+                if isinstance(requirements_data, OKHManifest)
+                else None
+            ),
         )
 
         if domain == "manufacturing" and required_processes and facilities:
@@ -2252,6 +2260,7 @@ async def _get_filtered_facilities(
     request: MatchRequest,
     request_id: str,
     domain: str = "manufacturing",
+    okh_manifest: Optional[OKHManifest] = None,
 ) -> List[Any]:
     """Get facilities with applied filters.
 
@@ -2326,35 +2335,80 @@ async def _get_filtered_facilities(
                         },
                     )
                 else:
-                    # Get all facilities using OKWService with proper pagination.
-                    # list() skips kitchen files — returns ManufacturingFacility only.
-                    okw_service = await OKWService.get_instance()
+                    from src.config.storage_config import get_mom_config, get_okw_source
 
-                    all_facilities = []
-                    page = 1
-                    page_size = 1000
-
-                    while True:
-                        facilities_batch, _ = await okw_service.list(
-                            page=page, page_size=page_size
+                    if get_okw_source() == "mom" and okh_manifest is not None:
+                        from src.core.services.mom_bridge import (
+                            fetch_mom_facilities_for_manifest,
                         )
-                        all_facilities.extend(facilities_batch)
 
-                        if len(facilities_batch) < page_size:
-                            break
+                        mom_cfg = get_mom_config()
+                        logger.info(
+                            "Loading OKW facilities from MoM SPARQL endpoint",
+                            extra={
+                                "request_id": request_id,
+                                "domain": domain,
+                                "endpoint": mom_cfg["endpoint"],
+                            },
+                        )
+                        facilities = await fetch_mom_facilities_for_manifest(
+                            okh_manifest, endpoint=mom_cfg["endpoint"]
+                        )
+                        logger.info(
+                            "Facility candidates loaded from MoM SPARQL",
+                            extra={
+                                "request_id": request_id,
+                                "domain": domain,
+                                "endpoint": mom_cfg["endpoint"],
+                                "facility_count": len(facilities),
+                            },
+                        )
+                    else:
+                        # Get all facilities using OKWService with proper pagination.
+                        # list() skips kitchen files — returns ManufacturingFacility only.
+                        from src.config.storage_config import get_default_storage_config
 
-                        page += 1
+                        try:
+                            cfg = get_default_storage_config()
+                            logger.info(
+                                "Loading OKW facilities from blob storage",
+                                extra={
+                                    "request_id": request_id,
+                                    "domain": domain,
+                                    "provider": cfg.provider,
+                                    "bucket": cfg.bucket_name,
+                                },
+                            )
+                        except Exception:
+                            pass
 
-                    facilities = all_facilities
-                    logger.info(
-                        "Facility candidates loaded from remote OKW storage listing "
-                        "(MATCHING_LOCAL_OKW_JSON_DIR was unset or invalid)",
-                        extra={
-                            "request_id": request_id,
-                            "domain": domain,
-                            "facility_count": len(facilities),
-                        },
-                    )
+                        okw_service = await OKWService.get_instance()
+
+                        all_facilities = []
+                        page = 1
+                        page_size = 1000
+
+                        while True:
+                            facilities_batch, _ = await okw_service.list(
+                                page=page, page_size=page_size
+                            )
+                            all_facilities.extend(facilities_batch)
+
+                            if len(facilities_batch) < page_size:
+                                break
+
+                            page += 1
+
+                        facilities = all_facilities
+                        logger.info(
+                            "Facility candidates loaded from remote OKW storage listing "
+                            "(MATCHING_LOCAL_OKW_JSON_DIR was unset or invalid)",
+                            extra={
+                                "request_id": request_id,
+                                "domain": domain,
+                                "facility_count": len(facilities),
+                            },
+                        )
 
         elif domain == "cooking":
             expected_type = KitchenCapability

--- a/src/core/api/routes/taxonomy.py
+++ b/src/core/api/routes/taxonomy.py
@@ -50,6 +50,7 @@ async def get_taxonomy(http_request: Request = None) -> Any:
                 "parent": defn.parent,
                 "aliases": sorted(defn.aliases),
                 "children": sorted(taxonomy.get_children(cid)),
+                "wikidata_iri": taxonomy.get_wikidata_iri(cid),
             }
         )
 

--- a/src/core/models/okw.py
+++ b/src/core/models/okw.py
@@ -862,18 +862,22 @@ class ManufacturingFacility:
             tomli_w.dump(self.to_dict(), f)
 
     def has_process(self, process_name: str) -> bool:
-        """
-        Check if the facility supports a given manufacturing process.
+        """Check if the facility supports a given manufacturing process."""
+        from ..taxonomy import taxonomy
 
-        Matches against manufacturing_processes (exact or substring) and
-        equipment capability descriptions.
-        """
-        process_lower = process_name.lower()
+        req_id = taxonomy.normalize(process_name)
 
         for process_url in self.manufacturing_processes:
-            if process_lower in process_url.lower():
+            if req_id:
+                cap_id = taxonomy.normalize(process_url)
+                if cap_id and (
+                    req_id == cap_id or req_id in (taxonomy.get_ancestors(cap_id) or [])
+                ):
+                    return True
+            if process_name.lower() in process_url.lower():
                 return True
 
+        process_lower = process_name.lower()
         for item in self.equipment:
             if process_lower in item.equipment_type.lower():
                 return True
@@ -881,3 +885,28 @@ class ManufacturingFacility:
                 return True
 
         return False
+
+    def to_spaceapi_json(self) -> Dict:
+        """Serialize to a SpaceAPI-compatible envelope for MoM ingestion."""
+        doc: Dict = {
+            "space": self.name,
+            "state": {"open": self.facility_status == FacilityStatus.ACTIVE},
+        }
+
+        if self.location.gps_coordinates:
+            try:
+                lat_str, lon_str = self.location.gps_coordinates.split(",", 1)
+                doc["location"] = {
+                    "lat": float(lat_str.strip()),
+                    "lon": float(lon_str.strip()),
+                }
+            except (ValueError, AttributeError):
+                pass
+
+        if self.description:
+            doc["description"] = self.description
+
+        if self.manufacturing_processes:
+            doc["ext_fablab"] = {"capabilities": self.manufacturing_processes}
+
+        return doc

--- a/src/core/services/mom_bridge.py
+++ b/src/core/services/mom_bridge.py
@@ -1,0 +1,68 @@
+"""MoM SPARQL bridge — query Maps of Making for spaces matching an OHM process."""
+
+from __future__ import annotations
+
+import httpx
+
+from ..taxonomy import taxonomy
+
+MOM_SPARQL_ENDPOINT = "https://mapsofmaking.org/sparql/query"
+
+_SPARQL_TEMPLATE = """
+SELECT DISTINCT ?space ?name ?lat ?lon WHERE {{
+  GRAPH ?g {{
+    ?space a <https://nicolasdb.github.io/mapsofmaking_ontology/ns#Space> ;
+           <https://schema.org/name> ?name ;
+           <https://schema.org/geo> [ <https://schema.org/latitude> ?lat ;
+                                       <https://schema.org/longitude> ?lon ] ;
+           <https://schema.org/knowsAbout> ?tag .
+  }}
+  GRAPH <urn:mak:ontology/mom> {{
+    ?concept <http://www.w3.org/2004/02/skos/core#prefLabel>|
+             <http://www.w3.org/2004/02/skos/core#altLabel> ?tag ;
+             <http://www.w3.org/2002/07/owl#sameAs> <{wikidata_iri}> .
+  }}
+}}
+"""
+
+
+async def query_mom_spaces_for_process(
+    canonical_id: str,
+    endpoint: str = MOM_SPARQL_ENDPOINT,
+    timeout: float = 10.0,
+) -> list[dict]:
+    """Query MoM SPARQL for spaces that have a given manufacturing process.
+
+    Args:
+        canonical_id: OHM canonical process ID (e.g. "laser_cutting").
+        endpoint: MoM SPARQL endpoint URL.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        List of dicts with keys: space (IRI), name, lat, lon.
+        Returns empty list if the process has no Wikidata QID or the endpoint
+        returns no results.
+    """
+    wikidata_iri = taxonomy.get_wikidata_iri(canonical_id)
+    if not wikidata_iri:
+        return []
+
+    sparql = _SPARQL_TEMPLATE.format(wikidata_iri=wikidata_iri)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.post(
+            endpoint,
+            data={"query": sparql},
+            headers={"Accept": "application/sparql-results+json"},
+        )
+    response.raise_for_status()
+
+    bindings = response.json().get("results", {}).get("bindings", [])
+    return [
+        {
+            "space": b["space"]["value"],
+            "name": b["name"]["value"],
+            "lat": float(b["lat"]["value"]),
+            "lon": float(b["lon"]["value"]),
+        }
+        for b in bindings
+    ]

--- a/src/core/services/mom_bridge.py
+++ b/src/core/services/mom_bridge.py
@@ -66,3 +66,70 @@ async def query_mom_spaces_for_process(
         }
         for b in bindings
     ]
+
+
+async def fetch_mom_facilities_for_manifest(
+    manifest: object,
+    endpoint: str = MOM_SPARQL_ENDPOINT,
+    timeout: float = 10.0,
+) -> list:
+    """Fetch ManufacturingFacility stubs from MoM for processes required by an OKH manifest.
+
+    Extracts all required process names from the manifest, resolves each to a
+    Wikidata IRI via the taxonomy, and queries MoM's SPARQL endpoint.  Spaces
+    that match multiple required processes are returned as a single facility with
+    all matched processes listed so the matching pipeline can score them correctly.
+
+    Args:
+        manifest: OKHManifest instance.
+        endpoint: MoM SPARQL endpoint URL.
+        timeout: HTTP request timeout per query in seconds.
+
+    Returns:
+        List of ManufacturingFacility objects.  Empty if no processes resolve
+        to Wikidata IRIs or the endpoint returns no results.
+    """
+    from ..models.okw import FacilityStatus, Location, ManufacturingFacility
+
+    # Gather required process names from both flat list and structured specs
+    process_names: list[str] = []
+    if getattr(manifest, "manufacturing_processes", None):
+        process_names.extend(manifest.manufacturing_processes)
+    if hasattr(manifest, "extract_requirements"):
+        for req in manifest.extract_requirements():
+            pname = getattr(req, "process_name", None)
+            if pname and pname not in process_names:
+                process_names.append(pname)
+
+    if not process_names:
+        return []
+
+    # Query MoM per process; accumulate space IRI → {name, lat, lon, processes}
+    space_data: dict[str, dict] = {}
+    for process_name in process_names:
+        cid = taxonomy.normalize(process_name)
+        if not cid:
+            continue
+        for space in await query_mom_spaces_for_process(
+            cid, endpoint=endpoint, timeout=timeout
+        ):
+            iri = space["space"]
+            if iri not in space_data:
+                space_data[iri] = {
+                    "name": space["name"],
+                    "lat": space["lat"],
+                    "lon": space["lon"],
+                    "processes": [],
+                }
+            space_data[iri]["processes"].append(process_name)
+
+    # One ManufacturingFacility stub per unique MoM space
+    return [
+        ManufacturingFacility(
+            name=data["name"],
+            location=Location(gps_coordinates=f"{data['lat']}, {data['lon']}"),
+            facility_status=FacilityStatus.ACTIVE,
+            manufacturing_processes=data["processes"],
+        )
+        for data in space_data.values()
+    ]

--- a/src/core/taxonomy/process_taxonomy.py
+++ b/src/core/taxonomy/process_taxonomy.py
@@ -55,6 +55,7 @@ class ProcessDefinition:
     tsdc_code: Optional[str] = None
     parent: Optional[str] = None
     aliases: FrozenSet[str] = field(default_factory=frozenset)
+    wikidata_qid: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -830,6 +831,7 @@ def load_from_yaml(path: Path) -> List[ProcessDefinition]:
             )
 
         aliases = frozenset(str(a) for a in raw_aliases if a)
+        wikidata_qid = entry.get("wikidata_qid")
 
         definitions.append(
             ProcessDefinition(
@@ -838,6 +840,7 @@ def load_from_yaml(path: Path) -> List[ProcessDefinition]:
                 tsdc_code=str(tsdc_code) if tsdc_code else None,
                 parent=str(parent) if parent else None,
                 aliases=aliases,
+                wikidata_qid=str(wikidata_qid) if wikidata_qid else None,
             )
         )
 
@@ -976,6 +979,9 @@ class ProcessTaxonomy:
         # Hierarchy: canonical_id -> set of child canonical_ids
         self._children: Dict[str, Set[str]] = {}
 
+        # Lookup: canonical_id -> Wikidata QID string (e.g. "Q3062349")
+        self._wikidata_map: Dict[str, str] = {}
+
         # Track which file was loaded (None means built-in definitions)
         self._source_path: Optional[Path] = None
 
@@ -1029,6 +1035,7 @@ class ProcessTaxonomy:
         self._alias_map = {}
         self._tsdc_map = {}
         self._children = {}
+        self._wikidata_map = {}
         self._build(new_definitions)
         self._source_path = path
 
@@ -1087,6 +1094,10 @@ class ProcessTaxonomy:
                 self._tsdc_map[tsdc_upper] = cid
                 # Also register TSDC code as alias (case-insensitive)
                 self._register_alias(defn.tsdc_code, cid)
+
+            # Register Wikidata QID
+            if defn.wikidata_qid:
+                self._wikidata_map[cid] = defn.wikidata_qid
 
         # Build children map from parent references
         for defn in definitions:
@@ -1340,6 +1351,19 @@ class ProcessTaxonomy:
             ProcessDefinition or None.
         """
         return self._definitions.get(canonical_id)
+
+    def get_wikidata_iri(self, canonical_id: str) -> Optional[str]:
+        """Return the Wikidata entity IRI for a canonical process ID.
+
+        Args:
+            canonical_id: A canonical process ID.
+
+        Returns:
+            Full Wikidata IRI (e.g. "https://www.wikidata.org/entity/Q3062349"),
+            or None if no Wikidata QID is associated with this process.
+        """
+        qid = self._wikidata_map.get(canonical_id)
+        return f"https://www.wikidata.org/entity/{qid}" if qid else None
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/tests/unit/test_smart_discovery_strategy_cascade.py
+++ b/tests/unit/test_smart_discovery_strategy_cascade.py
@@ -20,7 +20,6 @@ import pytest
 
 from src.core.storage.smart_discovery import SmartFileDiscovery
 
-
 # ---------------------------------------------------------------------------
 # Fake storage managers
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -3163,7 +3163,7 @@ wheels = [
 
 [[package]]
 name = "supply-graph-ai"
-version = "0.8.3"
+version = "0.8.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- **Wikidata QIDs**: Added `wikidata_qid` to 9 processes in `processes.yaml` (3D printing, CNC machining/milling/turning, laser cutting, PCB fabrication, electronics assembly, welding, painting). Exposed as `wikidata_iri` field in `GET /api/taxonomy` response.
- **MoM SPARQL bridge** (`src/core/services/mom_bridge.py`): New async service that queries the [Maps of Making](https://mapsofmaking.org) SPARQL endpoint for makerspaces that have a given manufacturing process, matched via Wikidata IRI alignment. Uses `httpx.AsyncClient` per project convention.
- **OKWResponse fix**: Added missing `message: str` field to `OKWResponse` — previously caused HTTP 500 on `POST /v1/api/okw/create`.
- **`has_process()` rewrite**: Now uses `taxonomy.normalize()` + `taxonomy.get_ancestors()` for hierarchical process matching (e.g. querying for "cnc_machining" matches a facility that lists "cnc_milling"), with substring fallback for unrecognized process strings.
- **`to_spaceapi_json()`**: New method on `OKWFacility` that serializes a facility to the [SpaceAPI](https://spaceapi.io) envelope format, enabling MoM ingestion.

## Test plan

- [ ] `make ready` passes (format, lint, tests, parity, docs)
- [ ] `GET /api/taxonomy` response includes `wikidata_iri` on processes that have QIDs, `null` on those that don't
- [ ] `POST /v1/api/okw/create` returns 200 (not 500) — OKWResponse message fix
- [ ] `has_process("cnc_machining")` returns `True` for a facility listing `cnc_milling` (ancestor match)
- [ ] `to_spaceapi_json()` returns a valid SpaceAPI envelope with `space`, `state`, and `location` keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)