### PR TITLE
Slice #189: OKW facility detail + validate

### DIFF
--- a/frontend/e2e/okw-detail.spec.ts
+++ b/frontend/e2e/okw-detail.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "./mock-api";
+
+// Slice #189: OKW facility detail + validate. Mocked lane (fixture id okw-1).
+
+test("shows OKW facility detail (mocked)", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "uses a fixture id");
+  await page.goto("/facilities/okw-1");
+  await expect(page.getByRole("heading", { name: "Laser Fab Lab" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: /equipment/i })).toBeVisible();
+  // Equipment type Wikipedia URI is humanized.
+  await expect(page.getByText("Laser Cutter")).toBeVisible();
+});
+
+test("validate surfaces a validation result (mocked)", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "uses fixtures");
+  await page.goto("/facilities/okw-1");
+  await page.getByRole("button", { name: "Validate" }).click();
+  await expect(page.getByRole("heading", { name: "Validation" })).toBeVisible();
+  await expect(page.getByText(/Missing intended_use/)).toBeVisible();
+});

--- a/frontend/harness.config.json
+++ b/frontend/harness.config.json
@@ -7,5 +7,5 @@
   "apiPathPrefix": "/v1/api",
   "openapiUrl": "http://localhost:8001/v1/openapi.json",
   "apiTypesOutput": "src/api/generated/schema.d.ts",
