### PR TITLE
Slice #192: Matching — System Mode selector

### DIFF
--- a/frontend/e2e/match.spec.ts
+++ b/frontend/e2e/match.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "./mock-api";
+import { matchResponseFixture } from "../src/test/fixtures";
 
-// Slice #191: run a match + ranked results. Mocked lane (deterministic match).
+// Slice #191/#192: run a match + ranked results + System Mode. Mocked lane.
 
 test("match page loads with a design selector", async ({ page }) => {
   await page.goto("/match");
@@ -24,4 +25,23 @@ test("running a match shows ranked results, summary, and coverage gaps (mocked)"
   await expect(page.getByText(/CNC Machining/)).toBeVisible();
   // Hand-off link into the supply-tree explorer.
   await expect(page.getByRole("link", { name: /view supply tree/i }).first()).toBeVisible();
+});
+
+test("System Mode selector controls the match request (mocked)", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "inspects the request body");
+  let body: { quality_level?: string; strict_mode?: boolean } | null = null;
+  await page.route("**/v1/api/match", async (route) => {
+    body = route.request().postDataJSON();
+    await route.fulfill({ json: matchResponseFixture });
+  });
+
+  await page.goto("/match");
+  await page.getByLabel("Design to match").selectOption({ label: "Open Ventilator" });
+  await page.getByRole("radio", { name: "Strict" }).click();
+  await page.getByRole("button", { name: /run match/i }).click();
+
+  await expect(page.getByRole("heading", { name: "FabLab Drome" })).toBeVisible();
+  // Strict mode maps to medical quality + strict validation.
+  expect(body!.quality_level).toBe("medical");
+  expect(body!.strict_mode).toBe(true);
 });

