### PR TITLE
fix(nlp): pin spaCy model as locked dependency; one-step contributor setup

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 428
+Total Python files: 430
 
 ├── deploy/
 │   ├── __init__.py
@@ -187,6 +187,9 @@ Total Python files: 428
 │   │       def read_pyproject_version()
 │   │       def major_minor()
 │   │       def write_github_output()
+│   │       def main()
+│   ├── verify_dev_env.py
+│   │       def check_spacy_model()
 │   │       def main()
 │   └── verify_newformats_matching.py
 ├── src/
@@ -1784,6 +1787,9 @@ Total Python files: 428
         │       def test_gcp_with_defaults_defaults_cors_origins()
         │       def test_azure_with_defaults_defaults_cors_origins()
         │       def test_aws_with_defaults_defaults_cors_origins()
+        ├── test_dev_env_spacy_model.py
+        │       def _load_verifier()
+        │       def test_spacy_model_is_installed_and_loadable()
         ├── test_geographic_facility_filtering.py
         │       def _make_facility()
         │       def matches_filters()
@@ -2007,7 +2013,7 @@ Total Python files: 428
 
 ## Overview
 
-Total files analyzed: 428
+Total files analyzed: 430
 
 ## Entry Points
 
@@ -3639,6 +3645,17 @@ Args...
 
 **Internal Dependencies:** 13 imports
 
+### `tests/unit/test_dev_env_spacy_model.py`
+> CI guard: the spaCy model must be a real, loadable, locked dependency.
+
+The other spaCy tests mock t...
+
+**Exports:** test_spacy_model_is_installed_and_loadable
+
+**Functions:**
+- `test_spacy_model_is_installed_and_loadable()`
+  - The pinned spaCy model must load in a properly provisioned environment....
+
 ### `tests/unit/test_repair_model.py`
 > Unit tests for TriageAction derivation logic and TriageReport model....
 
@@ -4647,6 +4664,20 @@ Usage:
 - `major_minor(version)`
 - `write_github_output(version)`
 - `main()`
+
+### `scripts/verify_dev_env.py`
+> Verify the local dev environment is fully provisioned.
+
+Fails loudly when a historically fragile dep...
+
+**Exports:** check_spacy_model, main
+
+**Functions:**
+- `check_spacy_model()`
+  - Assert the spaCy English model actually loads; return a version string....
+- `main()`
+
+**Internal Dependencies:** 1 imports
 
 ### `scripts/verify_newformats_matching.py`
 > Verify that matching in the 'newformats' container produces valid matches.

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,10 @@ COPY config/ ./config/
 
 RUN uv sync --frozen --no-dev --no-editable
 
-# Required for NLP processing
-RUN python -m spacy download en_core_web_md
+# The spaCy model (en_core_web_md) is a pinned dependency in pyproject.toml /
+# uv.lock, so the syncs above already installed it into /opt/venv. No separate
+# `spacy download` step — that installed it untracked, and uv's exact sync then
+# removed it on subsequent syncs.
 
 # Stage 2: Runtime image
 FROM python:3.12-slim AS runtime

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,20 @@
 # Code style and project map via uv-managed environment.
-.PHONY: format format-check lint test check black ruff repo-map validate-docs parity ready
+.PHONY: format format-check lint test check black ruff repo-map validate-docs parity ready setup verify-env
+
+# One-step contributor setup. Provisions the full uv-managed environment (all
+# dependencies incl. the pinned spaCy model) and verifies it is fully online.
+# Idempotent — safe to re-run any time to repair/refresh the environment.
+setup:
+	@command -v uv >/dev/null 2>&1 || { \
+	  echo "uv not found. Install it: https://docs.astral.sh/uv/getting-started/installation/"; \
+	  exit 1; }
+	uv sync --extra dev
+	$(MAKE) verify-env
+
+# Fail loudly if a historically fragile dependency is missing or unloadable.
+# Pure verification (no mutation), so it is also a step in the `ready` gate.
+verify-env:
+	uv run python scripts/verify_dev_env.py
 
 format: black ruff repo-map
 
@@ -34,9 +49,10 @@ parity:
 # Definition of done. Green tests are not "ready to merge"; this is.
 # Each step verifies (does not mutate) and fails fast. Run before any MR.
 ready:
-	@echo "==> [1/5] format check";    $(MAKE) format-check
-	@echo "==> [2/5] lint";            $(MAKE) lint
-	@echo "==> [3/5] unit tests";      $(MAKE) test
-	@echo "==> [4/5] service parity";  $(MAKE) parity
-	@echo "==> [5/5] docs ↔ code";     $(MAKE) validate-docs
+	@echo "==> [1/6] env verify";      $(MAKE) verify-env
+	@echo "==> [2/6] format check";    $(MAKE) format-check
+	@echo "==> [3/6] lint";            $(MAKE) lint
+	@echo "==> [4/6] unit tests";      $(MAKE) test
+	@echo "==> [5/6] service parity";  $(MAKE) parity
+	@echo "==> [6/6] docs ↔ code";     $(MAKE) validate-docs
 	@echo "==> READY: all gates passed."

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ cd supply-graph-ai
 # 2. Create your environment file
 cp env.template .env
 
