### PR TITLE
Slice #195: Saved solutions list + load

### DIFF
--- a/frontend/e2e/solutions.spec.ts
+++ b/frontend/e2e/solutions.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "./mock-api";
+import { solutionsEmptyFixture } from "../src/test/fixtures";
+
+// Slice #195: saved solutions list + load (into the supply-tree explorer).
+
+test("solutions page loads", async ({ page }) => {
+  await page.goto("/solutions");
+  await expect(page.getByRole("heading", { name: /saved solutions/i })).toBeVisible();
+});
+
+test("lists saved solutions and loads one into the explorer (mocked)", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "asserts fixture data");
+  await page.goto("/solutions");
+  await expect(page.getByRole("heading", { name: "Open Ventilator" })).toBeVisible();
+  await expect(page.getByText("95%")).toBeVisible();
+  // Loading a solution navigates into the supply-tree explorer.
+  await page.getByRole("link", { name: /open ventilator/i }).click();
+  await expect(page).toHaveURL(/\/visualization\/sol-1/);
+  await expect(page.getByRole("heading", { name: "Supply Tree", level: 1 })).toBeVisible();
+});
+
+test("shows the empty state when there are no solutions (mocked)", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "forces an empty response");
+  await page.route("**/v1/api/supply-tree/solutions**", (route) =>
+    route.fulfill({ json: solutionsEmptyFixture }),
+  );
+  await page.goto("/solutions");
+  await expect(page.getByText(/no saved solutions/i)).toBeVisible();
+});

--- a/frontend/harness.config.json
+++ b/frontend/harness.config.json
@@ -14,6 +14,7 @@
     "/facilities",
     "/facilities/okw-1",
     "/match",
+    "/solutions",
     "/visualization/sol-1"
   ]
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { HomePage } from "./pages/HomePage";
 import { OkhPage } from "./pages/OkhPage";
 import { OkwPage } from "./pages/OkwPage";
 import { MatchPage } from "./pages/MatchPage";
+import { SolutionsPage } from "./pages/SolutionsPage";
 import { VisualizationPage } from "./pages/VisualizationPage";
 import { RfqPage } from "./pages/RfqPage";
 import { PackagePage } from "./pages/PackagePage";