-  "routesToScreenshot": ["/", "/okh", "/okh/okh-0001", "/facilities", "/match"]
+  "routesToScreenshot": ["/", "/okh", "/okh/okh-0001", "/facilities", "/facilities/okw-1", "/match"]
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,6 +33,7 @@ export function App() {
               <Route path="okh" element={<OkhPage />} />
               <Route path="okh/:id" element={<OkhPage />} />
               <Route path="facilities" element={<OkwPage />} />
+              <Route path="facilities/:id" element={<OkwPage />} />
               <Route path="match" element={<MatchPage />} />
               <Route path="visualization" element={<VisualizationPage />} />
               <Route path="visualization/:solutionId" element={<VisualizationPage />} />

--- a/frontend/src/api/ohm/okw-detail.test.ts
+++ b/frontend/src/api/ohm/okw-detail.test.ts
@@ -1,0 +1,37 @@
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { server } from "../../test/msw/server";
+import { ApiError } from "./client";
+import { fetchOkwDetail, validateOkw } from "./okw";
+
+describe("fetchOkwDetail", () => {
+  it("returns the facility for an id", async () => {
+    const f = await fetchOkwDetail("okw-1");
+    expect(f.name).toBe("Laser Fab Lab");
+    expect(f.equipment?.length).toBeGreaterThan(0);
+  });
+
+  it("throws ApiError on failure", async () => {
+    server.use(
+      http.get("*/v1/api/okw/:id", () =>
+        HttpResponse.json({ message: "not found" }, { status: 404 }),
+      ),
+    );
+    await expect(fetchOkwDetail("missing")).rejects.toBeInstanceOf(ApiError);
+  });
+});
+
+describe("validateOkw", () => {
+  it("posts content and returns a validation result", async () => {
+    let body: { content?: unknown } | null = null;
+    server.use(
+      http.post("*/v1/api/okw/validate", async ({ request }) => {
+        body = (await request.json()) as { content?: unknown };
+        return HttpResponse.json({ is_valid: true, score: 1 });
+      }),
+    );
+    const res = await validateOkw({ name: "X" });
+    expect(res.is_valid).toBe(true);
+    expect(body!.content).toEqual({ name: "X" });
+  });
+});

--- a/frontend/src/api/ohm/okw.ts
+++ b/frontend/src/api/ohm/okw.ts
@@ -1,5 +1,8 @@
 import { apiClient, ApiError, errorMessage } from "./client";
 import type { OkwFacility } from "../../types/okw";
+import type { components } from "../generated/schema";
+
+export type ValidationResult = components["schemas"]["ValidationResult"];
 
 export interface OkwSearchResult {
   results: OkwFacility[];
@@ -55,4 +58,34 @@ export async function searchOkw(
     page: body.page ?? 1,
     page_size: body.page_size ?? 0,
   };
+}
+
+/** Fetch a single OKW facility by id (fields returned at the top level). */
+export async function fetchOkwDetail(id: string): Promise<OkwFacility> {
+  const { data, error, response } = await apiClient.GET("/api/okw/{id}", {
+    params: { path: { id } },
+  });
+  if (error || !response.ok) {
+    throw new ApiError(
+      response.status,
+      errorMessage(error, `Failed to load facility (HTTP ${response.status})`),
+    );
+  }
+  return data as unknown as OkwFacility;
+}
+
+/** Validate an OKW facility against domain rules; returns the validation result. */
+export async function validateOkw(
+  content: Record<string, unknown>,
+): Promise<ValidationResult> {
+  const { data, error, response } = await apiClient.POST("/api/okw/validate", {
+    body: { content },
+  });
+  if (error || !response.ok) {
+    throw new ApiError(
+      response.status,
+      errorMessage(error, `Validation failed (HTTP ${response.status})`),
+    );
+  }
+  return data as ValidationResult;
 }

--- a/frontend/src/features/okw/OkwCard.tsx
+++ b/frontend/src/features/okw/OkwCard.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { Badge } from "../../components/ui/Badge";
 import type { OkwFacility } from "../../types/okw";
 import { humanizeProcess } from "./processDisplay";
@@ -15,9 +16,12 @@ export function OkwCard({ facility }: { facility: OkwFacility }) {
   const processes = (facility.manufacturing_processes ?? []).map(humanizeProcess);
 
   return (
-    <div className="flex flex-col gap-3 rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+    <Link
+      to={`/facilities/${facility.id}`}
+      className="group flex flex-col gap-3 rounded-xl border border-slate-200 bg-white p-5 shadow-sm no-underline transition-shadow hover:shadow-md dark:border-slate-700 dark:bg-slate-900"
+    >
       <div>
-        <h3 className="font-semibold text-slate-800 dark:text-slate-100">
+        <h3 className="font-semibold text-slate-800 group-hover:text-indigo-600 dark:text-slate-100 dark:group-hover:text-indigo-400">
           {facility.name || "Unnamed facility"}
         </h3>
         {location && (
@@ -42,6 +46,6 @@ export function OkwCard({ facility }: { facility: OkwFacility }) {
           </Badge>
         )}
       </div>
-    </div>
+    </Link>
   );
 }

--- a/frontend/src/features/okw/OkwDetailView.tsx
+++ b/frontend/src/features/okw/OkwDetailView.tsx
@@ -1,0 +1,179 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { fetchOkwDetail, validateOkw, type ValidationResult } from "../../api/ohm/okw";
+import { LoadingState, ErrorState } from "../../components/ui/states";
+import { Button } from "../../components/ui/button";
+import { Badge } from "../../components/ui/Badge";
+import type { OkwFacility } from "../../types/okw";
+import { humanizeProcess } from "./processDisplay";
+
+function locationLabel(f: OkwFacility): string | null {
+  const a = f.location?.address;
+  const parts = [a?.city ?? f.location?.city, a?.region, a?.country ?? f.location?.country].filter(
+    Boolean,
+  );
+  return parts.length ? parts.join(", ") : null;
+}
+
+function ValidationPanel({ result }: { result: ValidationResult }) {
+  const warnings = result.warnings ?? [];
+  const suggestions = result.suggestions ?? [];
+  const errors = result.errors ?? [];
+  return (
+    <section
+      role="status"
+      aria-label="Validation result"
+      className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900"
+    >
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          Validation
+        </h2>
+        <Badge variant={result.is_valid ? "green" : "yellow"}>
+          {result.is_valid ? "Valid" : "Needs attention"}
+        </Badge>
+      </div>
+      <p className="mb-2 text-sm text-slate-600 dark:text-slate-300">
+        Score: {Math.round(result.score * 100)}%
+      </p>
+      {[
+        ["Errors", errors.map((e) => (e as { message?: string }).message ?? JSON.stringify(e))],
+        ["Warnings", warnings],
+        ["Suggestions", suggestions],
+      ].map(([label, items]) =>
+        (items as string[]).length > 0 ? (
+          <div key={label as string} className="mb-2">
+            <p className="text-xs font-semibold text-slate-500 dark:text-slate-400">{label}</p>
+            <ul className="mt-1 list-disc space-y-0.5 pl-5 text-sm text-slate-700 dark:text-slate-200">
+              {(items as string[]).map((t, i) => (
+                <li key={i}>{t}</li>
+              ))}
+            </ul>
+          </div>
+        ) : null,
+      )}
+      {errors.length === 0 && warnings.length === 0 && suggestions.length === 0 && (
+        <p className="text-sm text-slate-500 dark:text-slate-400">No issues reported.</p>
+      )}
+    </section>
+  );
+}
+
+export function OkwDetailView({ id }: { id: string }) {
+  const [validateState, setValidateState] = useState<"idle" | "running" | "done" | "error">("idle");
+  const [result, setResult] = useState<ValidationResult | null>(null);
+  const [validateError, setValidateError] = useState<string | null>(null);
+
+  const { data: f, isLoading, isError, error, refetch } = useQuery<OkwFacility>({
+    queryKey: ["okw-detail", id],
+    queryFn: () => fetchOkwDetail(id),
+    staleTime: 120_000,
+  });
+
+  const handleValidate = async () => {
+    if (!f) return;
+    setValidateState("running");
+    setValidateError(null);
+    try {
+      setResult(await validateOkw(f as unknown as Record<string, unknown>));
+      setValidateState("done");
+    } catch (e) {
+      setValidateError(e instanceof Error ? e.message : "Validation failed.");
+      setValidateState("error");
+    }
+  };
+
+  if (isLoading) return <LoadingState message="Loading facility…" />;
+  if (isError || !f) {
+    return (
+      <ErrorState
+        description={error instanceof Error ? error.message : "Facility not found."}
+        onRetry={() => refetch()}
+      />
+    );
+  }
+
+  const location = locationLabel(f);
+  const equipment = f.equipment ?? [];
+  const certifications = f.certifications ?? [];
+
+  return (
+    <div className="space-y-8">
+      <nav className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+        <Link to="/facilities" className="hover:text-indigo-600 dark:hover:text-indigo-400">
+          Facilities
+        </Link>
+        <span aria-hidden="true">›</span>
+        <span className="truncate text-slate-700 dark:text-slate-200">{f.name || "Facility"}</span>
+      </nav>
+
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-2">
+          <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">
+            {f.name || "Unnamed facility"}
+          </h1>
+          {location && <p className="text-base text-slate-600 dark:text-slate-300">📍 {location}</p>}
+          <div className="flex flex-wrap gap-1.5 pt-1">
+            {f.access_type && <Badge variant="blue">{f.access_type}</Badge>}
+            {f.facility_status && (
+              <Badge variant={f.facility_status === "Active" ? "green" : "yellow"}>
+                {f.facility_status}
+              </Badge>
+            )}
+          </div>
+        </div>
+        <Button variant="outline" onClick={handleValidate} disabled={validateState === "running"}>
+          {validateState === "running" ? "Validating…" : "Validate"}
+        </Button>
+      </div>
+
+      {validateState === "error" && (
+        <ErrorState description={validateError ?? "Validation failed."} onRetry={handleValidate} />
+      )}
+      {validateState === "done" && result && <ValidationPanel result={result} />}
+
+      {f.description && (
+        <section className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900">
+          <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            About
+          </h2>
+          <p className="text-sm text-slate-600 dark:text-slate-300">{f.description}</p>
+        </section>
+      )}
+
+      {equipment.length > 0 && (
+        <section className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900">
+          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Equipment ({equipment.length})
+          </h2>
+          <ul className="space-y-2">
+            {equipment.map((e, i) => (
+              <li key={i} className="flex items-center justify-between gap-2">
+                <span className="text-sm text-slate-700 dark:text-slate-200">
+                  {[e.make, e.model].filter(Boolean).join(" ") || "Equipment"}
+                </span>
+                {e.equipment_type && (
+                  <Badge variant="indigo">{humanizeProcess(e.equipment_type)}</Badge>
+                )}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {certifications.length > 0 && (
+        <section className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900">
+          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Certifications
+          </h2>
+          <div className="flex flex-wrap gap-1.5">
+            {certifications.map((c) => (
+              <Badge key={c} variant="default">{c}</Badge>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/OkwPage.tsx
+++ b/frontend/src/pages/OkwPage.tsx
@@ -1,5 +1,8 @@
+import { useParams } from "react-router-dom";
 import { OkwListView } from "../features/okw/OkwListView";
+import { OkwDetailView } from "../features/okw/OkwDetailView";
 
 export function OkwPage() {
-  return <OkwListView />;
+  const { id } = useParams<{ id?: string }>();
+  return id ? <OkwDetailView id={id} /> : <OkwListView />;
 }

--- a/frontend/src/test/fixtures/index.ts
+++ b/frontend/src/test/fixtures/index.ts
@@ -122,6 +122,17 @@ export const okwSearchFixture = {
 
 export const okwSearchEmptyFixture = { results: [], total: 0, page: 1, page_size: 100 };
 
+/** A single OKW facility (detail payload) with equipment + certifications. */
+export const okwDetailFixture = {
+  ...okwSearchFixture.results[0],
+  description: "A membership laser-cutting lab in Austin.",
+  equipment: [
+    { make: "Trotec", model: "LS-1630", equipment_type: "https://en.wikipedia.org/wiki/Laser_cutter" },
+    { make: "Epilog", model: "Fusion Pro", equipment_type: "https://en.wikipedia.org/wiki/Laser_engraving" },
+  ],
+  certifications: ["ISO 9001:2015", "OHSAS 18001"],
+};
+
 /** Path-keyed lookup used by the Playwright interceptor (see e2e/mock-api.ts). */
 export const fixturesByPath: Record<string, unknown> = {
   "/health": healthFixture,
@@ -130,4 +141,6 @@ export const fixturesByPath: Record<string, unknown> = {
   "/v1/api/okh/okh-0001": okhDetailFixture,
   "/v1/api/okh/validate": validationResultFixture,
   "/v1/api/okw/search": okwSearchFixture,
+  "/v1/api/okw/okw-1": okwDetailFixture,
+  "/v1/api/okw/validate": validationResultFixture,
 };

--- a/frontend/src/test/msw/handlers.ts
+++ b/frontend/src/test/msw/handlers.ts
@@ -4,6 +4,7 @@ import {
   healthFixture,
   okhDetailFixture,
   okhListFixture,
+  okwDetailFixture,
   okwSearchFixture,
   validationResultFixture,
 } from "../fixtures";
@@ -17,4 +18,6 @@ export const handlers = [
   http.get("*/v1/api/okh/:id", () => HttpResponse.json(okhDetailFixture)),
   http.post("*/v1/api/okh/validate", () => HttpResponse.json(validationResultFixture)),
   http.get("*/v1/api/okw/search", () => HttpResponse.json(okwSearchFixture)),
+  http.get("*/v1/api/okw/:id", () => HttpResponse.json(okwDetailFixture)),
+  http.post("*/v1/api/okw/validate", () => HttpResponse.json(validationResultFixture)),
 ];

--- a/frontend/src/types/okw.ts
+++ b/frontend/src/types/okw.ts
@@ -12,6 +12,12 @@ export interface OkwLocation {
   country?: string | null;
 }
 
+export interface OkwEquipment {
+  equipment_type?: string | null;
+  make?: string | null;
+  model?: string | null;
+}
+
 export interface OkwFacility {
   id: string;
   name: string;
@@ -20,4 +26,6 @@ export interface OkwFacility {
   access_type: string | null;
   facility_status: string | null;
   description: string | null;
+  equipment?: OkwEquipment[];
+  certifications?: string[];
 }


### PR DESCRIPTION
Closes #189. Independent off the merged foundation. Completes the OKW catalog → detail flow (mirrors OKH detail #187).

## What's in it

- **Typed client**: `fetchOkwDetail(id)`, `validateOkw(content)` → `ValidationResult`.
- **`OkwDetailView`** at `/facilities/:id`: breadcrumb, header (location + access/status badges), **Validate** action + validation panel, and About / **Equipment** (humanized equipment types) / **Certifications** sections. Facility cards now link to detail.
- **Humanized equipment types** (reuses `humanizeProcess`) — Wikipedia URIs → readable labels.

## Verification

- `make frontend-ready` **green** (unit: `fetchOkwDetail`/`validateOkw`; mocked E2E: detail loads + validate; a11y; screenshots).
- **Real-api lane green.**

## Note

Per the append-conflict pattern, this touches the shared harness files (`harness.config.json` routes, `fixtures`, `msw/handlers`) — merging promptly avoids re-conflicts with later slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)