### PR TITLE
Slice #188: OKW facility catalog (read-only)

### DIFF
--- a/frontend/e2e/okw-catalog.spec.ts
+++ b/frontend/e2e/okw-catalog.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "./mock-api";
+import { okwSearchEmptyFixture } from "../src/test/fixtures";
+
+// Slice #188: read-only OKW facility catalog. Mocked lane covers the behavior;
+// the real-api lane runs the lenient "loads" check against the live corpus.
+
+test("facility catalog loads", async ({ page }) => {
+  await page.goto("/facilities");
+  await expect(
+    page.getByRole("heading", { name: /manufacturing facilities/i }),
+  ).toBeVisible();
+});
+
+test("shows fixture facilities with humanized processes (mocked)", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "asserts fixture data");
+  await page.goto("/facilities");
+  await expect(page.getByRole("heading", { name: "Laser Fab Lab" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Community Makerspace" })).toBeVisible();
+  // Wikipedia URI is humanized for display.
+  await expect(page.getByText("Laser Cutter")).toBeVisible();
+});
+
+test("filtering by access type narrows results (mocked)", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "asserts fixture data");
+  await page.goto("/facilities");
+  await page.getByRole("button", { name: "Public", pressed: false }).click();
+  await expect(page.getByRole("heading", { name: "Community Makerspace" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Laser Fab Lab" })).toBeHidden();
+});
+
+test("shows the empty state (mocked)", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "forces an empty response");
+  await page.route("**/v1/api/okw/search**", (route) =>
+    route.fulfill({ json: okwSearchEmptyFixture }),
+  );
+  await page.goto("/facilities");
+  await expect(page.getByText(/no facilities/i)).toBeVisible();
+});
+
+test("shows the error state with retry (mocked)", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "forces an error response");
+  await page.route("**/v1/api/okw/search**", (route) =>
+    route.fulfill({ status: 500, json: { message: "boom" } }),
+  );
+  await page.goto("/facilities");
+  await expect(page.getByRole("alert")).toBeVisible();
+  await expect(page.getByRole("button", { name: /retry/i })).toBeVisible();
+});

--- a/frontend/harness.config.json
+++ b/frontend/harness.config.json
@@ -7,5 +7,5 @@
   "apiPathPrefix": "/v1/api",
   "openapiUrl": "http://localhost:8001/v1/openapi.json",
   "apiTypesOutput": "src/api/generated/schema.d.ts",
-  "routesToScreenshot": ["/", "/okh", "/match"]
+  "routesToScreenshot": ["/", "/okh", "/facilities", "/match"]
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Layout } from "./components/layout/Layout";
 import { HomePage } from "./pages/HomePage";
 import { OkhPage } from "./pages/OkhPage";
+import { OkwPage } from "./pages/OkwPage";
 import { MatchPage } from "./pages/MatchPage";
 import { VisualizationPage } from "./pages/VisualizationPage";
 import { RfqPage } from "./pages/RfqPage";