-# 3. Install all dependencies (if needed)
-uv sync
+# 3. Provision the environment (one step)
+make setup
 
 # 4. Activate the virtual environment
 source .venv/bin/activate          # macOS / Linux
@@ -103,11 +103,11 @@ ohm --help
 docker compose up -d ohm-api
 ```
 
-To include development dependencies (**pytest must live in this venv** so `uv run pytest` does not pick up a foreign interpreter from `PATH`):
-
-```bash
-uv sync --extra dev
-```
+`make setup` creates `.venv`, installs **all** dependencies (runtime + dev tools
+for tests, so `uv run pytest` uses this venv rather than a foreign interpreter on
+`PATH`), **including the spaCy NLP model** `en_core_web_md` — which is pinned in
+`uv.lock`, so you never install it by hand. It then verifies the environment is
+fully online, and is safe to re-run any time to repair or refresh it.
 
 You can also run one-off commands without activating the venv:
 
@@ -250,7 +250,7 @@ docker compose up --build ohm-api
 # Interactive docs:  http://localhost:8001/v1/docs
 ```
 
-### CLI commands (requires uv setup from Option B above)
+### CLI commands (requires uv setup from Option C above)
 
 ```bash
 # Health check

--- a/docs/development/local-development-setup.md
+++ b/docs/development/local-development-setup.md
@@ -58,14 +58,23 @@ The Supply Graph AI server provides the matching engine API that the frontend co
 cd supply-graph-ai
 ```
 
-#### Step 2: Install Python dependencies with uv
+#### Step 2: Provision the environment (one step)
 
 From the `supply-graph-ai` directory:
 
 ```bash
-# Create .venv, install locked deps, and the `ohm` entrypoint (includes dev tools for tests)
-uv sync --extra dev
+make setup
 ```
+
+This creates `.venv`, installs all locked dependencies (including the spaCy
+NLP model `en_core_web_md`, which is pinned in `uv.lock`), and verifies the
+environment is fully online. It is idempotent — re-run it any time to repair or
+refresh your environment.
+
+> **Why not `python -m spacy download`?** The spaCy model is a pinned dependency
+> in `pyproject.toml`/`uv.lock`, so `uv sync` installs and preserves it.
+> Installing it out-of-band leaves it untracked, and uv's exact sync then
+> deletes it on the next `uv run`/`uv sync` — the model would keep "disappearing."
 
 Optional docs / MkDocs plugins:
 
@@ -73,32 +82,19 @@ Optional docs / MkDocs plugins:
 uv sync --extra docs
 ```
 
-#### Step 3: Install spaCy models
-
-The NLP matching functionality requires spaCy language models. Install the recommended model:
-
-```bash
-uv run python -m spacy download en_core_web_md
-
-# Optional: larger model (more disk)
-# uv run python -m spacy download en_core_web_lg
-```
-
-**Note**: The system will automatically fall back to `en_core_web_sm` if the preferred models are not available, but the medium model (`en_core_web_md`) provides better semantic similarity matching with word vectors.
-
-#### Step 4: Create Logs Directory (if needed)
+#### Step 3: Create Logs Directory (if needed)
 ```bash
 mkdir -p logs
 ```
 
-#### Step 5: Start the Server
+#### Step 4: Start the Server
 ```bash
 docker compose up --build ohm-api
 ```
 
 The server will start on **http://localhost:8001**
 
-#### Step 6: Verify Installation
+#### Step 5: Verify Installation
 - Open your browser to: **http://localhost:8001/v1/docs**
 - You should see the FastAPI interactive documentation for the versioned API
 - Health check: **http://localhost:8001/health**
@@ -310,29 +306,30 @@ kill -9 <PID>
 
 #### 2. Python environment issues (uv)
 ```bash
-# Recreate the project venv from the lockfile
+# Recreate and re-verify the project venv from the lockfile
 rm -rf .venv
-uv sync --extra dev
+make setup
 ```
 
 #### 2a. spaCy Model Not Found
-If you see warnings about spaCy models not being found:
+If you see warnings about spaCy models not being found, your environment is out
+of sync with the lockfile (the model `en_core_web_md` is a pinned dependency).
+Re-provision it:
 ```bash
