### PR TITLE
feat(frontend): slice 1 — foundation + OKH design catalog (typed clie…

### DIFF
--- a/frontend/e2e/okh-catalog.spec.ts
+++ b/frontend/e2e/okh-catalog.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from "./mock-api";
+import { okhListEmptyFixture } from "../src/test/fixtures";
+
+// Slice 1: OKH design catalog list. Runs in the mocked lane (default gate) and,
+// for the lenient "loads" check, the real-api lane.
+
+test("OKH catalog route loads", async ({ page }) => {
+  await page.goto("/okh");
+  await expect(
+    page.getByRole("heading", { name: /open hardware designs/i }),
+  ).toBeVisible();
+});
+
+test("OKH catalog shows fixture designs (mocked)", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "asserts fixture data");
+  await page.goto("/okh");
+  await expect(page.getByRole("heading", { name: "Open Ventilator" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Face Shield" })).toBeVisible();
+});
+
+test("OKH catalog shows the empty state (mocked)", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "forces an empty response");
+  await page.route("**/v1/api/okh**", (route) =>
+    route.fulfill({ json: okhListEmptyFixture }),
+  );
+  await page.goto("/okh");
+  await expect(page.getByText(/no designs/i)).toBeVisible();
+});
+
+test("OKH catalog shows the error state with retry (mocked)", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "forces an error response");
+  await page.route("**/v1/api/okh**", (route) =>
+    route.fulfill({ status: 503, json: { message: "boom" } }),
+  );
+  await page.goto("/okh");
+  await expect(page.getByRole("alert")).toBeVisible();
+  await expect(page.getByRole("button", { name: /retry/i })).toBeVisible();
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "echarts": "^6.1.0",
         "echarts-for-react": "^3.0.2",
         "lucide-react": "^1.23.0",
+        "openapi-fetch": "^0.17.0",
         "react": "^19.0.0",
         "react-cytoscapejs": "^2.0.0",
         "react-dom": "^19.0.0",
@@ -6970,6 +6971,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-fetch": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.17.0.tgz",
+      "integrity": "sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.1.0"
+      }
+    },
     "node_modules/openapi-typescript": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
@@ -6990,6 +7000,12 @@
       "peerDependencies": {
         "typescript": "^5.x"
       }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.1.0.tgz",
