### PR TITLE
Slice #196: Dashboard / home (final v1 slice)

### DIFF
--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "./mock-api";
+import { expectNoA11yViolations } from "./a11y";
+
+// Slice #196: dashboard / home.
+
+test("dashboard shows journeys, recent solutions, and health", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: /open hardware manager/i })).toBeVisible();
+  // Journey entry points.
+  await expect(page.getByRole("link", { name: /designs/i }).first()).toBeVisible();
+  await expect(page.getByRole("heading", { name: /recent solutions/i })).toBeVisible();
+});
+
+test("dashboard surfaces recent solutions and domains (mocked)", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "asserts fixture data");
+  await page.goto("/");
+  // Recent solution from the fixture.
+  await expect(page.getByText("Open Ventilator")).toBeVisible();
+  // System health: online + a domain badge.
+  await expect(page.getByText(/api online/i)).toBeVisible();
+  await expect(page.getByText("Manufacturing", { exact: true })).toBeVisible();
+});
+
+test("dashboard has no serious accessibility violations", async ({ page }) => {
+  await page.goto("/");
+  await expectNoA11yViolations(page);
+});

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -6,7 +6,7 @@ import { expectNoA11yViolations } from "./a11y";
 test("home page renders the app shell", async ({ page }) => {
   await page.goto("/");
   await expect(
-    page.getByRole("heading", { name: /open hardware matchmaker/i }),
+    page.getByRole("heading", { name: /open hardware manager/i }),
   ).toBeVisible();
   // Navigation shell present (brand link).
   await expect(page.getByRole("link", { name: "OHM" })).toBeVisible();

--- a/frontend/src/api/ohm/utility.test.ts
+++ b/frontend/src/api/ohm/utility.test.ts
@@ -1,0 +1,28 @@
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { server } from "../../test/msw/server";
+import { ApiError } from "./client";
+import { fetchDomains, fetchMetrics } from "./utility";
+
+describe("fetchDomains", () => {
+  it("narrows data.domains to Domain[]", async () => {
+    const domains = await fetchDomains();
+    expect(domains.map((d) => d.id)).toContain("manufacturing");
+    expect(domains[0]).toHaveProperty("name");
+  });
+
+  it("throws ApiError on failure", async () => {
+    server.use(
+      http.get("*/v1/api/utility/domains", () => HttpResponse.json({}, { status: 500 })),
+    );
+    await expect(fetchDomains()).rejects.toBeInstanceOf(ApiError);
+  });
+});
+
+describe("fetchMetrics", () => {
+  it("flattens error_summary.total_errors and request counts", async () => {
+    const m = await fetchMetrics();
+    expect(m.total_errors).toBe(0);
+    expect(m.recent_requests_1h).toBe(111);
+  });
+});

--- a/frontend/src/api/ohm/utility.ts
+++ b/frontend/src/api/ohm/utility.ts
@@ -1,0 +1,51 @@
+import { apiClient, ApiError, errorMessage } from "./client";
+
+export interface Domain {
+  id: string;
+  name: string;
+  description?: string | null;
+}
+
+/** Available matching domains (manufacturing, cooking, …). */
+export async function fetchDomains(): Promise<Domain[]> {
+  const { data, error, response } = await apiClient.GET("/api/utility/domains");
+  if (error || !response.ok) {
+    throw new ApiError(
+      response.status,
+      errorMessage(error, `Failed to load domains (HTTP ${response.status})`),
+    );
+  }
+  return ((data as { data?: { domains?: Domain[] } })?.data?.domains ?? []) as Domain[];
+}
+
+export interface SystemMetrics {
+  total_requests: number;
+  recent_requests_1h: number;
+  active_requests: number;
+  total_errors: number;
+}
+
+/** System metrics for the dashboard health panel. */
+export async function fetchMetrics(): Promise<SystemMetrics> {
+  const { data, error, response } = await apiClient.GET("/api/utility/metrics");
+  if (error || !response.ok) {
+    throw new ApiError(
+      response.status,
+      errorMessage(error, `Failed to load metrics (HTTP ${response.status})`),
+    );
+  }
+  const d = (data as {
+    data?: {
+      total_requests?: number;
+      recent_requests_1h?: number;
+      active_requests?: number;
+      error_summary?: { total_errors?: number };
+    };
+  })?.data ?? {};
+  return {
+    total_requests: d.total_requests ?? 0,
+    recent_requests_1h: d.recent_requests_1h ?? 0,
+    active_requests: d.active_requests ?? 0,
+    total_errors: d.error_summary?.total_errors ?? 0,
+  };
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,38 +1,116 @@
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
+import { fetchDomains, fetchMetrics } from "../api/ohm/utility";
+import { listSolutions } from "../api/ohm/supply-tree";
+import { Badge } from "../components/ui/Badge";
 
-const steps = [
-  { icon: "🔩", title: "Browse Designs", description: "Discover and inspect OKH hardware designs.", to: "/okh" },
-  { icon: "⚡", title: "Run Match", description: "Match a design to manufacturing facilities.", to: "/match" },
-  { icon: "🗺️", title: "Visualize", description: "Explore supply chain graphs and KPIs.", to: "/visualization" },
-  { icon: "📄", title: "Export RFQ", description: "Generate request-for-quote documents.", to: "/rfq" },
-] as const;
+const JOURNEYS = [
+  { to: "/okh", icon: "🔩", title: "Designs", desc: "Browse open hardware designs by category and capability." },
+  { to: "/facilities", icon: "🏭", title: "Facilities", desc: "Explore manufacturing facilities and their capabilities." },
+  { to: "/match", icon: "⚡", title: "Match", desc: "Find facilities that can produce a design." },
+  { to: "/solutions", icon: "🌳", title: "Solutions", desc: "Revisit saved supply-tree solutions." },
+];
 
 export function HomePage() {
+  const domains = useQuery({ queryKey: ["domains"], queryFn: fetchDomains, staleTime: 300_000 });
+  const metrics = useQuery({ queryKey: ["metrics"], queryFn: fetchMetrics, staleTime: 60_000 });
+  const solutions = useQuery({ queryKey: ["solutions"], queryFn: listSolutions, staleTime: 30_000 });
+
+  const recent = (solutions.data ?? []).slice(0, 3);
+  const online = !domains.isError && !metrics.isError;
+
   return (
-    <div className="py-8">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold tracking-tight text-slate-800 dark:text-slate-100">
-          Open Hardware Matchmaker
-        </h1>
-        <p className="mt-3 text-lg text-slate-500 dark:text-slate-400">
-          Discover designs · Match facilities · Visualize supply chains · Export RFQs
+    <div className="space-y-10 py-4">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight text-foreground">Open Hardware Manager</h1>
+        <p className="mt-2 max-w-2xl text-muted-foreground">
+          Match open hardware designs to manufacturing facilities and explore the resulting supply
+          chains.
         </p>
       </div>
 
-      <div className="mt-12 grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
-        {steps.map(({ icon, title, description, to }) => (
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {JOURNEYS.map((j) => (
           <Link
-            key={to}
-            to={to}
-            className="group flex flex-col gap-3 rounded-xl border border-slate-200 bg-white p-6 shadow-sm transition-shadow hover:shadow-md no-underline dark:border-slate-700 dark:bg-slate-900 dark:hover:shadow-slate-800"
+            key={j.to}
+            to={j.to}
+            className="group flex flex-col gap-2 rounded-xl border border-slate-200 bg-white p-5 no-underline shadow-sm transition-shadow hover:shadow-md dark:border-slate-700 dark:bg-slate-900"
           >
-            <span className="text-3xl" aria-hidden="true">{icon}</span>
-            <div>
-              <p className="font-semibold text-slate-800 group-hover:text-indigo-600 transition-colors dark:text-slate-100 dark:group-hover:text-indigo-400">{title}</p>
-              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{description}</p>
-            </div>
+            <span className="text-3xl" aria-hidden="true">{j.icon}</span>
+            <p className="font-semibold text-slate-800 group-hover:text-indigo-600 dark:text-slate-100 dark:group-hover:text-indigo-400">
+              {j.title}
+            </p>
+            <p className="text-sm text-muted-foreground">{j.desc}</p>
           </Link>
         ))}
+      </div>
+
+      <div className="grid gap-8 lg:grid-cols-3">
+        <section className="lg:col-span-2">
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-foreground">Recent solutions</h2>
+            <Link to="/solutions" className="text-sm text-indigo-600 hover:underline dark:text-indigo-400">
+              View all →
+            </Link>
+          </div>
+          {recent.length === 0 ? (
+            <p className="rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+              No saved solutions yet — run a match to create one.
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {recent.map((s) => (
+                <li key={s.id}>
+                  <Link
+                    to={`/visualization/${s.id}`}
+                    className="flex items-center justify-between rounded-lg border border-slate-200 bg-white p-4 no-underline hover:bg-accent dark:border-slate-700 dark:bg-slate-900"
+                  >
+                    <span className="text-sm font-medium text-slate-800 dark:text-slate-100">
+                      {s.okh_title || (s.okh_id ? `${s.okh_id.slice(0, 8)}…` : "Untitled")}
+                    </span>
+                    <Badge variant={s.score >= 0.8 ? "green" : s.score >= 0.5 ? "yellow" : "red"}>
+                      {Math.round(s.score * 100)}%
+                    </Badge>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-lg font-semibold text-foreground">System</h2>
+          <div className="space-y-3 rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900">
+            <div className="flex items-center gap-2">
+              <span
+                className={`h-2.5 w-2.5 rounded-full ${online ? "bg-green-500" : "bg-red-500"}`}
+                aria-hidden="true"
+              />
+              <span className="text-sm text-slate-700 dark:text-slate-200">
+                {online ? "API online" : "API unreachable"}
+              </span>
+            </div>
+            {metrics.data && (
+              <p className="text-xs text-muted-foreground">
+                {metrics.data.total_errors} error{metrics.data.total_errors !== 1 ? "s" : ""} ·{" "}
+                {metrics.data.recent_requests_1h} requests (1h)
+              </p>
+            )}
+            <div>
+              <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Domains
+              </p>
+              <div className="flex flex-wrap gap-1.5">
+                {(domains.data ?? []).map((d) => (
+                  <Badge key={d.id} variant="blue">{d.name}</Badge>
+                ))}
+                {domains.isLoading && (
+                  <span className="text-xs text-muted-foreground">loading…</span>
+                )}
+              </div>
+            </div>
+          </div>
+        </section>
       </div>
     </div>
   );

--- a/frontend/src/test/fixtures/index.ts
+++ b/frontend/src/test/fixtures/index.ts
@@ -14,7 +14,21 @@ export const healthFixture = {
 };
 
 export const domainsFixture = {
-  domains: ["manufacturing", "cooking"],
+  data: {
+    domains: [
+      { id: "manufacturing", name: "Manufacturing", description: "Hardware manufacturing" },
+      { id: "cooking", name: "Cooking & Food Prep", description: "Recipe matching" },
+    ],
+  },
+};
+
+export const metricsFixture = {
+  data: {
+    total_requests: 1094,
+    recent_requests_1h: 111,
+    active_requests: 1,
+    error_summary: { total_errors: 0 },
+  },
 };
 
 /** A minimal OKH manifest shaped like the list payload the UI renders. */
@@ -244,6 +258,7 @@ export const solutionsEmptyFixture = { data: { result: [] } };
 export const fixturesByPath: Record<string, unknown> = {
   "/health": healthFixture,
   "/v1/api/utility/domains": domainsFixture,
+  "/v1/api/utility/metrics": metricsFixture,
   "/v1/api/okh": okhListFixture,
   "/v1/api/okh/okh-0001": okhDetailFixture,
   "/v1/api/okh/validate": validationResultFixture,

--- a/frontend/src/test/msw/handlers.ts
+++ b/frontend/src/test/msw/handlers.ts
@@ -2,6 +2,7 @@ import { http, HttpResponse } from "msw";
 import {
   domainsFixture,
   healthFixture,
+  metricsFixture,
   matchResponseFixture,
   solutionsListFixture,
   vizBundleFixture,
@@ -17,6 +18,7 @@ import {
 export const handlers = [
   http.get("*/health", () => HttpResponse.json(healthFixture)),
   http.get("*/v1/api/utility/domains", () => HttpResponse.json(domainsFixture)),
+  http.get("*/v1/api/utility/metrics", () => HttpResponse.json(metricsFixture)),
   http.get("*/v1/api/okh", () => HttpResponse.json(okhListFixture)),
   http.get("*/v1/api/okh/:id", () => HttpResponse.json(okhDetailFixture)),
   http.post("*/v1/api/okh/validate", () => HttpResponse.json(validationResultFixture)),


### PR DESCRIPTION
Closes #196. **The final v1 slice** — rebuilds the static legacy landing as a real dashboard, completing every in-scope journey from PRD #184.

## What's in it

- **Typed utility client**: `fetchDomains` (→ `Domain[]`) + `fetchMetrics` (flattens `error_summary.total_errors` + request counts).
- **Dashboard `HomePage`**:
  - Hero + tagline
  - Four **journey entry cards** (Designs / Facilities / Match / Solutions)
  - **Recent solutions** (reuses `listSolutions`, links into the supply-tree explorer)
  - **System panel**: online status, error/request counts, domain badges

## Verification

- `make frontend-ready` **green** (unit: `fetchDomains`/`fetchMetrics`; mocked E2E: journeys + recent solutions + health; **a11y clean**; screenshots).
- **Real-api lane green.**

## 🎉 v1 in-scope journeys complete

With this, the whole thing is browsable end-to-end: **dashboard → designs (faceted) → facilities → match (System Mode) → ranked results → supply tree (viz + sequence + deps) → saved solutions.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)