@@ -31,6 +32,7 @@ export function App() {
               <Route index element={<HomePage />} />
               <Route path="okh" element={<OkhPage />} />
               <Route path="okh/:id" element={<OkhPage />} />
+              <Route path="facilities" element={<OkwPage />} />
               <Route path="match" element={<MatchPage />} />
               <Route path="visualization" element={<VisualizationPage />} />
               <Route path="visualization/:solutionId" element={<VisualizationPage />} />

--- a/frontend/src/api/ohm/okw.test.ts
+++ b/frontend/src/api/ohm/okw.test.ts
@@ -1,0 +1,24 @@
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { server } from "../../test/msw/server";
+import { ApiError } from "./client";
+import { searchOkw } from "./okw";
+
+describe("searchOkw", () => {
+  it("narrows the {results,total} envelope to facilities", async () => {
+    const res = await searchOkw();
+    expect(res.results).toHaveLength(3);
+    expect(res.total).toBe(3);
+    expect(res.results.map((f) => f.name)).toContain("Laser Fab Lab");
+  });
+
+  it("throws ApiError on failure", async () => {
+    server.use(
+      http.get("*/v1/api/okw/search", () =>
+        HttpResponse.json({ message: "boom" }, { status: 500 }),
+      ),
+    );
+    await expect(searchOkw()).rejects.toMatchObject({ name: "ApiError", status: 500 });
+    await expect(searchOkw()).rejects.toBeInstanceOf(ApiError);
+  });
+});

--- a/frontend/src/api/ohm/okw.ts
+++ b/frontend/src/api/ohm/okw.ts
@@ -1,0 +1,58 @@
+import { apiClient, ApiError, errorMessage } from "./client";
+import type { OkwFacility } from "../../types/okw";
+
+export interface OkwSearchResult {
+  results: OkwFacility[];
+  total: number;
+  page: number;
+  page_size: number;
+}
+
+export interface SearchOkwParams {
+  page?: number;
+  page_size?: number;
+  location?: string;
+  access_type?: string;
+  facility_status?: string;
+}
+
+/**
+ * Search OKW facilities. Response envelope is `{results, total, page, page_size}`
+ * (distinct from OKH's `{items, pagination}`); results are narrowed to the
+ * OkwFacility view type the catalog renders.
+ */
+export async function searchOkw(
+  params: SearchOkwParams = {},
+): Promise<OkwSearchResult> {
+  const { data, error, response } = await apiClient.GET("/api/okw/search", {
+    params: {
+      query: {
+        page: params.page ?? 1,
+        page_size: params.page_size ?? 100,
+        location: params.location,
+        access_type: params.access_type,
+        facility_status: params.facility_status,
+      },
+    },
+  });
+
+  if (error || !response.ok) {
+    throw new ApiError(
+      response.status,
+      errorMessage(error, `Failed to load facilities (HTTP ${response.status})`),
+    );
+  }
+
+  const body = (data ?? {}) as {
+    results?: unknown[];
+    total?: number;
+    page?: number;
+    page_size?: number;
+  };
+  return {
+    results: (body.results ?? []) as OkwFacility[],
+    total: body.total ?? 0,
+    page: body.page ?? 1,
+    page_size: body.page_size ?? 0,
+  };
+}

--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -3,6 +3,7 @@ import { useTheme } from "../../context/ThemeContext";
 
 const navItems = [
   { to: "/okh", label: "Designs", icon: "🔩" },
+  { to: "/facilities", label: "Facilities", icon: "🏭" },
   { to: "/match", label: "Match", icon: "⚡" },
   { to: "/visualization", label: "Visualization", icon: "🗺️" },
   { to: "/rfq", label: "RFQ", icon: "📄" },

--- a/frontend/src/features/okw/OkwCard.tsx
+++ b/frontend/src/features/okw/OkwCard.tsx
@@ -1,0 +1,47 @@
+import { Badge } from "../../components/ui/Badge";
+import type { OkwFacility } from "../../types/okw";
+import { humanizeProcess } from "./processDisplay";
+
+function locationLabel(f: OkwFacility): string | null {
+  const a = f.location?.address;
+  const parts = [a?.city ?? f.location?.city, a?.region, a?.country ?? f.location?.country].filter(
+    Boolean,
+  );
+  return parts.length ? parts.join(", ") : null;
+}
+
+export function OkwCard({ facility }: { facility: OkwFacility }) {
+  const location = locationLabel(facility);
+  const processes = (facility.manufacturing_processes ?? []).map(humanizeProcess);
+
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+      <div>
+        <h3 className="font-semibold text-slate-800 dark:text-slate-100">
+          {facility.name || "Unnamed facility"}
+        </h3>
+        {location && (
+          <p className="mt-0.5 text-sm text-slate-500 dark:text-slate-400">📍 {location}</p>
+        )}
+      </div>
+
+      {processes.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {processes.slice(0, 4).map((p) => (
+            <Badge key={p} variant="indigo">{p}</Badge>
+          ))}
+          {processes.length > 4 && <Badge variant="default">+{processes.length - 4}</Badge>}
+        </div>
+      )}
+
+      <div className="mt-auto flex flex-wrap items-center gap-1.5 pt-1">
+        {facility.access_type && <Badge variant="blue">{facility.access_type}</Badge>}
+        {facility.facility_status && (
+          <Badge variant={facility.facility_status === "Active" ? "green" : "yellow"}>
+            {facility.facility_status}
+          </Badge>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/okw/OkwListView.tsx
+++ b/frontend/src/features/okw/OkwListView.tsx
@@ -1,0 +1,145 @@
+import { useOkwList } from "./useOkwList";
+import { OkwCard } from "./OkwCard";
+import { LoadingState, EmptyState, ErrorState } from "../../components/ui/states";
+import { Button } from "../../components/ui/button";
+import { Pagination } from "../../components/ui/Pagination";
+import { cn } from "@/lib/utils";
+
+function Chip({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      className={cn(
+        "rounded-full border px-3 py-1 text-xs transition-colors",
+        active
+          ? "border-primary bg-primary text-primary-foreground"
+          : "border-input bg-background text-foreground hover:bg-accent",
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+export function OkwListView() {
+  const {
+    pageItems,
+    totalItems,
+    totalPages,
+    safePage,
+    filterText,
+    accessOptions,
+    statusOptions,
+    selectedAccess,
+    selectedStatus,
+    filterCount,
+    isLoading,
+    isError,
+    error,
+    refetch,
+    setPage,
+    setFilterText,
+    toggleAccess,
+    toggleStatus,
+    clearFilters,
+    PAGE_SIZE,
+  } = useOkwList();
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">Manufacturing Facilities</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Browse facilities (OKW) that can produce open hardware designs.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <input
+          type="search"
+          aria-label="Search facilities"
+          placeholder="Search by name, location, or process…"
+          value={filterText}
+          onChange={(e) => setFilterText(e.target.value)}
+          className="w-full max-w-md rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        />
+        {(accessOptions.length > 0 || statusOptions.length > 0) && (
+          <div className="flex flex-wrap items-center gap-1.5">
+            {accessOptions.map((v) => (
+              <Chip key={v} label={v} active={selectedAccess.has(v)} onClick={() => toggleAccess(v)} />
+            ))}
+            {statusOptions.map((v) => (
+              <Chip key={v} label={v} active={selectedStatus.has(v)} onClick={() => toggleStatus(v)} />
+            ))}
+            {filterCount > 0 && (
+              <Button variant="ghost" size="sm" onClick={clearFilters}>
+                Clear
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {!isLoading && !isError && (
+        <p className="text-xs text-muted-foreground">
+          {totalItems} facilit{totalItems !== 1 ? "ies" : "y"}
+          {filterCount > 0 || filterText ? " (filtered)" : ""}
+        </p>
+      )}
+
+      {isLoading && <LoadingState message="Loading facilities…" />}
+      {isError && (
+        <ErrorState
+          description={error instanceof Error ? error.message : "Failed to load facilities."}
+          onRetry={() => refetch()}
+        />
+      )}
+
+      {!isLoading && !isError && pageItems.length === 0 && (
+        <EmptyState
+          icon="🏭"
+          title="No facilities found"
+          description={
+            filterCount > 0 || filterText
+              ? "No facilities match the current filters."
+              : "No OKW facilities are available yet."
+          }
+          action={
+            filterCount > 0 || filterText ? (
+              <Button variant="outline" size="sm" onClick={clearFilters}>
+                Clear filters
+              </Button>
+            ) : undefined
+          }
+        />
+      )}
+
+      {!isLoading && !isError && pageItems.length > 0 && (
+        <>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {pageItems.map((f) => (
+              <OkwCard key={f.id} facility={f} />
+            ))}
+          </div>
+          <Pagination
+            page={safePage}
+            totalPages={totalPages}
+            totalItems={totalItems}
+            pageSize={PAGE_SIZE}
+            onPage={setPage}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/okw/processDisplay.test.ts
+++ b/frontend/src/features/okw/processDisplay.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { humanizeProcess } from "./processDisplay";
+
+describe("humanizeProcess", () => {
+  it("humanizes a Wikipedia URI to a readable label", () => {
+    expect(humanizeProcess("https://en.wikipedia.org/wiki/Laser_cutter")).toBe(
+      "Laser Cutter",
+    );
+    expect(humanizeProcess("https://en.wikipedia.org/wiki/Assembly_station")).toBe(
+      "Assembly Station",
+    );
+  });
+
+  it("leaves a plain name unchanged", () => {
+    expect(humanizeProcess("Laser Cutting")).toBe("Laser Cutting");
+  });
+});

--- a/frontend/src/features/okw/processDisplay.ts
+++ b/frontend/src/features/okw/processDisplay.ts
@@ -1,0 +1,18 @@
+/**
+ * Humanize an OKW manufacturing-process value for display (pure, unit-tested).
+ *
+ * The synthetic corpus stores processes inconsistently — Wikipedia URIs
+ * (`https://en.wikipedia.org/wiki/Laser_cutter`) alongside plain names
+ * (`Laser Cutting`). This yields a consistent readable label regardless. The
+ * underlying data normalization is tracked separately (issue #207).
+ */
+export function humanizeProcess(value: string): string {
+  if (/^https?:\/\//i.test(value)) {
+    const tail = value.split("/").pop() || value;
+    return tail
+      .replace(/[_-]+/g, " ")
+      .trim()
+      .replace(/\b\w/g, (c) => c.toUpperCase());
+  }
+  return value;
+}

--- a/frontend/src/features/okw/useOkwList.ts
+++ b/frontend/src/features/okw/useOkwList.ts
@@ -1,0 +1,100 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { searchOkw } from "../../api/ohm/okw";
+import type { OkwFacility } from "../../types/okw";
+import { humanizeProcess } from "./processDisplay";
+
+const PAGE_SIZE = 24;
+
+function locationText(f: OkwFacility): string {
+  const a = f.location?.address;
+  return [a?.city ?? f.location?.city, a?.region, a?.country ?? f.location?.country]
+    .filter(Boolean)
+    .join(" ");
+}
+
+function textMatches(f: OkwFacility, q: string): boolean {
+  if (!q) return true;
+  const hay = [
+    f.name,
+    f.description,
+    locationText(f),
+    ...(f.manufacturing_processes ?? []).map(humanizeProcess),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  return hay.includes(q.trim().toLowerCase());
+}
+
+function distinct(values: (string | null | undefined)[]): string[] {
+  return [...new Set(values.filter((v): v is string => !!v))].sort();
+}
+
+export function useOkwList() {
+  const [filterText, setFilterText] = useState("");
+  const [access, setAccess] = useState<Set<string>>(new Set());
+  const [status, setStatus] = useState<Set<string>>(new Set());
+  const [page, setPage] = useState(1);
+
+  const query = useQuery({
+    queryKey: ["okw-list"],
+    queryFn: () => searchOkw({ page: 1, page_size: 100 }),
+    staleTime: 60_000,
+  });
+
+  const all = useMemo(() => query.data?.results ?? [], [query.data]);
+
+  const accessOptions = useMemo(() => distinct(all.map((f) => f.access_type)), [all]);
+  const statusOptions = useMemo(() => distinct(all.map((f) => f.facility_status)), [all]);
+
+  const processed = useMemo(() => {
+    const filtered = all.filter(
+      (f) =>
+        textMatches(f, filterText) &&
+        (access.size === 0 || (f.access_type != null && access.has(f.access_type))) &&
+        (status.size === 0 || (f.facility_status != null && status.has(f.facility_status))),
+    );
+    const totalItems = filtered.length;
+    const totalPages = Math.max(1, Math.ceil(totalItems / PAGE_SIZE));
+    const safePage = Math.min(page, totalPages);
+    const pageItems = filtered.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE);
+    return { pageItems, totalItems, totalPages, safePage };
+  }, [all, filterText, access, status, page]);
+
+  function toggle(set: Set<string>, setter: (s: Set<string>) => void, value: string) {
+    const next = new Set(set);
+    if (next.has(value)) next.delete(value);
+    else next.add(value);
+    setter(next);
+    setPage(1);
+  }
+
+  return {
+    ...processed,
+    filterText,
+    accessOptions,
+    statusOptions,
+    selectedAccess: access,
+    selectedStatus: status,
+    filterCount: access.size + status.size,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    error: query.error,
+    refetch: query.refetch,
+    setPage,
+    setFilterText: (t: string) => {
+      setFilterText(t);
+      setPage(1);
+    },
+    toggleAccess: (v: string) => toggle(access, setAccess, v),
+    toggleStatus: (v: string) => toggle(status, setStatus, v),
+    clearFilters: () => {
+      setAccess(new Set());
+      setStatus(new Set());
+      setFilterText("");
+      setPage(1);
+    },
+    PAGE_SIZE,
+  };
+}

--- a/frontend/src/pages/OkwPage.tsx
+++ b/frontend/src/pages/OkwPage.tsx
@@ -1,0 +1,5 @@
+import { OkwListView } from "../features/okw/OkwListView";
+
+export function OkwPage() {
+  return <OkwListView />;
+}

--- a/frontend/src/test/fixtures/index.ts
+++ b/frontend/src/test/fixtures/index.ts
@@ -74,9 +74,43 @@ export const okhListEmptyFixture = {
   items: [],
 };
 
+function okwFacility(
+  id: string,
+  name: string,
+  city: string,
+  processes: string[],
+  access_type: string,
+  facility_status: string,
+): Record<string, unknown> {
+  return {
+    id,
+    name,
+    location: { address: { city, region: "TX", country: "US" }, city, country: "US" },
+    manufacturing_processes: processes,
+    access_type,
+    facility_status,
+    description: `${name} in ${city}`,
+  };
+}
+
+/** OKW search envelope ({results,total,page,page_size}) with varied facets. */
+export const okwSearchFixture = {
+  results: [
+    okwFacility("okw-1", "Laser Fab Lab", "Austin", ["https://en.wikipedia.org/wiki/Laser_cutter"], "Membership", "Active"),
+    okwFacility("okw-2", "Community Makerspace", "Austin", ["Assembly"], "Public", "Active"),
+    okwFacility("okw-3", "Precision CNC Shop", "Denver", ["https://en.wikipedia.org/wiki/CNC_mill"], "Restricted", "Planned"),
+  ],
+  total: 3,
+  page: 1,
+  page_size: 100,
+};
+
+export const okwSearchEmptyFixture = { results: [], total: 0, page: 1, page_size: 100 };
+
 /** Path-keyed lookup used by the Playwright interceptor (see e2e/mock-api.ts). */
 export const fixturesByPath: Record<string, unknown> = {
   "/health": healthFixture,
   "/v1/api/utility/domains": domainsFixture,
   "/v1/api/okh": okhListFixture,
+  "/v1/api/okw/search": okwSearchFixture,
 };

--- a/frontend/src/test/msw/handlers.ts
+++ b/frontend/src/test/msw/handlers.ts
@@ -3,6 +3,7 @@ import {
   domainsFixture,
   healthFixture,
   okhListFixture,
+  okwSearchFixture,
 } from "../fixtures";
 
 // MSW handlers for vitest (node) unit/component tests. These mirror the
@@ -11,4 +12,5 @@ export const handlers = [
   http.get("*/health", () => HttpResponse.json(healthFixture)),
   http.get("*/v1/api/utility/domains", () => HttpResponse.json(domainsFixture)),
   http.get("*/v1/api/okh", () => HttpResponse.json(okhListFixture)),
+  http.get("*/v1/api/okw/search", () => HttpResponse.json(okwSearchFixture)),
 ];

--- a/frontend/src/types/okw.ts
+++ b/frontend/src/types/okw.ts
@@ -1,0 +1,23 @@
+/** OKW facility view types (subset of the facility payload the catalog renders). */
+
+export interface OkwAddress {
+  city?: string | null;
+  region?: string | null;
+  country?: string | null;
+}
+
+export interface OkwLocation {
+  address?: OkwAddress | null;
+  city?: string | null;
+  country?: string | null;
+}
+
+export interface OkwFacility {
+  id: string;
+  name: string;
+  location: OkwLocation | null;
+  manufacturing_processes: string[];
+  access_type: string | null;
+  facility_status: string | null;
+  description: string | null;
+}


### PR DESCRIPTION
Closes #188. Independent off the merged foundation (not stacked). Adds the **read-only OKW facility catalog** — the facility half of the design→facility story, previously absent from the UI.

## What's in it

- **New `/facilities` route + "Facilities" nav tab.**
- **Typed `searchOkw` wrapper** — handles OKW's `{results,total,page,page_size}` envelope (distinct from OKH's), narrowed to an `OkwFacility` view type.
- **List**: search (name/location/process), **access_type + facility_status filter chips**, pagination, loading/empty/error states, facility cards (location, processes, access/status badges).
- **Humanized process display** (`processDisplay.ts`, pure + unit-tested): Wikipedia URIs → readable labels (`…/Laser_cutter` → "Laser Cutter"), so the UI is consistent despite the mixed stored representation. Underlying data normalization is tracked in #207.

## Verification

- `make frontend-ready` **green** (unit incl. `searchOkw` + `humanizeProcess`; mocked E2E: loads, fixtures + humanized processes, access-filter narrows, empty, error; a11y; screenshots).
- **Real-api lane green** against the live **79 synthetic facilities**.

## Notes

- **Read-only** per v1 scope. Facility **detail** is slice #189; a facet **sidebar** (matching the OKH catalog) is deferred until a shared facet engine is extracted post-A1-merge — chips cover the key facets (access/status) for now.
- Built on `frontend-dev` (foundation), independent of the A1/A2 OKH-facet PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)