### PR TITLE
fix(okw): create endpoint returns 500 on every successful create

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 430
+Total Python files: 431
 
 ├── deploy/
 │   ├── __init__.py
@@ -1480,6 +1480,9 @@ Total Python files: 430
     │           class MatchQualityAnalyzer (__init__, analyze_match_quality, _calculate_overall_metrics...)
     │           def main()
     ├── api/
+    │   ├── test_okw_create_route.py
+    │   │       def _get_app()
+    │   │       def _facility_content()
     │   ├── test_package_download_integration.py
     │   ├── test_package_download_route.py
     │   │       def _get_app()
@@ -2013,7 +2016,7 @@ Total Python files: 430
 
 ## Overview
 
-Total files analyzed: 430
+Total files analyzed: 431
 
 ## Entry Points
 
@@ -7007,6 +7010,13 @@ This module evaluates the quality and accuracy of ...
 **Functions:**
 - `main()`
   - Example usage of the match quality analyzer...
+
+### `tests/api/test_okw_create_route.py`
+> Contract test for POST /api/okw/create.
+
+Regression guard: the handler previously built ``OKWUploadR...
+
+**Internal Dependencies:** 2 imports
 
 ### `tests/api/test_package_download_integration.py`
 > Live API integration test for package download (requires running OHM API).

--- a/src/core/api/routes/okw.py
+++ b/src/core/api/routes/okw.py
@@ -1009,8 +1009,7 @@ async def create_okw_facility(
         return OKWUploadResponse(
             success=True,
             message="OKW facility created and stored successfully",
-            facility=okw_response,
-            facility_id=str(facility.id),
+            okw=okw_response,
         )
     except HTTPException:
         raise

--- a/tests/api/test_okw_create_route.py
+++ b/tests/api/test_okw_create_route.py
@@ -1,0 +1,63 @@
+"""
+Contract test for POST /api/okw/create.
+
+Regression guard: the handler previously built ``OKWUploadResponse`` with the
+wrong field names (``facility=``/``facility_id=``) while the model requires
+``okw=``, so every successful create raised a 500 when serializing the response.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+
+def _get_app() -> tuple[FastAPI, FastAPI]:
+    from src.core.main import api_v1
+
+    app = FastAPI()
+    app.mount("/v1", api_v1)
+    return app, api_v1
+
+
+def _facility_content() -> dict:
+    data_dir = Path(__file__).resolve().parents[2] / "synthetic_data"
+    facility_file = sorted(data_dir.glob("*okw*.json"))[0]
+    return json.loads(facility_file.read_text(encoding="utf-8"))
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_create_okw_returns_201_with_okw_field():
+    from src.core.api.routes.okw import get_okw_service
+
+    app, api_v1 = _get_app()
+    svc = MagicMock()
+    # Service echoes the parsed facility back (create returns the stored record).
+    svc.create = AsyncMock(side_effect=lambda facility: facility)
+    api_v1.dependency_overrides[get_okw_service] = lambda: svc
+
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as client:
+            resp = await client.post(
+                "/v1/api/okw/create", json={"content": _facility_content()}
+            )
+
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["success"] is True
+        assert body.get("okw") is not None
+    finally:
+        api_v1.dependency_overrides.clear()


### PR DESCRIPTION
**Urgent bug.** `POST /api/okw/create` returns **HTTP 500** on every call, even though it stores the facility correctly — so the API path for adding a facility is broken from a caller's perspective (this would bite any real makerspace submitting their data via API/CLI). Surfaced while loading synthetic OKW facilities for the frontend work.

## Cause

The handler constructed the response with field names the model doesn't define:

```python
return OKWUploadResponse(facility=okw_response, facility_id=str(facility.id))
```

but `OKWUploadResponse` requires `okw: OKWResponse`. Pydantic raised *"okw Field required"*, which the generic `except` turned into a 500 — *after* the facility was already stored.

## Fix

Construct the response with the correct field:

```python
return OKWUploadResponse(success=True, message=..., okw=okw_response)
```

## Verification

- New TestClient contract test `tests/api/test_okw_create_route.py` — create returns **201** with the `okw` field (would 500 before this fix).
- `make ready` green: 522 passed, parity 4/4, docs ✓.

## Follow-up (separate)

Process representation in the synthetic OKW data is inconsistent (Wikipedia URIs vs plain names). `ProcessTaxonomy.normalize()` already exists to canonicalize these; normalizing the data + updating `generate_synthetic_data.py` is a tracked follow-up (lower urgency, and a data-model decision rather than a bugfix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)