### PR TITLE
Slice A2: OKH provisional category spine

### DIFF
--- a/frontend/e2e/okh-catalog.spec.ts
+++ b/frontend/e2e/okh-catalog.spec.ts
@@ -31,6 +31,20 @@ test("selecting a facet narrows the results (mocked)", async ({ page }, testInfo
   await expect(page).toHaveURL(/license=GPL-2\.0/);
 });
 
+test("category facet is the primary spine and narrows results (mocked)", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "asserts fixture data");
+  await page.goto("/okh");
+  // Category is present as a facet group. Test Rig ("Calibration test rig") is
+  // the only Test & Measurement device.
+  await expect(page.getByRole("heading", { name: "Category" })).toBeVisible();
+  await page.getByRole("checkbox", { name: /Test & Measurement/ }).check();
+  await expect(page.getByRole("heading", { name: "Test Rig" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Open Ventilator" })).toBeHidden();
+  await expect(page).toHaveURL(/category=Test/);
+});
+
 test("shows the empty state (mocked)", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name === "real-api", "forces an empty response");
   await page.route("**/v1/api/okh**", (route) =>

--- a/frontend/src/features/okh/FacetPanel.tsx
+++ b/frontend/src/features/okh/FacetPanel.tsx
@@ -1,5 +1,5 @@
 import { Button } from "../../components/ui/button";
-import type { FacetGroup, FacetKey, FacetSelections } from "./facets";
+import { PRIMARY_FACET, type FacetGroup, type FacetKey, type FacetSelections } from "./facets";
 
 interface Props {
   groups: FacetGroup[];
@@ -31,7 +31,17 @@ export function FacetPanel({
         const selected = selections[group.key] ?? [];
         return (
           <div key={group.key}>
-            <h3 className="mb-2 font-medium text-muted-foreground">{group.label}</h3>
+            <h3 className="mb-2 flex items-center gap-1.5 font-medium text-muted-foreground">
+              {group.label}
+              {group.key === PRIMARY_FACET && (
+                <span
+                  title="Provisional categories derived from design text; a curated taxonomy is coming."
+                  className="rounded bg-muted px-1 py-0.5 text-[10px] font-normal uppercase tracking-wide text-muted-foreground"
+                >
+                  provisional
+                </span>
+              )}
+            </h3>
             <ul className="space-y-1">
               {group.options.map((opt) => {
                 const checked = selected.includes(opt.value);

--- a/frontend/src/features/okh/categories.test.ts
+++ b/frontend/src/features/okh/categories.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import type { OkhManifest } from "../../types/okh";
+import { deriveCategories, UNCATEGORIZED } from "./categories";
+
+function withFunction(fn: string, title = "x"): OkhManifest {
+  return {
+    id: "x",
+    title,
+    version: null,
+    repo: null,
+    function: fn,
+    description: null,
+    intended_use: null,
+    keywords: [],
+    documentation_language: null,
+    license: null,
+    licensor: null,
+    contributors: [],
+    manufacturing_processes: [],
+    materials: [],
+    design_files: [],
+    manufacturing_files: [],
+    making_instructions: [],
+    parts: [],
+    tool_list: [],
+    image: null,
+    project_link: null,
+  };
+}
+
+describe("deriveCategories", () => {
+  it("derives a category from the function text", () => {
+    expect(deriveCategories(withFunction("A laboratory centrifuge"))).toContain(
+      "Laboratory & Bio",
+    );
+  });
+
+  it("is multi-valued — a device can belong to several categories", () => {
+    const cats = deriveCategories(
+      withFunction("A laboratory centrifuge driven by a peristaltic pump"),
+    );
+    expect(cats).toContain("Laboratory & Bio");
+    expect(cats).toContain("Fluid Handling");
+    expect(cats.length).toBeGreaterThan(1);
+  });
+
+  it("matches on title and keywords too", () => {
+    const item = withFunction("Does things", "Emergency Ventilator");
+    expect(deriveCategories(item)).toContain("Medical & PPE");
+  });
+
+  it("falls back to Uncategorized when nothing matches", () => {
+    expect(deriveCategories(withFunction("An inscrutable widget"))).toEqual([
+      UNCATEGORIZED,
+    ]);
+  });
+});

--- a/frontend/src/features/okh/categories.ts
+++ b/frontend/src/features/okh/categories.ts
@@ -1,0 +1,64 @@
+import type { OkhManifest } from "../../types/okh";
+
+/**
+ * Provisional device categorization (pure, unit-tested).
+ *
+ * A lightweight keyword→category dictionary applied to a manifest's `function`
+ * (rich in the corpus), `title`, and `keywords`. Categories are **multi-valued**
+ * — a device may fall under several — and this is deliberately a placeholder for
+ * the real, service-backed Device Category Taxonomy (Epic #199): once that lands
+ * the category facet swaps from derived to service-backed with no UX change.
+ * Keep the rules broad and honest, not tuned to any one corpus.
+ */
+
+export const UNCATEGORIZED = "Uncategorized";
+
+interface CategoryRule {
+  category: string;
+  keywords: string[];
+}
+
+const CATEGORY_RULES: CategoryRule[] = [
+  {
+    category: "Laboratory & Bio",
+    keywords: ["centrifuge", "incubator", "spectrophotometer", "photobioreactor", "thermocycler", "pcr", "gel", "dna", "assay", "bioreactor", "laboratory", "lab", "stirrer", "reagent"],
+  },
+  {
+    category: "Optics & Imaging",
+    keywords: ["microscope", "camera", "webcam", "optical", "optics", "lens", "imaging", "spectro", "photo"],
+  },
+  {
+    category: "Fluid Handling",
+    keywords: ["pump", "syringe", "peristaltic", "fluid", "liquid", "dispense", "valve", "flow"],
+  },
+  {
+    category: "Thermal Control",
+    keywords: ["thermal", "temperature", "incubator", "thermocycler", "heat", "cooling", "furnace"],
+  },
+  {
+    category: "Computing & Electronics",
+    keywords: ["computer", "single-board", "board", "arm", "cpu", "processor", "beaglebone", "raspberry", "microcontroller", "pcb", "electronics", "sensor"],
+  },
+  {
+    category: "Medical & PPE",
+    keywords: ["ventilator", "respirator", "mask", "shield", "ppe", "medical", "surgical", "prosthetic"],
+  },
+  {
+    category: "Test & Measurement",
+    keywords: ["test", "calibration", "measurement", "meter", "gauge", "analyzer"],
+  },
+];
+
+/** Categories a manifest belongs to (multi-valued); [UNCATEGORIZED] if none. */
+export function deriveCategories(item: OkhManifest): string[] {
+  const haystack = [item.function, item.title, ...(item.keywords ?? [])]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  const matched = CATEGORY_RULES.filter((rule) =>
+    rule.keywords.some((kw) => haystack.includes(kw)),
+  ).map((r) => r.category);
+
+  return matched.length > 0 ? matched : [UNCATEGORIZED];
+}

--- a/frontend/src/features/okh/facets.test.ts
+++ b/frontend/src/features/okh/facets.test.ts
@@ -91,9 +91,11 @@ describe("deriveFacetGroups", () => {
     expect(process.options).toEqual([{ value: "Laser Cutting", count: 1 }]);
   });
 
-  it("omits groups with no options", () => {
+  it("omits groups with no options (category always present via fallback)", () => {
     const groups = deriveFacetGroups([item("x", [], null, [])], {});
-    expect(groups).toEqual([]);
+    // process/license/material have no values → omitted; category always yields
+    // at least the Uncategorized fallback.
+    expect(groups.map((g) => g.key)).toEqual(["category"]);
   });
 });
 

--- a/frontend/src/features/okh/facets.ts
+++ b/frontend/src/features/okh/facets.ts
@@ -1,14 +1,21 @@
 import type { OkhManifest } from "../../types/okh";
+import { deriveCategories } from "./categories";
 
 /**
  * Faceted-browse logic for the OKH catalog (pure, framework-free, unit-tested).
  *
- * Facets are derived from fields that are actually populated across the real
- * manifest corpus: manufacturing process, hardware license, and material.
- * (keywords and development_stage were dropped — too sparse / no variance.)
+ * `category` is the primary drill-down facet (provisional, derived from the
+ * manifest `function`/title/keywords — see categories.ts; swaps to the
+ * service-backed taxonomy in Epic #199). The rest are orthogonal facets derived
+ * from fields populated across the real corpus: manufacturing process, hardware
+ * license, and material. (keywords / development_stage dropped — sparse / no
+ * variance.)
  */
 
-export type FacetKey = "process" | "license" | "material";
+export type FacetKey = "category" | "process" | "license" | "material";
+
+/** The primary drill-down facet, rendered first and marked provisional. */
+export const PRIMARY_FACET: FacetKey = "category";
 
 export interface FacetDef {
   key: FacetKey;
@@ -18,6 +25,11 @@ export interface FacetDef {
 }
 
 export const FACET_DEFS: FacetDef[] = [
+  {
+    key: "category",
+    label: "Category",
+    values: (i) => deriveCategories(i),
+  },
   {
     key: "process",
     label: "Manufacturing process",


### PR DESCRIPTION
Phase A category spine. Closes #201. **Stacked on #203 (A1)** — base retargets to `frontend-dev` once A1 merges.

Adds the **primary category drill-down facet** to the faceted catalog, composing with A1's orthogonal facets (Category → refine by process/license/material). Per the #201 decision, the category spine is **function-derived and provisional**, and **variant grouping is deferred** (`variant_of` is 0/27 in the real corpus).

## What's in it

- **Provisional category derivation** (`categories.ts`, pure + unit-tested): a keyword→category dictionary over `function`/title/keywords, **multi-valued** (a device can belong to several categories — your requirement #2), `Uncategorized` fallback. An honest placeholder for the service-backed **Device Category Taxonomy (Epic #199)** — the facet swaps derived→service-backed with no UX change.
- **Category wired as the PRIMARY facet** — rendered first, marked `provisional`.
- **E2E**: category present as the spine, narrows results, URL reflects the selection.

## Verification

- `make frontend-ready` **green**; **real-api lane green**.
- Category derivation over the **real 27 manifests**: Computing & Electronics 13, Laboratory & Bio 9, Fluid Handling 8, Optics & Imaging 8, Thermal 7, Test & Measurement 3, Medical & PPE 3, Uncategorized 1 (multi-membership → sums > 27; only 1 uncategorized).

Screenshot (`/okh`) shows Category as the primary spine with the provisional badge above process/license/material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)