@@ -35,6 +36,7 @@ export function App() {
               <Route path="facilities" element={<OkwPage />} />
               <Route path="facilities/:id" element={<OkwPage />} />
               <Route path="match" element={<MatchPage />} />
+              <Route path="solutions" element={<SolutionsPage />} />
               <Route path="visualization" element={<VisualizationPage />} />
               <Route path="visualization/:solutionId" element={<VisualizationPage />} />
               <Route path="rfq" element={<RfqPage />} />

--- a/frontend/src/api/ohm/supply-tree.test.ts
+++ b/frontend/src/api/ohm/supply-tree.test.ts
@@ -1,0 +1,23 @@
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { server } from "../../test/msw/server";
+import { ApiError } from "./client";
+import { listSolutions } from "./supply-tree";
+
+describe("listSolutions", () => {
+  it("narrows the data.result envelope to solution summaries", async () => {
+    const solutions = await listSolutions();
+    expect(solutions).toHaveLength(2);
+    expect(solutions.map((s) => s.okh_title)).toContain("Open Ventilator");
+    expect(solutions[0].facility_count).toBe(2);
+  });
+
+  it("throws ApiError on failure", async () => {
+    server.use(
+      http.get("*/v1/api/supply-tree/solutions", () =>
+        HttpResponse.json({ message: "boom" }, { status: 500 }),
+      ),
+    );
+    await expect(listSolutions()).rejects.toBeInstanceOf(ApiError);
+  });
+});

--- a/frontend/src/api/ohm/supply-tree.ts
+++ b/frontend/src/api/ohm/supply-tree.ts
@@ -1,6 +1,33 @@
 import { apiClient, ApiError, errorMessage } from "./client";
 import type { VisualizationData } from "../../types/supply-tree";
 
+export interface SolutionSummary {
+  id: string;
+  okh_id: string | null;
+  okh_title: string | null;
+  matching_mode: string | null;
+  tree_count: number;
+  facility_count: number;
+  score: number;
+  created_at: string | null;
+}
+
+/** List saved supply-tree solutions (most recent first). */
+export async function listSolutions(): Promise<SolutionSummary[]> {
+  const { data, error, response } = await apiClient.GET(
+    "/api/supply-tree/solutions",
+    { params: { query: { limit: 100 } } },
+  );
+  if (error || !response.ok) {
+    throw new ApiError(
+      response.status,
+      errorMessage(error, `Failed to load solutions (HTTP ${response.status})`),
+    );
+  }
+  const result = (data as { data?: { result?: unknown[] } })?.data?.result ?? [];
+  return result as SolutionSummary[];
+}
+
 /** Fetch the visualization bundle for a saved supply-tree solution. */
 export async function fetchVisualization(
   solutionId: string,

--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -5,7 +5,7 @@ const navItems = [
   { to: "/okh", label: "Designs", icon: "🔩" },
   { to: "/facilities", label: "Facilities", icon: "🏭" },
   { to: "/match", label: "Match", icon: "⚡" },
-  { to: "/visualization", label: "Visualization", icon: "🗺️" },
+  { to: "/solutions", label: "Solutions", icon: "🌳" },
   { to: "/rfq", label: "RFQ", icon: "📄" },
   { to: "/packages", label: "Packages", icon: "📦" },
 ] as const;

--- a/frontend/src/features/solutions/SolutionsListView.tsx
+++ b/frontend/src/features/solutions/SolutionsListView.tsx
@@ -1,0 +1,89 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { listSolutions } from "../../api/ohm/supply-tree";
+import { LoadingState, EmptyState, ErrorState } from "../../components/ui/states";
+import { Badge } from "../../components/ui/Badge";
+
+function fmtDate(s: string | null): string {
+  if (!s) return "";
+  const d = new Date(s);
+  return Number.isNaN(d.getTime()) ? "" : d.toLocaleDateString();
+}
+
+export function SolutionsListView() {
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: ["solutions"],
+    queryFn: listSolutions,
+    staleTime: 30_000,
+  });
+
+  const solutions = data ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">Saved Solutions</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Supply-tree solutions saved from matching.
+        </p>
+      </div>
+
+      {isLoading && <LoadingState message="Loading solutions…" />}
+      {isError && (
+        <ErrorState
+          description={error instanceof Error ? error.message : "Failed to load solutions."}
+          onRetry={() => refetch()}
+        />
+      )}
+
+      {!isLoading && !isError && solutions.length === 0 && (
+        <EmptyState
+          icon="🌳"
+          title="No saved solutions"
+          description="Run a match to create a supply-tree solution."
+          action={
+            <Link
+              to="/match"
+              className="text-sm font-medium text-indigo-600 hover:underline dark:text-indigo-400"
+            >
+              Go to Match →
+            </Link>
+          }
+        />
+      )}
+
+      {!isLoading && !isError && solutions.length > 0 && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {solutions.map((s) => (
+            <Link
+              key={s.id}
+              to={`/visualization/${s.id}`}
+              className="group flex flex-col gap-2 rounded-xl border border-slate-200 bg-white p-5 no-underline shadow-sm transition-shadow hover:shadow-md dark:border-slate-700 dark:bg-slate-900"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <h3 className="font-semibold text-slate-800 group-hover:text-indigo-600 dark:text-slate-100 dark:group-hover:text-indigo-400">
+                  {s.okh_title || (s.okh_id ? `${s.okh_id.slice(0, 8)}…` : "Untitled solution")}
+                </h3>
+                <Badge variant={s.score >= 0.8 ? "green" : s.score >= 0.5 ? "yellow" : "red"}>
+                  {Math.round(s.score * 100)}%
+                </Badge>
+              </div>
+              <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-slate-400 dark:text-slate-500">
+                <span>
+                  {s.facility_count} facilit{s.facility_count !== 1 ? "ies" : "y"}
+                </span>
+                <span>
+                  {s.tree_count} tree{s.tree_count !== 1 ? "s" : ""}
+                </span>
+                {fmtDate(s.created_at) && <span>{fmtDate(s.created_at)}</span>}
+              </div>
+              <span className="mt-1 text-sm font-medium text-indigo-600 dark:text-indigo-400">
+                View supply tree →
+              </span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/SolutionsPage.tsx
+++ b/frontend/src/pages/SolutionsPage.tsx
@@ -1,0 +1,5 @@
+import { SolutionsListView } from "../features/solutions/SolutionsListView";
+
+export function SolutionsPage() {
+  return <SolutionsListView />;
+}

--- a/frontend/src/test/fixtures/index.ts
+++ b/frontend/src/test/fixtures/index.ts
@@ -211,6 +211,36 @@ export const vizBundleFixture = {
 };
 
 /** Path-keyed lookup used by the Playwright interceptor (see e2e/mock-api.ts). */
+/** Saved supply-tree solutions list (envelope: data.result[]). */
+export const solutionsListFixture = {
+  data: {
+    result: [
+      {
+        id: "sol-1",
+        okh_id: "okh-0001",
+        okh_title: "Open Ventilator",
+        matching_mode: "single-level",
+        tree_count: 1,
+        facility_count: 2,
+        score: 0.95,
+        created_at: "2026-07-03T12:00:00Z",
+      },
+      {
+        id: "sol-2",
+        okh_id: "okh-0002",
+        okh_title: "Face Shield",
+        matching_mode: "single-level",
+        tree_count: 1,
+        facility_count: 1,
+        score: 0.6,
+        created_at: "2026-07-02T09:00:00Z",
+      },
+    ],
+  },
+};
+
+export const solutionsEmptyFixture = { data: { result: [] } };
+
 export const fixturesByPath: Record<string, unknown> = {
   "/health": healthFixture,
   "/v1/api/utility/domains": domainsFixture,
@@ -221,5 +251,6 @@ export const fixturesByPath: Record<string, unknown> = {
   "/v1/api/okw/okw-1": okwDetailFixture,
   "/v1/api/okw/validate": validationResultFixture,
   "/v1/api/match": matchResponseFixture,
+  "/v1/api/supply-tree/solutions": solutionsListFixture,
   "/v1/api/supply-tree/solution/sol-1/visualization": vizBundleFixture,
 };

--- a/frontend/src/test/msw/handlers.ts
+++ b/frontend/src/test/msw/handlers.ts
@@ -3,6 +3,7 @@ import {
   domainsFixture,
   healthFixture,
   matchResponseFixture,
+  solutionsListFixture,
   vizBundleFixture,
   okhDetailFixture,
   okhListFixture,
@@ -23,6 +24,7 @@ export const handlers = [
   http.get("*/v1/api/okw/:id", () => HttpResponse.json(okwDetailFixture)),
   http.post("*/v1/api/okw/validate", () => HttpResponse.json(validationResultFixture)),
   http.post("*/v1/api/match", () => HttpResponse.json(matchResponseFixture)),
+  http.get("*/v1/api/supply-tree/solutions", () => HttpResponse.json(solutionsListFixture)),
   http.get("*/v1/api/supply-tree/solution/:id/visualization", () =>
     HttpResponse.json(vizBundleFixture),
   ),


### PR DESCRIPTION
Closes #195. Completes the solution lifecycle: matching already **saves** (`save_solution`), this adds **list + load**.

## What's in it

- **Typed `listSolutions()`** (GET `/api/supply-tree/solutions` → `data.result[]`, narrowed to `SolutionSummary`; the endpoint uses `limit`/`offset`).
- **`SolutionsListView`** at `/solutions`: solution cards (design title, score badge, facility/tree counts, date) that **load** into the supply-tree explorer (`/visualization/:id`); loading / empty / error states.
- **Nav change:** replaced the id-less "Visualization" nav entry (needed a solution id to be useful) with **"Solutions"** — the browsable entry into the explorer.

## Verification

- `make frontend-ready` **green** (unit: `listSolutions` envelope narrowing + error; mocked E2E: list renders, loading a solution navigates into the explorer, empty state; a11y; screenshots).
- **Real-api lane green** — lists the live saved solutions.

Screenshot: two saved solutions (Open Ventilator 95%, Face Shield 60%) with facility/tree counts, each loading the supply tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)