--- a/frontend/src/api/ohm/match.ts
+++ b/frontend/src/api/ohm/match.ts
@@ -3,6 +3,8 @@ import { apiClient, ApiError, errorMessage } from "./client";
 export interface RunMatchParams {
   okhId: string;
   maxResults?: number;
+  qualityLevel?: string;
+  strictMode?: boolean;
 }
 
 export interface RawSolution {
@@ -41,6 +43,8 @@ export async function runMatch(params: RunMatchParams): Promise<RawMatchResponse
       max_results: params.maxResults ?? 10,
       include_human_summary: true,
       include_explanation: true,
+      quality_level: params.qualityLevel,
+      strict_mode: params.strictMode,
     } as never,
   });
   if (error || !response.ok) {

--- a/frontend/src/features/match/MatchView.tsx
+++ b/frontend/src/features/match/MatchView.tsx
@@ -3,9 +3,11 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import { fetchOkhList } from "../../api/ohm/okh";
 import { runMatch } from "../../api/ohm/match";
 import { toMatchView } from "./matchViewModel";
+import { buildMatchRequest, SYSTEM_MODES, type SystemMode } from "./matchRequest";
 import { MatchResultCard } from "./MatchResultCard";
 import { LoadingState, EmptyState, ErrorState } from "../../components/ui/states";
 import { Button } from "../../components/ui/button";
+import { cn } from "@/lib/utils";
 
 export function MatchView({ okhId, autoRun }: { okhId?: string; autoRun?: boolean }) {
   const designs = useQuery({
@@ -14,19 +16,24 @@ export function MatchView({ okhId, autoRun }: { okhId?: string; autoRun?: boolea
     staleTime: 60_000,
   });
   const [selected, setSelected] = useState(okhId ?? "");
-  const mutation = useMutation({ mutationFn: (id: string) => runMatch({ okhId: id }) });
+  const [mode, setMode] = useState<SystemMode>("standard");
+  const mutation = useMutation({
+    mutationFn: ({ id, m }: { id: string; m: SystemMode }) =>
+      runMatch(buildMatchRequest(id, m)),
+  });
   const view = useMemo(
     () => (mutation.data ? toMatchView(mutation.data) : null),
     [mutation.data],
   );
 
   useEffect(() => {
-    if (autoRun && okhId) mutation.mutate(okhId);
+    if (autoRun && okhId) mutation.mutate({ id: okhId, m: "standard" });
     // Run once on mount; MatchPage remounts (via key) when the design changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const renderable = (designs.data?.items ?? []).filter((d) => d.title?.trim());
+  const modeInfo = SYSTEM_MODES.find((s) => s.mode === mode);
 
   return (
     <div className="space-y-6">
@@ -37,33 +44,68 @@ export function MatchView({ okhId, autoRun }: { okhId?: string; autoRun?: boolea
         </p>
       </div>
 
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
-        <label className="max-w-md flex-1 text-sm">
-          <span className="mb-1 block text-muted-foreground">Design</span>
-          <select
-            value={selected}
-            onChange={(e) => setSelected(e.target.value)}
-            aria-label="Design to match"
-            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+      <div className="space-y-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+          <label className="max-w-md flex-1 text-sm">
+            <span className="mb-1 block text-muted-foreground">Design</span>
+            <select
+              value={selected}
+              onChange={(e) => setSelected(e.target.value)}
+              aria-label="Design to match"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              <option value="">Select a design…</option>
+              {renderable.map((d) => (
+                <option key={d.id} value={d.id}>
+                  {d.title}
+                </option>
+              ))}
+            </select>
+          </label>
+          <Button
+            disabled={!selected || mutation.isPending}
+            onClick={() => mutation.mutate({ id: selected, m: mode })}
           >
-            <option value="">Select a design…</option>
-            {renderable.map((d) => (
-              <option key={d.id} value={d.id}>
-                {d.title}
-              </option>
+            {mutation.isPending ? "Matching…" : "⚡ Run Match"}
+          </Button>
+        </div>
+
+        <div>
+          <span className="mb-1 block text-sm text-muted-foreground">System mode</span>
+          <div
+            role="radiogroup"
+            aria-label="System mode"
+            className="inline-flex overflow-hidden rounded-md border border-input"
+          >
+            {SYSTEM_MODES.map((s) => (
+              <button
+                key={s.mode}
+                type="button"
+                role="radio"
+                aria-checked={mode === s.mode}
+                onClick={() => setMode(s.mode)}
+                className={cn(
+                  "px-3 py-1.5 text-sm transition-colors",
+                  mode === s.mode
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-background text-foreground hover:bg-accent",
+                )}
+              >
+                {s.label}
+              </button>
             ))}
-          </select>
-        </label>
-        <Button disabled={!selected || mutation.isPending} onClick={() => mutation.mutate(selected)}>
-          {mutation.isPending ? "Matching…" : "⚡ Run Match"}
-        </Button>
+          </div>
+          {modeInfo && (
+            <p className="mt-1.5 max-w-xl text-xs text-muted-foreground">{modeInfo.description}</p>
+          )}
+        </div>
       </div>
 
       {mutation.isPending && <LoadingState message="Matching against facilities…" />}
       {mutation.isError && (
         <ErrorState
           description={mutation.error instanceof Error ? mutation.error.message : "Match failed."}
-          onRetry={() => selected && mutation.mutate(selected)}
+          onRetry={() => selected && mutation.mutate({ id: selected, m: mode })}
         />
       )}
 

--- a/frontend/src/features/match/matchRequest.test.ts
+++ b/frontend/src/features/match/matchRequest.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { buildMatchRequest } from "./matchRequest";
+
+describe("buildMatchRequest", () => {
+  it("maps minimal to relaxed params", () => {
+    expect(buildMatchRequest("okh-1", "minimal")).toMatchObject({
+      okhId: "okh-1",
+      qualityLevel: "hobby",
+      strictMode: false,
+    });
+  });
+
+  it("maps standard to the professional default", () => {
+    expect(buildMatchRequest("okh-1", "standard")).toMatchObject({
+      qualityLevel: "professional",
+      strictMode: false,
+    });
+  });
+
+  it("maps strict to enforced params", () => {
+    expect(buildMatchRequest("okh-1", "strict")).toMatchObject({
+      qualityLevel: "medical",
+      strictMode: true,
+    });
+  });
+
+  it("passes through maxResults", () => {
+    expect(buildMatchRequest("okh-1", "standard", 5).maxResults).toBe(5);
+  });
+});

--- a/frontend/src/features/match/matchRequest.ts
+++ b/frontend/src/features/match/matchRequest.ts
@@ -1,0 +1,51 @@
+import type { RunMatchParams } from "../../api/ohm/match";
+
+/**
+ * Match-request builder (pure, unit-tested) — module 4.
+ *
+ * Maps a System Mode preset to concrete match-request params. The API has no
+ * single "mode" field; a mode is expressed via quality_level + strict_mode
+ * (relaxed → strict). Mirrors the roadmap's minimal/standard/strict presets.
+ */
+
+export type SystemMode = "minimal" | "standard" | "strict";
+
+export interface SystemModeInfo {
+  mode: SystemMode;
+  label: string;
+  description: string;
+}
+
+export const SYSTEM_MODES: SystemModeInfo[] = [
+  {
+    mode: "minimal",
+    label: "Minimal",
+    description:
+      "Coverage + dependency checks only, relaxed thresholds. Fastest — for crisis or low-data contexts where a partial answer now beats a perfect one later.",
+  },
+  {
+    mode: "standard",
+    label: "Standard",
+    description: "Adds quality and completeness checks. The default balance.",
+  },
+  {
+    mode: "strict",
+    label: "Strict",
+    description:
+      "All validations and thresholds enforced. Highest confidence, slowest — for production commitments.",
+  },
+];
+
+const MODE_PARAMS: Record<SystemMode, { qualityLevel: string; strictMode: boolean }> = {
+  minimal: { qualityLevel: "hobby", strictMode: false },
+  standard: { qualityLevel: "professional", strictMode: false },
+  strict: { qualityLevel: "medical", strictMode: true },
+};
+
+export function buildMatchRequest(
+  okhId: string,
+  mode: SystemMode,
+  maxResults?: number,
+): RunMatchParams {
+  return { okhId, ...MODE_PARAMS[mode], maxResults };
+}


### PR DESCRIPTION
Closes #192. Adds the **System Mode** (minimal / standard / strict) selector to the match flow — the crisis-response narrative made operable.

## What's in it

- **Match-request builder** (`matchRequest.ts`, pure + unit-tested): `buildMatchRequest(okhId, mode)`. The API has no single "mode" field, so a mode maps to `quality_level` + `strict_mode`:
  - **minimal** → `hobby` / relaxed (fastest; crisis / low-data — "a partial answer now beats a perfect one later")
  - **standard** → `professional` (default balance)
  - **strict** → `medical` / strict (highest confidence; production)
  - `SYSTEM_MODES` carries the plain-language tradeoff copy shown in the UI.
- **`MatchView`**: segmented Minimal/Standard/Strict control + the selected mode's description; `runMatch` carries the mode.

## Verification

- `make frontend-ready` **green** (unit: the mode→params mapping; mocked E2E asserts selecting **Strict** sends `quality_level: "medical"` + `strict_mode: true` end-to-end).

## Note

Confirms the mode threads through to the request; the backend already honors `quality_level`/`strict_mode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)