-# Verify spaCy is installed
-uv run python -c "import spacy; print(spacy.__version__)"
-
-# Check available models
-uv run python -m spacy info
-
-# Install the recommended model
-uv run python -m spacy download en_core_web_md
+make setup
 ```
 
-**Symptoms**: You may see warnings like:
-- `spaCy model 'en_core_web_md' not found, trying next...`
-- `[W007] The model you're using has no word vectors loaded`
+`make setup` runs a verification step that fails loudly if the model cannot
+load, so a broken environment is caught immediately rather than silently
+degrading matching to the string/heuristic layers. To check the model directly:
+```bash
+make verify-env
+# or: uv run python -m spacy info
+```
 
-**Solution**: Install the spaCy model as shown above. The system will work with `en_core_web_sm` (installed by default), but `en_core_web_md` provides better semantic matching.
+**Do not** run `python -m spacy download` — installing the model out-of-band
+leaves it untracked, and uv's exact sync will delete it on the next
+`uv run`/`uv sync`.
 
 #### 3. Node.js Dependencies Issues
 ```bash

--- a/docs/matching/nlp-matching.md
+++ b/docs/matching/nlp-matching.md
@@ -368,12 +368,15 @@ python -m spacy download en_core_web_lg
 
 #### spaCy Model Not Found
 ```
-OSError: [E050] Can't find model 'en_core_web_sm'
+OSError: [E050] Can't find model 'en_core_web_md'
 ```
-**Solution**: Install spaCy model:
+**Solution**: Re-provision the environment — the model is a pinned dependency in
+`uv.lock`, so this reinstalls it:
 ```bash
