### PR TITLE
Slice A1: Faceted OKH catalog browse (orthogonal facets)

### DIFF
--- a/frontend/e2e/okh-catalog.spec.ts
+++ b/frontend/e2e/okh-catalog.spec.ts
@@ -1,24 +1,37 @@
 import { test, expect } from "./mock-api";
 import { okhListEmptyFixture } from "../src/test/fixtures";
 
-// Slice 1: OKH design catalog list. Runs in the mocked lane (default gate) and,
-// for the lenient "loads" check, the real-api lane.
+// Slice A1: faceted OKH design catalog. Mocked lane (default gate) covers the
+// facet behavior; the real-api lane only runs the lenient "loads" check.
 
-test("OKH catalog route loads", async ({ page }) => {
+test("faceted catalog loads with a filter panel", async ({ page }) => {
   await page.goto("/okh");
   await expect(
     page.getByRole("heading", { name: /open hardware designs/i }),
   ).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Filters" })).toBeVisible();
 });
 
-test("OKH catalog shows fixture designs (mocked)", async ({ page }, testInfo) => {
+test("shows fixture designs (mocked)", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name === "real-api", "asserts fixture data");
   await page.goto("/okh");
   await expect(page.getByRole("heading", { name: "Open Ventilator" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Face Shield" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Test Rig" })).toBeVisible();
 });
 
-test("OKH catalog shows the empty state (mocked)", async ({ page }, testInfo) => {
+test("selecting a facet narrows the results (mocked)", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "asserts fixture data");
+  await page.goto("/okh");
+  // Only Face Shield is GPL-2.0.
+  await page.getByRole("checkbox", { name: /GPL-2\.0/ }).check();
+  await expect(page.getByRole("heading", { name: "Face Shield" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Open Ventilator" })).toBeHidden();
+  // Facet selection is reflected in the URL (deep-linkable).
+  await expect(page).toHaveURL(/license=GPL-2\.0/);
+});
+
+test("shows the empty state (mocked)", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name === "real-api", "forces an empty response");
   await page.route("**/v1/api/okh**", (route) =>
     route.fulfill({ json: okhListEmptyFixture }),
@@ -27,7 +40,7 @@ test("OKH catalog shows the empty state (mocked)", async ({ page }, testInfo) =>
   await expect(page.getByText(/no designs/i)).toBeVisible();
 });
 
-test("OKH catalog shows the error state with retry (mocked)", async ({ page }, testInfo) => {
+test("shows the error state with retry (mocked)", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name === "real-api", "forces an error response");
   await page.route("**/v1/api/okh**", (route) =>
     route.fulfill({ status: 503, json: { message: "boom" } }),

--- a/frontend/e2e/okh-catalog.spec.ts
+++ b/frontend/e2e/okh-catalog.spec.ts
@@ -31,6 +31,20 @@ test("selecting a facet narrows the results (mocked)", async ({ page }, testInfo
   await expect(page).toHaveURL(/license=GPL-2\.0/);
 });
 
+test("category facet is the primary spine and narrows results (mocked)", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "asserts fixture data");
+  await page.goto("/okh");
+  // Category is present as a facet group. Test Rig ("Calibration test rig") is
+  // the only Test & Measurement device.
+  await expect(page.getByRole("heading", { name: "Category" })).toBeVisible();
+  await page.getByRole("checkbox", { name: /Test & Measurement/ }).check();
+  await expect(page.getByRole("heading", { name: "Test Rig" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Open Ventilator" })).toBeHidden();
+  await expect(page).toHaveURL(/category=Test/);
+});
+
 test("shows the empty state (mocked)", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name === "real-api", "forces an empty response");
   await page.route("**/v1/api/okh**", (route) =>

--- a/frontend/src/api/ohm/okh.test.ts
+++ b/frontend/src/api/ohm/okh.test.ts
@@ -7,9 +7,9 @@ import { fetchOkhList } from "./okh";
 describe("fetchOkhList", () => {
   it("returns narrowed items and pagination from the paginated envelope", async () => {
     const result = await fetchOkhList();
-    expect(result.items).toHaveLength(2);
+    expect(result.items).toHaveLength(3);
     expect(result.items.map((i) => i.title)).toContain("Open Ventilator");
-    expect(result.pagination.total_items).toBe(2);
+    expect(result.pagination.total_items).toBe(3);
   });
 
   it("passes paging/sort/filter as query params", async () => {

--- a/frontend/src/features/okh/FacetPanel.test.tsx
+++ b/frontend/src/features/okh/FacetPanel.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { FacetPanel } from "./FacetPanel";
+import type { FacetGroup } from "./facets";
+
+const groups: FacetGroup[] = [
+  {
+    key: "process",
+    label: "Manufacturing process",
+    options: [
+      { value: "3D Printing", count: 9 },
+      { value: "Laser Cutting", count: 14 },
+    ],
+  },
+  { key: "license", label: "License", options: [{ value: "MIT", count: 6 }] },
+];
+
+describe("FacetPanel", () => {
+  it("renders groups, options, and counts", () => {
+    render(
+      <FacetPanel
+        groups={groups}
+        selections={{}}
+        selectedCount={0}
+        onToggle={vi.fn()}
+        onClear={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Manufacturing process")).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: /3D Printing/ })).toBeInTheDocument();
+    expect(screen.getByText("14")).toBeInTheDocument();
+  });
+
+  it("fires onToggle with the group key and value", async () => {
+    const onToggle = vi.fn();
+    render(
+      <FacetPanel
+        groups={groups}
+        selections={{}}
+        selectedCount={0}
+        onToggle={onToggle}
+        onClear={vi.fn()}
+      />,
+    );
+    await userEvent.click(screen.getByRole("checkbox", { name: /Laser Cutting/ }));
+    expect(onToggle).toHaveBeenCalledWith("process", "Laser Cutting");
+  });
+
+  it("reflects selected state and shows Clear all only when something is selected", async () => {
+    const onClear = vi.fn();
+    const { rerender } = render(
+      <FacetPanel
+        groups={groups}
+        selections={{}}
+        selectedCount={0}
+        onToggle={vi.fn()}
+        onClear={onClear}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /clear all/i })).toBeNull();
+
+    rerender(
+      <FacetPanel
+        groups={groups}
+        selections={{ license: ["MIT"] }}
+        selectedCount={1}
+        onToggle={vi.fn()}
+        onClear={onClear}
+      />,
+    );
+    expect(screen.getByRole("checkbox", { name: /MIT/ })).toBeChecked();
+    await userEvent.click(screen.getByRole("button", { name: /clear all/i }));
+    expect(onClear).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/features/okh/FacetPanel.tsx
+++ b/frontend/src/features/okh/FacetPanel.tsx
@@ -1,0 +1,61 @@
+import { Button } from "../../components/ui/button";
+import type { FacetGroup, FacetKey, FacetSelections } from "./facets";
+
+interface Props {
+  groups: FacetGroup[];
+  selections: FacetSelections;
+  selectedCount: number;
+  onToggle: (key: FacetKey, value: string) => void;
+  onClear: () => void;
+}
+
+export function FacetPanel({
+  groups,
+  selections,
+  selectedCount,
+  onToggle,
+  onClear,
+}: Props) {
+  return (
+    <nav aria-label="Filters" className="space-y-5 text-sm">
+      <div className="flex items-center justify-between">
+        <h2 className="font-semibold text-foreground">Filters</h2>
+        {selectedCount > 0 && (
+          <Button variant="ghost" size="sm" onClick={onClear}>
+            Clear all
+          </Button>
+        )}
+      </div>
+
+      {groups.map((group) => {
+        const selected = selections[group.key] ?? [];
+        return (
+          <div key={group.key}>
+            <h3 className="mb-2 font-medium text-muted-foreground">{group.label}</h3>
+            <ul className="space-y-1">
+              {group.options.map((opt) => {
+                const checked = selected.includes(opt.value);
+                return (
+                  <li key={opt.value}>
+                    <label className="flex cursor-pointer items-center gap-2 rounded px-1 py-0.5 hover:bg-accent">
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => onToggle(group.key, opt.value)}
+                        className="h-4 w-4 accent-primary"
+                      />
+                      <span className="flex-1 truncate text-foreground">{opt.value}</span>
+                      <span className="tabular-nums text-xs text-muted-foreground">
+                        {opt.count}
+                      </span>
+                    </label>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        );
+      })}
+    </nav>
+  );
+}

--- a/frontend/src/features/okh/FacetPanel.tsx
+++ b/frontend/src/features/okh/FacetPanel.tsx
@@ -1,5 +1,5 @@
 import { Button } from "../../components/ui/button";
-import type { FacetGroup, FacetKey, FacetSelections } from "./facets";
+import { PRIMARY_FACET, type FacetGroup, type FacetKey, type FacetSelections } from "./facets";
 
 interface Props {
   groups: FacetGroup[];
@@ -31,7 +31,17 @@ export function FacetPanel({
         const selected = selections[group.key] ?? [];
         return (
           <div key={group.key}>
-            <h3 className="mb-2 font-medium text-muted-foreground">{group.label}</h3>
+            <h3 className="mb-2 flex items-center gap-1.5 font-medium text-muted-foreground">
+              {group.label}
+              {group.key === PRIMARY_FACET && (
+                <span
+                  title="Provisional categories derived from design text; a curated taxonomy is coming."
+                  className="rounded bg-muted px-1 py-0.5 text-[10px] font-normal uppercase tracking-wide text-muted-foreground"
+                >
+                  provisional
+                </span>
+              )}
+            </h3>
             <ul className="space-y-1">
               {group.options.map((opt) => {
                 const checked = selected.includes(opt.value);

--- a/frontend/src/features/okh/OkhListView.tsx
+++ b/frontend/src/features/okh/OkhListView.tsx
@@ -1,17 +1,10 @@
-import { useOkhList } from "./useOkhList";
+import { useState } from "react";
+import { useOkhCatalog } from "./useOkhList";
 import { OkhCard } from "./OkhCard";
+import { FacetPanel } from "./FacetPanel";
 import { LoadingState, EmptyState, ErrorState } from "../../components/ui/states";
 import { Button } from "../../components/ui/button";
 import { Pagination } from "../../components/ui/Pagination";
-import type { SortField, SortOrder } from "./useOkhList";
-
-const SORT_OPTIONS: { label: string; field: SortField; order: SortOrder }[] = [
-  { label: "Title A→Z", field: "title", order: "asc" },
-  { label: "Title Z→A", field: "title", order: "desc" },
-  { label: "Version A→Z", field: "version", order: "asc" },
-  { label: "Version Z→A", field: "version", order: "desc" },
-  { label: "Language A→Z", field: "documentation_language", order: "asc" },
-];
 
 export function OkhListView() {
   const {
@@ -19,122 +12,124 @@ export function OkhListView() {
     totalItems,
     totalPages,
     safePage,
+    facetGroups,
+    selections,
+    selectedCount,
     filterText,
-    sortField,
-    sortOrder,
     isLoading,
     isError,
     error,
     refetch,
+    toggleFacet,
+    clearFacets,
+    setFilterText,
     setPage,
-    handleFilterChange,
-    handleSortChange,
     PAGE_SIZE,
-  } = useOkhList();
+  } = useOkhCatalog();
 
-  const selectedSortKey = `${sortField}:${sortOrder}`;
+  const [showFilters, setShowFilters] = useState(false);
+
+  const panel = (
+    <FacetPanel
+      groups={facetGroups}
+      selections={selections}
+      selectedCount={selectedCount}
+      onToggle={toggleFacet}
+      onClear={clearFacets}
+    />
+  );
 
   return (
     <div className="space-y-6">
-      {/* Page header */}
       <div>
-        <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">
-          Open Hardware Designs
-        </h1>
-        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-          Browse OKH manifests and run facility matching.
+        <h1 className="text-2xl font-bold text-foreground">Open Hardware Designs</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Browse designs by category and capability, then run facility matching.
         </p>
       </div>
 
-      {/* Controls */}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        {/* Search */}
-        <div className="relative flex-1 max-w-md">
-          <span className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-slate-400">
-            🔍
-          </span>
-          <input
-            type="search"
-            placeholder="Filter by title, function, process…"
-            value={filterText}
-            onChange={(e) => handleFilterChange(e.target.value)}
-            className="w-full rounded-lg border border-slate-300 bg-white py-2 pl-9 pr-3 text-sm text-slate-800 placeholder:text-slate-400 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-indigo-500 dark:focus:ring-indigo-900"
-          />
-        </div>
+      <div className="flex gap-8">
+        {/* Facet sidebar (desktop) */}
+        <aside className="hidden w-60 shrink-0 lg:block">{panel}</aside>
 
-        {/* Sort */}
-        <div className="flex items-center gap-2">
-          <label className="text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">
-            Sort by
-          </label>
-          <select
-            value={selectedSortKey}
-            onChange={(e) => {
-              const [field, order] = e.target.value.split(":") as [SortField, SortOrder];
-              handleSortChange(field, order);
-            }}
-            className="rounded-lg border border-slate-300 bg-white py-2 pl-3 pr-8 text-sm text-slate-700 focus:border-indigo-400 focus:outline-none dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200"
-          >
-            {SORT_OPTIONS.map(({ label, field, order }) => (
-              <option key={`${field}:${order}`} value={`${field}:${order}`}>
-                {label}
-              </option>
-            ))}
-          </select>
-        </div>
-      </div>
-
-      {/* Results count */}
-      {!isLoading && !isError && (
-        <p className="text-xs text-slate-500 dark:text-slate-400">
-          {filterText
-            ? `${totalItems} result${totalItems !== 1 ? "s" : ""} matching "${filterText}"`
-            : `${totalItems} design${totalItems !== 1 ? "s" : ""} total`}
-        </p>
-      )}
-
-      {/* States */}
-      {isLoading && <LoadingState message="Loading designs…" />}
-      {isError && (
-        <ErrorState
-          description={error instanceof Error ? error.message : "Failed to load designs."}
-          onRetry={() => refetch()}
-        />
-      )}
-
-      {/* Grid */}
-      {!isLoading && !isError && pageItems.length === 0 && (
-        <EmptyState
-          icon="🔩"
-          title="No designs found"
-          description={filterText ? `No designs match "${filterText}". Try a different search.` : "No OKH designs are available."}
-          action={
-            filterText ? (
-              <Button variant="outline" size="sm" onClick={() => handleFilterChange("")}>
-                Clear filter
-              </Button>
-            ) : undefined
-          }
-        />
-      )}
-
-      {!isLoading && !isError && pageItems.length > 0 && (
-        <>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            {pageItems.map((okh) => (
-              <OkhCard key={okh.id} okh={okh} />
-            ))}
+        <div className="min-w-0 flex-1 space-y-4">
+          {/* Controls */}
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <input
+              type="search"
+              aria-label="Search designs"
+              placeholder="Search designs…"
+              value={filterText}
+              onChange={(e) => setFilterText(e.target.value)}
+              className="w-full max-w-md rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+            <Button
+              variant="outline"
+              size="sm"
+              className="lg:hidden"
+              onClick={() => setShowFilters((v) => !v)}
+            >
+              Filters{selectedCount > 0 ? ` (${selectedCount})` : ""}
+            </Button>
           </div>
 
-          <Pagination
-            page={safePage}
-            totalPages={totalPages}
-            totalItems={totalItems}
-            pageSize={PAGE_SIZE}
-            onPage={setPage}
-          />
-        </>
-      )}
+          {/* Facet panel (mobile disclosure) */}
+          {showFilters && (
+            <div className="rounded-lg border p-4 lg:hidden">{panel}</div>
+          )}
+
+          {!isLoading && !isError && (
+            <p className="text-xs text-muted-foreground">
+              {totalItems} design{totalItems !== 1 ? "s" : ""}
+              {selectedCount > 0 || filterText ? " (filtered)" : ""}
+            </p>
+          )}
+
+          {isLoading && <LoadingState message="Loading designs…" />}
+          {isError && (
+            <ErrorState
+              description={error instanceof Error ? error.message : "Failed to load designs."}
+              onRetry={() => refetch()}
+            />
+          )}
+
+          {!isLoading && !isError && pageItems.length === 0 && (
+            <EmptyState
+              icon="🔩"
+              title="No designs found"
+              description={
+                selectedCount > 0 || filterText
+                  ? "No designs match the current filters."
+                  : "No OKH designs are available."
+              }
+              action={
+                selectedCount > 0 || filterText ? (
+                  <Button variant="outline" size="sm" onClick={clearFacets}>
+                    Clear filters
+                  </Button>
+                ) : undefined
+              }
+            />
+          )}
+
+          {!isLoading && !isError && pageItems.length > 0 && (
+            <>
+              <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                {pageItems.map((okh) => (
+                  <OkhCard key={okh.id} okh={okh} />
+                ))}
+              </div>
+              <Pagination
+                page={safePage}
+                totalPages={totalPages}
+                totalItems={totalItems}
+                pageSize={PAGE_SIZE}
+                onPage={setPage}
+              />
+            </>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/features/okh/categories.test.ts
+++ b/frontend/src/features/okh/categories.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import type { OkhManifest } from "../../types/okh";
+import { deriveCategories, UNCATEGORIZED } from "./categories";
+
+function withFunction(fn: string, title = "x"): OkhManifest {
+  return {
+    id: "x",
+    title,
+    version: null,
+    repo: null,
+    function: fn,
+    description: null,
+    intended_use: null,
+    keywords: [],
+    documentation_language: null,
+    license: null,
+    licensor: null,
+    contributors: [],
+    manufacturing_processes: [],
+    materials: [],
+    design_files: [],
+    manufacturing_files: [],
+    making_instructions: [],
+    parts: [],
+    tool_list: [],
+    image: null,
+    project_link: null,
+  };
+}
+
+describe("deriveCategories", () => {
+  it("derives a category from the function text", () => {
+    expect(deriveCategories(withFunction("A laboratory centrifuge"))).toContain(
+      "Laboratory & Bio",
+    );
+  });
+
+  it("is multi-valued — a device can belong to several categories", () => {
+    const cats = deriveCategories(
+      withFunction("A laboratory centrifuge driven by a peristaltic pump"),
+    );
+    expect(cats).toContain("Laboratory & Bio");
+    expect(cats).toContain("Fluid Handling");
+    expect(cats.length).toBeGreaterThan(1);
+  });
+
+  it("matches on title and keywords too", () => {
+    const item = withFunction("Does things", "Emergency Ventilator");
+    expect(deriveCategories(item)).toContain("Medical & PPE");
+  });
+
+  it("falls back to Uncategorized when nothing matches", () => {
+    expect(deriveCategories(withFunction("An inscrutable widget"))).toEqual([
+      UNCATEGORIZED,
+    ]);
+  });
+});

--- a/frontend/src/features/okh/categories.ts
+++ b/frontend/src/features/okh/categories.ts
@@ -1,0 +1,64 @@
+import type { OkhManifest } from "../../types/okh";
+
+/**
+ * Provisional device categorization (pure, unit-tested).
+ *
+ * A lightweight keyword→category dictionary applied to a manifest's `function`
+ * (rich in the corpus), `title`, and `keywords`. Categories are **multi-valued**
+ * — a device may fall under several — and this is deliberately a placeholder for
+ * the real, service-backed Device Category Taxonomy (Epic #199): once that lands
+ * the category facet swaps from derived to service-backed with no UX change.
+ * Keep the rules broad and honest, not tuned to any one corpus.
+ */
+
+export const UNCATEGORIZED = "Uncategorized";
+
+interface CategoryRule {
+  category: string;
+  keywords: string[];
+}
+
+const CATEGORY_RULES: CategoryRule[] = [
+  {
+    category: "Laboratory & Bio",
+    keywords: ["centrifuge", "incubator", "spectrophotometer", "photobioreactor", "thermocycler", "pcr", "gel", "dna", "assay", "bioreactor", "laboratory", "lab", "stirrer", "reagent"],
+  },
+  {
+    category: "Optics & Imaging",
+    keywords: ["microscope", "camera", "webcam", "optical", "optics", "lens", "imaging", "spectro", "photo"],
+  },
+  {
+    category: "Fluid Handling",
+    keywords: ["pump", "syringe", "peristaltic", "fluid", "liquid", "dispense", "valve", "flow"],
+  },
+  {
+    category: "Thermal Control",
+    keywords: ["thermal", "temperature", "incubator", "thermocycler", "heat", "cooling", "furnace"],
+  },
+  {
+    category: "Computing & Electronics",
+    keywords: ["computer", "single-board", "board", "arm", "cpu", "processor", "beaglebone", "raspberry", "microcontroller", "pcb", "electronics", "sensor"],
+  },
+  {
+    category: "Medical & PPE",
+    keywords: ["ventilator", "respirator", "mask", "shield", "ppe", "medical", "surgical", "prosthetic"],
+  },
+  {
+    category: "Test & Measurement",
+    keywords: ["test", "calibration", "measurement", "meter", "gauge", "analyzer"],
+  },
+];
+
+/** Categories a manifest belongs to (multi-valued); [UNCATEGORIZED] if none. */
+export function deriveCategories(item: OkhManifest): string[] {
+  const haystack = [item.function, item.title, ...(item.keywords ?? [])]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  const matched = CATEGORY_RULES.filter((rule) =>
+    rule.keywords.some((kw) => haystack.includes(kw)),
+  ).map((r) => r.category);
+
+  return matched.length > 0 ? matched : [UNCATEGORIZED];
+}

--- a/frontend/src/features/okh/facets.test.ts
+++ b/frontend/src/features/okh/facets.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import type { OkhManifest } from "../../types/okh";
+import {
+  countSelected,
+  deriveFacetGroups,
+  filterItems,
+  matchesSelections,
+} from "./facets";
+
+function item(
+  id: string,
+  processes: string[],
+  license: string | null,
+  materials: string[],
+): OkhManifest {
+  return {
+    id,
+    title: id,
+    version: "1",
+    repo: null,
+    function: null,
+    description: null,
+    intended_use: null,
+    keywords: [],
+    documentation_language: "en",
+    license: { hardware: license, documentation: null, software: null },
+    licensor: { name: "x", email: null, affiliation: null, social: [] },
+    contributors: [],
+    manufacturing_processes: processes,
+    materials: materials.map((name) => ({
+      material_id: name,
+      name,
+      quantity: null,
+      unit: "",
+      notes: null,
+    })),
+    design_files: [],
+    manufacturing_files: [],
+    making_instructions: [],
+    parts: [],
+    tool_list: [],
+    image: null,
+    project_link: null,
+  };
+}
+
+const items = [
+  item("a", ["3D Printing", "Assembly"], "MIT", ["PLA"]),
+  item("b", ["Laser Cutting"], "GPL-2.0", ["Acrylic"]),
+  item("c", ["3D Printing"], "MIT", ["PLA", "Steel"]),
+];
+
+describe("faceted filtering", () => {
+  it("ANDs across groups and ORs within a group", () => {
+    // process ∈ {3D Printing} AND license ∈ {MIT} → a, c
+    const filtered = filterItems(items, {
+      process: ["3D Printing"],
+      license: ["MIT"],
+    });
+    expect(filtered.map((i) => i.id)).toEqual(["a", "c"]);
+  });
+
+  it("OR within a group broadens", () => {
+    const filtered = filterItems(items, {
+      process: ["Laser Cutting", "Assembly"],
+    });
+    expect(filtered.map((i) => i.id).sort()).toEqual(["a", "b"]);
+  });
+
+  it("empty selections match everything", () => {
+    expect(items.every((i) => matchesSelections(i, {}))).toBe(true);
+  });
+});
+
+describe("deriveFacetGroups", () => {
+  it("counts options and sorts by count desc", () => {
+    const groups = deriveFacetGroups(items, {});
+    const process = groups.find((g) => g.key === "process")!;
+    expect(process.options[0]).toEqual({ value: "3D Printing", count: 2 });
+    const license = groups.find((g) => g.key === "license")!;
+    expect(license.options).toEqual([
+      { value: "MIT", count: 2 },
+      { value: "GPL-2.0", count: 1 },
+    ]);
+  });
+
+  it("computes drill-down counts against other groups' selections", () => {
+    // With license=GPL-2.0 selected, the process group counts only item b.
+    const groups = deriveFacetGroups(items, { license: ["GPL-2.0"] });
+    const process = groups.find((g) => g.key === "process")!;
+    expect(process.options).toEqual([{ value: "Laser Cutting", count: 1 }]);
+  });
+
+  it("omits groups with no options", () => {
+    const groups = deriveFacetGroups([item("x", [], null, [])], {});
+    expect(groups).toEqual([]);
+  });
+});
+
+describe("countSelected", () => {
+  it("totals selected values across groups", () => {
+    expect(countSelected({ process: ["a", "b"], license: ["MIT"] })).toBe(3);
+  });
+});

--- a/frontend/src/features/okh/facets.test.ts
+++ b/frontend/src/features/okh/facets.test.ts
@@ -91,9 +91,11 @@ describe("deriveFacetGroups", () => {
     expect(process.options).toEqual([{ value: "Laser Cutting", count: 1 }]);
   });
 
-  it("omits groups with no options", () => {
+  it("omits groups with no options (category always present via fallback)", () => {
     const groups = deriveFacetGroups([item("x", [], null, [])], {});
-    expect(groups).toEqual([]);
+    // process/license/material have no values → omitted; category always yields
+    // at least the Uncategorized fallback.
+    expect(groups.map((g) => g.key)).toEqual(["category"]);
   });
 });
 

--- a/frontend/src/features/okh/facets.ts
+++ b/frontend/src/features/okh/facets.ts
@@ -1,14 +1,21 @@
 import type { OkhManifest } from "../../types/okh";
+import { deriveCategories } from "./categories";
 
 /**
  * Faceted-browse logic for the OKH catalog (pure, framework-free, unit-tested).
  *
- * Facets are derived from fields that are actually populated across the real
- * manifest corpus: manufacturing process, hardware license, and material.
- * (keywords and development_stage were dropped — too sparse / no variance.)
+ * `category` is the primary drill-down facet (provisional, derived from the
+ * manifest `function`/title/keywords — see categories.ts; swaps to the
+ * service-backed taxonomy in Epic #199). The rest are orthogonal facets derived
+ * from fields populated across the real corpus: manufacturing process, hardware
+ * license, and material. (keywords / development_stage dropped — sparse / no
+ * variance.)
  */
 
-export type FacetKey = "process" | "license" | "material";
+export type FacetKey = "category" | "process" | "license" | "material";
+
+/** The primary drill-down facet, rendered first and marked provisional. */
+export const PRIMARY_FACET: FacetKey = "category";
 
 export interface FacetDef {
   key: FacetKey;
@@ -18,6 +25,11 @@ export interface FacetDef {
 }
 
 export const FACET_DEFS: FacetDef[] = [
+  {
+    key: "category",
+    label: "Category",
+    values: (i) => deriveCategories(i),
+  },
   {
     key: "process",
     label: "Manufacturing process",

--- a/frontend/src/features/okh/facets.ts
+++ b/frontend/src/features/okh/facets.ts
@@ -1,0 +1,113 @@
+import type { OkhManifest } from "../../types/okh";
+
+/**
+ * Faceted-browse logic for the OKH catalog (pure, framework-free, unit-tested).
+ *
+ * Facets are derived from fields that are actually populated across the real
+ * manifest corpus: manufacturing process, hardware license, and material.
+ * (keywords and development_stage were dropped — too sparse / no variance.)
+ */
+
+export type FacetKey = "process" | "license" | "material";
+
+export interface FacetDef {
+  key: FacetKey;
+  label: string;
+  /** All facet values a manifest contributes to this group (0..n). */
+  values: (item: OkhManifest) => string[];
+}
+
+export const FACET_DEFS: FacetDef[] = [
+  {
+    key: "process",
+    label: "Manufacturing process",
+    values: (i) => i.manufacturing_processes ?? [],
+  },
+  {
+    key: "license",
+    label: "License",
+    values: (i) => (i.license?.hardware ? [i.license.hardware] : []),
+  },
+  {
+    key: "material",
+    label: "Material",
+    values: (i) =>
+      (i.materials ?? []).map((m) => m.name).filter((n): n is string => !!n),
+  },
+];
+
+export type FacetSelections = Partial<Record<FacetKey, string[]>>;
+
+export interface FacetOption {
+  value: string;
+  count: number;
+}
+export interface FacetGroup {
+  key: FacetKey;
+  label: string;
+  options: FacetOption[];
+}
+
+const DEFS_BY_KEY: Record<FacetKey, FacetDef> = Object.fromEntries(
+  FACET_DEFS.map((d) => [d.key, d]),
+) as Record<FacetKey, FacetDef>;
+
+/** Does an item satisfy the selections in a single group? (OR within a group.) */
+function matchesGroup(
+  item: OkhManifest,
+  key: FacetKey,
+  selected: string[],
+): boolean {
+  if (selected.length === 0) return true;
+  const vals = DEFS_BY_KEY[key].values(item);
+  return selected.some((s) => vals.includes(s));
+}
+
+/** AND across groups, OR within each group — standard faceted filtering. */
+export function matchesSelections(
+  item: OkhManifest,
+  selections: FacetSelections,
+): boolean {
+  return FACET_DEFS.every((d) =>
+    matchesGroup(item, d.key, selections[d.key] ?? []),
+  );
+}
+
+export function filterItems(
+  items: OkhManifest[],
+  selections: FacetSelections,
+): OkhManifest[] {
+  return items.filter((i) => matchesSelections(i, selections));
+}
+
+/**
+ * Build facet groups with option counts. Each group's counts reflect the items
+ * that pass every *other* group's selections (drill-down counts), so counts
+ * preview what selecting an option would yield.
+ */
+export function deriveFacetGroups(
+  items: OkhManifest[],
+  selections: FacetSelections,
+): FacetGroup[] {
+  return FACET_DEFS.map((def) => {
+    const otherSelections: FacetSelections = { ...selections, [def.key]: [] };
+    const scoped = items.filter((i) => matchesSelections(i, otherSelections));
+    const counts = new Map<string, number>();
+    for (const item of scoped) {
+      for (const v of def.values(item)) {
+        counts.set(v, (counts.get(v) ?? 0) + 1);
+      }
+    }
+    const options = [...counts.entries()]
+      .map(([value, count]) => ({ value, count }))
+      .sort((a, b) => b.count - a.count || a.value.localeCompare(b.value));
+    return { key: def.key, label: def.label, options };
+  }).filter((g) => g.options.length > 0);
+}
+
+export function countSelected(selections: FacetSelections): number {
+  return FACET_DEFS.reduce(
+    (n, d) => n + (selections[d.key]?.length ?? 0),
+    0,
+  );
+}

--- a/frontend/src/features/okh/useOkhList.ts
+++ b/frontend/src/features/okh/useOkhList.ts
@@ -1,17 +1,22 @@
 import { useQuery } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
 import { fetchOkhList } from "../../api/ohm/okh";
 import type { OkhManifest } from "../../types/okh";
+import {
+  countSelected,
+  deriveFacetGroups,
+  FACET_DEFS,
+  filterItems,
+  type FacetKey,
+  type FacetSelections,
+} from "./facets";
 
-export type SortField = "title" | "version" | "documentation_language";
-export type SortOrder = "asc" | "desc";
-
-const PAGE_SIZE = 20;
+const PAGE_SIZE = 24;
 
 /**
- * List payloads can include BOM sidecars or other JSON under okh/ that parse as
- * manifests with empty title and no licensor; detail view then fails API
- * validation. Only show rows the GET /okh/:id contract can render.
+ * List payloads can include sidecars that parse as manifests with empty title
+ * and no licensor; only show rows the GET /okh/:id contract can render.
  */
 function isApiRenderableOkhListItem(item: OkhManifest): boolean {
   if (!item.title?.trim()) return false;
@@ -19,45 +24,34 @@ function isApiRenderableOkhListItem(item: OkhManifest): boolean {
   if (lic == null) return false;
   if (typeof lic === "string") return lic.trim().length > 0;
   if (Array.isArray(lic)) return lic.length > 0;
-  if (typeof lic === "object" && lic !== null && "name" in lic) {
+  if (typeof lic === "object" && "name" in lic) {
     const n = (lic as { name?: unknown }).name;
     return typeof n === "string" && n.trim().length > 0;
   }
   return false;
 }
 
-function normalize(s: string | null | undefined) {
-  return (s ?? "").toLowerCase();
+function textMatches(item: OkhManifest, q: string): boolean {
+  if (!q) return true;
+  const hay = [
+    item.title,
+    item.function,
+    item.description,
+    ...(item.keywords ?? []),
+    ...(item.manufacturing_processes ?? []),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  return hay.includes(q.trim().toLowerCase());
 }
 
-function sortItems(items: OkhManifest[], field: SortField, order: SortOrder): OkhManifest[] {
-  return [...items].sort((a, b) => {
-    const av = normalize(a[field]);
-    const bv = normalize(b[field]);
-    const cmp = av.localeCompare(bv);
-    return order === "asc" ? cmp : -cmp;
-  });
+function parseList(raw: string | null): string[] {
+  return raw ? raw.split(",").map((s) => s.trim()).filter(Boolean) : [];
 }
 
-function filterItems(items: OkhManifest[], query: string): OkhManifest[] {
-  const q = query.trim().toLowerCase();
-  if (!q) return items;
-  return items.filter((item) => {
-    return (
-      normalize(item.title).includes(q) ||
-      normalize(item.function).includes(q) ||
-      normalize(item.description).includes(q) ||
-      item.keywords.some((k) => k.toLowerCase().includes(q)) ||
-      item.manufacturing_processes.some((p) => p.toLowerCase().includes(q))
-    );
-  });
-}
-
-export function useOkhList() {
-  const [filterText, setFilterText] = useState("");
-  const [sortField, setSortField] = useState<SortField>("title");
-  const [sortOrder, setSortOrder] = useState<SortOrder>("asc");
-  const [page, setPage] = useState(1);
+export function useOkhCatalog() {
+  const [params, setParams] = useSearchParams();
 
   const query = useQuery({
     queryKey: ["okh-list"],
@@ -65,41 +59,87 @@ export function useOkhList() {
     staleTime: 60_000,
   });
 
-  const processed = useMemo(() => {
-    const items = (query.data?.items ?? []).filter(isApiRenderableOkhListItem);
-    const filtered = filterItems(items, filterText);
-    const sorted = sortItems(filtered, sortField, sortOrder);
-    const totalItems = sorted.length;
-    const totalPages = Math.max(1, Math.ceil(totalItems / PAGE_SIZE));
-    const safePage = Math.min(page, totalPages);
-    const start = (safePage - 1) * PAGE_SIZE;
-    const pageItems = sorted.slice(start, start + PAGE_SIZE);
-    return { pageItems, totalItems, totalPages, safePage };
-  }, [query.data, filterText, sortField, sortOrder, page]);
+  const filterText = params.get("q") ?? "";
+  const page = Math.max(1, Number(params.get("page") ?? "1") || 1);
 
-  function handleFilterChange(text: string) {
-    setFilterText(text);
-    setPage(1);
+  const selections: FacetSelections = useMemo(() => {
+    const s: FacetSelections = {};
+    for (const def of FACET_DEFS) s[def.key] = parseList(params.get(def.key));
+    return s;
+  }, [params]);
+
+  const renderable = useMemo(
+    () => (query.data?.items ?? []).filter(isApiRenderableOkhListItem),
+    [query.data],
+  );
+
+  const facetGroups = useMemo(
+    () => deriveFacetGroups(renderable, selections),
+    [renderable, selections],
+  );
+
+  const matched = useMemo(() => {
+    const byFacet = filterItems(renderable, selections);
+    return byFacet.filter((i) => textMatches(i, filterText));
+  }, [renderable, selections, filterText]);
+
+  const totalItems = matched.length;
+  const totalPages = Math.max(1, Math.ceil(totalItems / PAGE_SIZE));
+  const safePage = Math.min(page, totalPages);
+  const pageItems = matched.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE);
+
+  function mutate(fn: (p: URLSearchParams) => void) {
+    const next = new URLSearchParams(params);
+    fn(next);
+    next.delete("page"); // any refinement resets to page 1
+    setParams(next, { replace: true });
   }
 
-  function handleSortChange(field: SortField, order: SortOrder) {
-    setSortField(field);
-    setSortOrder(order);
-    setPage(1);
+  function toggleFacet(key: FacetKey, value: string) {
+    mutate((p) => {
+      const cur = parseList(p.get(key));
+      const nextVals = cur.includes(value)
+        ? cur.filter((v) => v !== value)
+        : [...cur, value];
+      if (nextVals.length) p.set(key, nextVals.join(","));
+      else p.delete(key);
+    });
+  }
+
+  function clearFacets() {
+    mutate((p) => {
+      for (const def of FACET_DEFS) p.delete(def.key);
+      p.delete("q");
+    });
+  }
+
+  function setFilterText(text: string) {
+    mutate((p) => (text ? p.set("q", text) : p.delete("q")));
+  }
+
+  function setPage(next: number) {
+    const p = new URLSearchParams(params);
+    p.set("page", String(next));
+    setParams(p, { replace: true });
   }
 
   return {
-    ...processed,
+    pageItems,
+    totalItems,
+    totalPages,
+    safePage,
+    facetGroups,
+    selections,
+    selectedCount: countSelected(selections),
     filterText,
-    sortField,
-    sortOrder,
     isLoading: query.isLoading,
     isError: query.isError,
     error: query.error,
     refetch: query.refetch,
+    toggleFacet,
+    clearFacets,
+    setFilterText,
     setPage,
-    handleFilterChange,
-    handleSortChange,
     PAGE_SIZE,
   };
 }

--- a/frontend/src/test/fixtures/index.ts
+++ b/frontend/src/test/fixtures/index.ts
@@ -23,6 +23,8 @@ function okhItem(
   title: string,
   fn: string,
   processes: string[],
+  license: string,
+  material: string,
 ): Record<string, unknown> {
   return {
     id,
@@ -32,11 +34,11 @@ function okhItem(
     description: fn,
     keywords: [],
     documentation_language: "en",
-    license: { hardware: "CERN-OHL-S-2.0", documentation: null, software: null },
+    license: { hardware: license, documentation: null, software: null },
     licensor: { name: "OHM Test", email: null, affiliation: null, social: [] },
     contributors: [],
     manufacturing_processes: processes,
-    materials: [{ material_id: "m1", name: "PLA", quantity: 1, unit: "kg", notes: null }],
+    materials: [{ material_id: material, name: material, quantity: 1, unit: "kg", notes: null }],
     design_files: [],
     manufacturing_files: [],
     making_instructions: [],
@@ -47,7 +49,7 @@ function okhItem(
   };
 }
 
-/** Populated OKH list (paginated envelope) for catalog browse tests + screenshots. */
+/** Populated OKH list (paginated envelope) with varied facets for browse tests. */
 export const okhListFixture = {
   status: "success",
   message: "ok",
@@ -56,14 +58,15 @@ export const okhListFixture = {
   pagination: {
     page: 1,
     page_size: 100,
-    total_items: 2,
+    total_items: 3,
     total_pages: 1,
     has_next: false,
     has_previous: false,
   },
   items: [
-    okhItem("okh-0001", "Open Ventilator", "Emergency ventilator", ["3DP", "PCB"]),
-    okhItem("okh-0002", "Face Shield", "Protective face shield", ["3DP", "Laser"]),
+    okhItem("okh-0001", "Open Ventilator", "Emergency ventilator", ["3D Printing", "Assembly"], "MIT", "PLA"),
+    okhItem("okh-0002", "Face Shield", "Protective face shield", ["3D Printing", "Laser Cutting"], "GPL-2.0", "Acrylic"),
+    okhItem("okh-0003", "Test Rig", "Calibration test rig", ["Laser Cutting"], "MIT", "Steel"),
   ],
 };
 


### PR DESCRIPTION
Phase A of the catalog IA pivot. Closes #200. Merges into `frontend-dev`.

Replaces the simple OKH list with a **Newegg/Amazon-style left-nav faceted browse**, built on slice 1's typed client + state primitives.

## What's in it

- **Facet deep module** (`facets.ts`, pure + unit-tested): derives facet groups with **drill-down counts** (each group's counts reflect the other groups' selections) and filters with standard semantics (**AND across groups, OR within**).
- **Facets chosen from real data** — profiled the 27-manifest oshwa corpus: **manufacturing process**, **license**, **material** (all well-populated). Dropped `development_stage` (all "development" — no variance) and `keywords` (only 8/27).
- **FacetPanel** component (checkbox groups + counts + clear-all), component-tested.
- **URL-synced facet + search state** → deep-linkable/shareable; pagination; **responsive** (facet drawer on mobile).

## Verification

- `make frontend-ready` **green**: typecheck, lint, unit (facet module + FacetPanel + wrapper), build, mocked E2E, a11y, screenshots.
- **Mocked E2E** covers: loads with filter panel, fixture designs, **facet narrows results + URL reflects selection**, empty, error.
- **Real-api lane green** against the live 27-manifest corpus (real facet distributions: Assembly 16 / Laser 14 / 3DP 9 …; GPL-2.0 11 / MIT 6 …).

## Review notes

- Screenshot (`/okh`, mocked fixtures) is below the fold — shows the left-nav facet layout. To see it against the **real 27 manifests**: `cd frontend && npm run dev`.
- This is the orthogonal-facet half. The **category spine** (function-derived, provisional) + the (deferred) variant grouping are slice A2 / #201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)