+      "integrity": "sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==",
+      "license": "MIT"
     },
     "node_modules/openapi-typescript/node_modules/supports-color": {
       "version": "10.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "echarts": "^6.1.0",
     "echarts-for-react": "^3.0.2",
     "lucide-react": "^1.23.0",
+    "openapi-fetch": "^0.17.0",
     "react": "^19.0.0",
     "react-cytoscapejs": "^2.0.0",
     "react-dom": "^19.0.0",

--- a/frontend/src/api/ohm/client.ts
+++ b/frontend/src/api/ohm/client.ts
@@ -1,0 +1,51 @@
+/**
+ * Typed OHM API client (module 1 of the frontend architecture).
+ *
+ * Built on `openapi-fetch` over the types generated from the backend OpenAPI
+ * spec (`src/api/generated/schema.d.ts`). Paths, query params, and response
+ * envelopes are type-checked against the real contract, so backend drift is a
+ * compile error. Per-domain wrappers (e.g. `okh.ts`) live alongside this and
+ * expose small, intention-revealing functions to the rest of the app.
+ *
+ * The generated `paths` are rooted at `/api/...`; the versioned app is mounted
+ * at `/v1` (proxied to the OHM API in dev), so the base URL is `/v1`.
+ */
+import createClient from "openapi-fetch";
+import type { paths } from "../generated/schema";
+
+// Absolute base so requests work identically in the browser (real origin +
+// dev-proxy) and in the node/jsdom test env, where undici's fetch rejects
+// relative URLs. In a browser this resolves to the current origin + /v1.
+const origin =
+  typeof window !== "undefined" && window.location?.origin
+    ? window.location.origin
+    : "http://localhost";
+
+export const apiClient = createClient<paths>({
+  baseUrl: `${origin}/v1`,
+  // Defer to the *current* global fetch on each call rather than the reference
+  // captured at module load, so test-time interceptors (MSW) that replace
+  // globalThis.fetch after import are honored. No-op difference in the browser.
+  fetch: (input) => globalThis.fetch(input),
+});
+
+/** Thrown by domain wrappers when a request fails; carries the HTTP status. */
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+/** Best-effort human message from a JSON error body ({message} or {detail}). */
+export function errorMessage(body: unknown, fallback: string): string {
+  if (body && typeof body === "object") {
+    const b = body as { message?: unknown; detail?: unknown };
+    if (typeof b.message === "string") return b.message;
+    if (typeof b.detail === "string") return b.detail;
+  }
+  return fallback;
+}

--- a/frontend/src/api/ohm/okh.test.ts
+++ b/frontend/src/api/ohm/okh.test.ts
@@ -1,0 +1,42 @@
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { server } from "../../test/msw/server";
+import { ApiError } from "./client";
+import { fetchOkhList } from "./okh";
+
+describe("fetchOkhList", () => {
+  it("returns narrowed items and pagination from the paginated envelope", async () => {
+    const result = await fetchOkhList();
+    expect(result.items).toHaveLength(2);
+    expect(result.items.map((i) => i.title)).toContain("Open Ventilator");
+    expect(result.pagination.total_items).toBe(2);
+  });
+
+  it("passes paging/sort/filter as query params", async () => {
+    let captured: URLSearchParams | null = null;
+    server.use(
+      http.get("*/v1/api/okh", ({ request }) => {
+        captured = new URL(request.url).searchParams;
+        return HttpResponse.json({ items: [], pagination: { total_items: 0 } });
+      }),
+    );
+    await fetchOkhList({ page: 2, page_size: 10, sort_by: "title", sort_order: "asc", filter: "vent" });
+    expect(captured!.get("page")).toBe("2");
+    expect(captured!.get("page_size")).toBe("10");
+    expect(captured!.get("sort_by")).toBe("title");
+    expect(captured!.get("filter")).toBe("vent");
+  });
+
+  it("throws ApiError with the HTTP status on failure", async () => {
+    server.use(
+      http.get("*/v1/api/okh", () =>
+        HttpResponse.json({ message: "boom" }, { status: 503 }),
+      ),
+    );
+    await expect(fetchOkhList()).rejects.toMatchObject({
+      name: "ApiError",
+      status: 503,
+    });
+    await expect(fetchOkhList()).rejects.toBeInstanceOf(ApiError);
+  });
+});

--- a/frontend/src/api/ohm/okh.ts
+++ b/frontend/src/api/ohm/okh.ts
@@ -1,0 +1,70 @@
+import { apiClient, ApiError, errorMessage } from "./client";
+import type { OkhManifest } from "../../types/okh";
+
+export interface OkhPagination {
+  page: number;
+  page_size: number;
+  total_items: number;
+  total_pages: number;
+  has_next: boolean;
+  has_previous: boolean;
+}
+
+export interface OkhListResult {
+  items: OkhManifest[];
+  pagination: OkhPagination;
+}
+
+export interface FetchOkhListParams {
+  page?: number;
+  page_size?: number;
+  sort_by?: string;
+  sort_order?: "asc" | "desc";
+  filter?: string;
+}
+
+const EMPTY_PAGINATION: OkhPagination = {
+  page: 1,
+  page_size: 0,
+  total_items: 0,
+  total_pages: 1,
+  has_next: false,
+  has_previous: false,
+};
+
+/**
+ * List OKH design manifests. The backend types the list response as a generic
+ * paginated envelope (items: object[]), so we narrow items to the OkhManifest
+ * view type the UI renders.
+ */
+export async function fetchOkhList(
+  params: FetchOkhListParams = {},
+): Promise<OkhListResult> {
+  const { data, error, response } = await apiClient.GET("/api/okh", {
+    params: {
+      query: {
+        page: params.page ?? 1,
+        page_size: params.page_size ?? 100,
+        sort_by: params.sort_by,
+        sort_order: params.sort_order,
+        filter: params.filter,
+      },
+    },
+  });
+
+  if (error || !response.ok) {
+    throw new ApiError(
+      response.status,
+      errorMessage(error, `Failed to load designs (HTTP ${response.status})`),
+    );
+  }
+
+  const body = (data ?? {}) as {
+    items?: unknown[];
+    pagination?: Partial<OkhPagination>;
+  };
+  return {
+    items: (body.items ?? []) as OkhManifest[],
+    pagination: { ...EMPTY_PAGINATION, ...body.pagination },
+  };
+}

--- a/frontend/src/components/ui/states.test.tsx
+++ b/frontend/src/components/ui/states.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { EmptyState, ErrorState, LoadingState } from "./states";
+
+describe("state primitives", () => {
+  it("LoadingState exposes a status role and message", () => {
+    render(<LoadingState message="Loading designs…" />);
+    expect(screen.getByRole("status")).toHaveTextContent("Loading designs…");
+  });
+
+  it("EmptyState renders title, description, and action", () => {
+    render(
+      <EmptyState
+        title="No designs found"
+        description="Try a different search."
+        action={<button>Clear</button>}
+      />,
+    );
+    expect(screen.getByText("No designs found")).toBeInTheDocument();
+    expect(screen.getByText("Try a different search.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Clear" })).toBeInTheDocument();
+  });
+
+  it("ErrorState exposes an alert role and fires onRetry", async () => {
+    const onRetry = vi.fn();
+    render(<ErrorState description="Network error" onRetry={onRetry} />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it("ErrorState omits the retry button when no handler is given", () => {
+    render(<ErrorState description="Network error" />);
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+});

--- a/frontend/src/components/ui/states.tsx
+++ b/frontend/src/components/ui/states.tsx
@@ -1,0 +1,97 @@
+import { type ReactNode } from "react";
+import { Loader2 } from "lucide-react";
+import { Button } from "./button";
+import { cn } from "@/lib/utils";
+
+/**
+ * The three mandatory data states, standardized so every data surface renders
+ * them consistently and E2E tests can assert them by role/text.
+ */
+
+export function LoadingState({
+  message = "Loading…",
+  className,
+}: {
+  message?: string;
+  className?: string;
+}) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "flex flex-col items-center justify-center gap-3 py-16 text-muted-foreground",
+        className,
+      )}
+    >
+      <Loader2 className="h-6 w-6 animate-spin" aria-hidden="true" />
+      <span className="text-sm">{message}</span>
+    </div>
+  );
+}
+
+export function EmptyState({
+  title,
+  description,
+  icon,
+  action,
+  className,
+}: {
+  title: string;
+  description?: string;
+  icon?: ReactNode;
+  action?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed py-16 text-center",
+        className,
+      )}
+    >
+      {icon ? <div className="text-3xl" aria-hidden="true">{icon}</div> : null}
+      <div>
+        <p className="font-medium text-foreground">{title}</p>
+        {description ? (
+          <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+        ) : null}
+      </div>
+      {action}
+    </div>
+  );
+}
+
+export function ErrorState({
+  title = "Something went wrong",
+  description,
+  onRetry,
+  className,
+}: {
+  title?: string;
+  description?: string;
+  onRetry?: () => void;
+  className?: string;
+}) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "flex flex-col items-center justify-center gap-3 rounded-lg border border-destructive/40 bg-destructive/5 py-16 text-center",
+        className,
+      )}
+    >
+      <div>
+        <p className="font-medium text-destructive">{title}</p>
+        {description ? (
+          <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+        ) : null}
+      </div>
+      {onRetry ? (
+        <Button variant="outline" size="sm" onClick={onRetry}>
+          Retry
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/features/okh/OkhListView.tsx
+++ b/frontend/src/features/okh/OkhListView.tsx
@@ -1,8 +1,7 @@
 import { useOkhList } from "./useOkhList";
 import { OkhCard } from "./OkhCard";
-import { LoadingSpinner } from "../../components/ui/LoadingSpinner";
-import { ErrorMessage } from "../../components/ui/ErrorMessage";
-import { EmptyState } from "../../components/ui/EmptyState";
+import { LoadingState, EmptyState, ErrorState } from "../../components/ui/states";
+import { Button } from "../../components/ui/button";
 import { Pagination } from "../../components/ui/Pagination";
 import type { SortField, SortOrder } from "./useOkhList";
 
@@ -95,23 +94,25 @@ export function OkhListView() {
       )}
 
       {/* States */}
-      {isLoading && <LoadingSpinner message="Loading designs…" />}
-      {isError && <ErrorMessage error={error} retry={() => refetch()} />}
+      {isLoading && <LoadingState message="Loading designs…" />}
+      {isError && (
+        <ErrorState
+          description={error instanceof Error ? error.message : "Failed to load designs."}
+          onRetry={() => refetch()}
+        />
+      )}
 
       {/* Grid */}
       {!isLoading && !isError && pageItems.length === 0 && (
         <EmptyState
           icon="🔩"
-          heading="No designs found"
-          body={filterText ? `No designs match "${filterText}". Try a different search.` : "No OKH designs are available."}
+          title="No designs found"
+          description={filterText ? `No designs match "${filterText}". Try a different search.` : "No OKH designs are available."}
           action={
             filterText ? (
-              <button
-                onClick={() => handleFilterChange("")}
-                className="rounded-md bg-indigo-50 px-4 py-2 text-sm font-medium text-indigo-700 hover:bg-indigo-100 dark:bg-indigo-950 dark:text-indigo-300"
-              >
+              <Button variant="outline" size="sm" onClick={() => handleFilterChange("")}>
                 Clear filter
-              </button>
+              </Button>
             ) : undefined
           }
         />

--- a/frontend/src/features/okh/useOkhList.ts
+++ b/frontend/src/features/okh/useOkhList.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
-import { fetchOkhList } from "../../api/okh";
+import { fetchOkhList } from "../../api/ohm/okh";
 import type { OkhManifest } from "../../types/okh";
 
 export type SortField = "title" | "version" | "documentation_language";

--- a/frontend/src/test/fixtures/index.ts
+++ b/frontend/src/test/fixtures/index.ts
@@ -17,12 +17,61 @@ export const domainsFixture = {
   domains: ["manufacturing", "cooking"],
 };
 
-/** Empty OKH list — exercises the empty-state path deterministically. */
+/** A minimal OKH manifest shaped like the list payload the UI renders. */
+function okhItem(
+  id: string,
+  title: string,
+  fn: string,
+  processes: string[],
+): Record<string, unknown> {
+  return {
+    id,
+    title,
+    version: "1.0.0",
+    function: fn,
+    description: fn,
+    keywords: [],
+    documentation_language: "en",
+    license: { hardware: "CERN-OHL-S-2.0", documentation: null, software: null },
+    licensor: { name: "OHM Test", email: null, affiliation: null, social: [] },
+    contributors: [],
+    manufacturing_processes: processes,
+    materials: [{ material_id: "m1", name: "PLA", quantity: 1, unit: "kg", notes: null }],
+    design_files: [],
+    manufacturing_files: [],
+    making_instructions: [],
+    parts: [],
+    tool_list: [],
+    image: null,
+    project_link: null,
+  };
+}
+
+/** Populated OKH list (paginated envelope) for catalog browse tests + screenshots. */
 export const okhListFixture = {
+  status: "success",
+  message: "ok",
+  timestamp: "2026-01-01T00:00:00Z",
+  request_id: "test",
+  pagination: {
+    page: 1,
+    page_size: 100,
+    total_items: 2,
+    total_pages: 1,
+    has_next: false,
+    has_previous: false,
+  },
+  items: [
+    okhItem("okh-0001", "Open Ventilator", "Emergency ventilator", ["3DP", "PCB"]),
+    okhItem("okh-0002", "Face Shield", "Protective face shield", ["3DP", "Laser"]),
+  ],
+};
+
+/** Empty OKH list — exercises the empty-state path deterministically. */
+export const okhListEmptyFixture = {
+  ...okhListFixture,
+  pagination: { ...okhListFixture.pagination, total_items: 0 },
   items: [],
-  total: 0,
-  page: 1,
-  page_size: 20,
 };
 
 /** Path-keyed lookup used by the Playwright interceptor (see e2e/mock-api.ts). */


### PR DESCRIPTION
First vertical slice of the v1 frontend (PRD #184, slice #197), establishing the patterns every later slice copies:

- Typed API client (module 1): openapi-fetch over the generated OpenAPI types (src/api/ohm/*). Path/param/envelope are type-checked against the real contract; items narrowed to the OkhManifest view type. fetch() is resolved per-call so test interceptors (MSW) are honored.
- State primitives (module 6): shadcn-based LoadingState / EmptyState / ErrorState with role=status / role=alert, component-tested.
- OKH design catalog list rebuilt on the typed client + primitives, preserving search / sort / pagination and the renderable-item filter; explicit loading / empty / error states.

Tests: unit (typed OKH wrapper via MSW — happy path, query params, ApiError), component (state primitives), mocked-lane E2E (browse / empty / error) + real-api lane (route loads against live API) + /okh screenshot.

`make frontend-ready` green; real-api lane green against the live backend.