-python -m spacy download en_core_web_sm
+make setup
 ```
+Do **not** run `python -m spacy download`: an out-of-band install is untracked
+and uv's exact sync deletes it on the next `uv run`/`uv sync`.
 
 #### Memory Issues
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,12 @@ dependencies = [
     "tqdm",
     # NLP
     "spacy>=3.7.0",
+    # spaCy English model, pinned as a locked dependency so `uv sync` installs and
+    # preserves it. Installing via `python -m spacy download` leaves it untracked,
+    # and uv's exact sync then deletes it on the next `uv run`/`uv sync`. The wheel
+    # is py3-none-any (arch-independent), so it serves all platforms in multi-arch
+    # builds. Bump in lockstep with spaCy's minor version (model is >=3.8,<3.9).
+    "en_core_web_md @ https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.8.0/en_core_web_md-3.8.0-py3-none-any.whl",
     # Server
     "gunicorn>=21.0.0",
     "psutil>=5.9.0",

--- a/scripts/verify_dev_env.py
+++ b/scripts/verify_dev_env.py
@@ -1,0 +1,47 @@
+"""Verify the local dev environment is fully provisioned.
+
+Fails loudly when a historically fragile dependency is missing, so a broken
+environment is caught at setup time (or by `make ready`) instead of silently
+degrading at runtime. Currently checks the spaCy model — the dependency that
+repeatedly went missing under uv's exact sync before it was pinned in uv.lock.
+
+Run: uv run python scripts/verify_dev_env.py  (or `make setup` / `make verify-env`)
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def check_spacy_model() -> str:
+    """Assert the spaCy English model actually loads; return a version string."""
+    from src.core.nlp import load_spacy_english
+
+    nlp = load_spacy_english()
+    if nlp is None:
+        raise RuntimeError(
+            "spaCy English model failed to load. It is a locked dependency — "
+            "run `make setup` to (re)provision the environment."
+        )
+    meta = getattr(nlp, "meta", {})
+    # spaCy stores lang and name separately; the canonical model id joins them
+    # (e.g. lang="en", name="core_web_md" -> "en_core_web_md").
+    lang, name = meta.get("lang"), meta.get("name", "unknown")
+    full_name = f"{lang}_{name}" if lang else name
+    return f"{full_name} {meta.get('version', '?')}"
+
+
+def main() -> int:
+    ok = True
+    for label, fn in [("spaCy NLP model", check_spacy_model)]:
+        try:
+            print(f"OK    {label}: {fn()}")
+        except Exception as exc:  # report any failure clearly
+            print(f"FAIL  {label}: {exc}")
+            ok = False
+    print("\nEnvironment OK." if ok else "\nVerification failed. Run `make setup`.")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_dev_env_spacy_model.py
+++ b/tests/unit/test_dev_env_spacy_model.py
@@ -1,0 +1,40 @@
+"""CI guard: the spaCy model must be a real, loadable, locked dependency.
+
+The other spaCy tests mock the library to check fallback/logging behaviour.
+This one exercises the *actually installed* model. It exists because the model
+repeatedly went missing when it was installed out-of-band (`python -m spacy
+download`) instead of pinned in uv.lock: uv's exact sync deleted it on the next
+`uv run`/`uv sync`. Now that it is a locked dependency, any regression (unpin,
+spaCy major bump breaking model compat, botched provisioning) fails loudly here
+instead of silently degrading matching to the string/heuristic layers.
+
+Reuses `check_spacy_model()` from scripts/verify_dev_env.py so the contributor
+setup path (`make setup`), the local gate (`make ready`), and CI share one
+source of truth.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "verify_dev_env.py"
+
+
+def _load_verifier():
+    spec = importlib.util.spec_from_file_location("verify_dev_env", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.unit
+def test_spacy_model_is_installed_and_loadable():
+    """The pinned spaCy model must load in a properly provisioned environment."""
+    verifier = _load_verifier()
+    # Raises RuntimeError if the model is missing/unloadable; the message tells
+    # the contributor to run `make setup`.
+    detail = verifier.check_spacy_model()
+    assert "en_core_web" in detail, f"unexpected model reported: {detail!r}"

--- a/uv.lock
+++ b/uv.lock
@@ -855,6 +855,14 @@ wheels = [
 ]
 
 [[package]]
+name = "en-core-web-md"
+version = "3.8.0"
+source = { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.8.0/en_core_web_md-3.8.0-py3-none-any.whl" }
+wheels = [
+    { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.8.0/en_core_web_md-3.8.0-py3-none-any.whl", hash = "sha256:5e6329fe3fecedb1d1a02c3ea2172ee0fede6cea6e4aefb6a02d832dba78a310" },
+]
+
+[[package]]
 name = "faker"
 version = "40.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3174,6 +3182,7 @@ dependencies = [
     { name = "boto3" },
     { name = "click" },
     { name = "cryptography" },
+    { name = "en-core-web-md" },
     { name = "faker" },
     { name = "fastapi" },
     { name = "geopy" },
@@ -3232,6 +3241,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.26.0" },
     { name = "click" },
     { name = "cryptography", specifier = ">=48.0.1" },
+    { name = "en-core-web-md", url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.8.0/en_core_web_md-3.8.0-py3-none-any.whl" },
     { name = "faker", specifier = ">=19.0.0" },
     { name = "fastapi", specifier = ">=0.120.0" },
     { name = "geopy", specifier = ">=2.3.0" },


### PR DESCRIPTION
## Problem

The spaCy NLP model (`en_core_web_md`) kept "disappearing," requiring 10+ manual reinstalls over several months.

## Root cause

The model was installed **out-of-band** via `python -m spacy download`, which leaves it untracked in `uv.lock`. uv's sync is **exact by default** — it removes any package not in the lockfile. Every `uv run`/`uv sync` (including `make ready`, local `make` targets, and CI) reconciled `.venv` to the lockfile and **deleted the untracked model**. The NLP layer then silently fell back to the string/heuristic layers, which is why the failure looked random rather than like a one-time setup miss.

## Fix

Pin the model wheel URL as a real dependency so `uv sync` installs and preserves it in **every** environment — local venv (`make`), `docker compose`, CI, and the multi-arch Docker Hub publish. The wheel is `py3-none-any` (arch-independent), so a single artifact serves both `linux/amd64` and `linux/arm64`; verified the pinned URL resolves and the model declares `spacy_version >=3.8,<3.9` (compatible with locked spaCy 3.8.x).

## Changes

- **`pyproject.toml` / `uv.lock`** — pin `en_core_web_md` wheel URL; locked with sha256. Confirmed it now survives an exact `uv sync`.
- **`Dockerfile`** — drop the now-redundant `python -m spacy download` step (the `uv sync --frozen` steps install it).
- **`Makefile`** — add **`make setup`** (one-step, idempotent: guards on `uv`, syncs, verifies) and `make verify-env`; run `verify-env` as the first `ready` gate step (pure verification, honoring the gate's no-mutation contract).
- **`scripts/verify_dev_env.py`** — assert the model actually **loads**, turning the old silent degradation into a loud, actionable failure.
- **`tests/unit/test_dev_env_spacy_model.py`** — CI guard (`unit` lane) reusing `check_spacy_model()` so setup, `make ready`, and CI share one source of truth.
- **`README.md` / docs** — replace manual `spacy download` instructions with `make setup`; add "do not install out-of-band" warnings.

## Contributor experience

New contributors now run a single command:

```bash
make setup
```

## Trade-off

The model URL pins an exact version decoupled from spaCy's floating version. If spaCy ever resolves to `3.9.x`, the pinned `3.8.0` model becomes incompatible — but that now surfaces as a visible `uv lock` diff / loud load failure (caught by the CI guard) instead of silent degradation.

## Verification

`make ready` — all 6 gates green: **521 passed**, parity **4/4**, docs validation passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)