### PR TITLE
fix(match): save friendly design + facility name with solutions

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 431
+Total Python files: 432
 
 ├── deploy/
 │   ├── __init__.py
@@ -1675,7 +1675,8 @@ Total Python files: 431
     │   │       def _post_match()
     │   │       def _classify()
     │   │       def test_matching_ab_report_remote_okw()
-    │   └── test_matching_baseline.py
+    │   ├── test_matching_baseline.py
+    │   └── test_solution_friendly_name.py
     ├── parity/
     │   ├── __init__.py
     │   ├── manifest.py
@@ -2016,7 +2017,7 @@ Total Python files: 431
 
 ## Overview
 
-Total files analyzed: 431
+Total files analyzed: 432
 
 ## Entry Points
 
@@ -7569,6 +7570,12 @@ Requires:
 > Regression baseline for MatchingService layer orchestration (real initialize + call).
 
 Uses a minima...
+
+**Internal Dependencies:** 4 imports
+
+### `tests/integration/test_solution_friendly_name.py`
+> Saved supply-tree solutions must carry a human-readable identity — the design
+title and primary faci...
 
 **Internal Dependencies:** 4 imports
 

--- a/src/core/api/routes/match.py
+++ b/src/core/api/routes/match.py
@@ -505,8 +505,11 @@ async def match_requirements_to_capabilities(
                     best_solution_dict = solutions[0]
                     tree_dict = best_solution_dict.get("tree", {})
                     tree = SupplyTree.from_dict(tree_dict)
+                    tree_meta = tree.metadata or {}
 
-                    # Create SupplyTreeSolution from single tree
+                    # Create SupplyTreeSolution from single tree. Capture a
+                    # human-readable identity (design title + primary facility)
+                    # so saved solutions list under a friendly name, not a UUID.
                     solution = SupplyTreeSolution(
                         all_trees=[tree],
                         score=best_solution_dict.get(
@@ -515,6 +518,11 @@ async def match_requirements_to_capabilities(
                         metrics=best_solution_dict.get("metrics", {}),
                         metadata={
                             "okh_id": str(request.okh_id) if request.okh_id else None,
+                            "okh_title": tree_meta.get("okh_title"),
+                            "facility_name": (
+                                best_solution_dict.get("facility_name")
+                                or tree_meta.get("facility_name")
+                            ),
                             "matching_mode": MATCH_MODE_SINGLE_LEVEL,
                         },
                     )

--- a/src/core/services/storage_service.py
+++ b/src/core/services/storage_service.py
@@ -407,6 +407,7 @@ class StorageService:
             "id": str(solution_id),
             "okh_id": solution.metadata.get("okh_id"),
             "okh_title": solution.metadata.get("okh_title"),
+            "facility_name": solution.metadata.get("facility_name"),
             "matching_mode": solution.metadata.get(
                 "matching_mode", MATCH_MODE_SINGLE_LEVEL
             ),
@@ -544,6 +545,7 @@ class StorageService:
                         "id": metadata_dict.get("id"),
                         "okh_id": metadata_dict.get("okh_id"),
                         "okh_title": metadata_dict.get("okh_title"),
+                        "facility_name": metadata_dict.get("facility_name"),
                         "matching_mode": metadata_dict.get("matching_mode"),
                         "tree_count": metadata_dict.get("tree_count"),
                         "component_count": metadata_dict.get("component_count"),

--- a/tests/integration/test_solution_friendly_name.py
+++ b/tests/integration/test_solution_friendly_name.py
@@ -1,0 +1,61 @@
+"""
+Saved supply-tree solutions must carry a human-readable identity — the design
+title and primary facility — in their metadata, so the UI lists them by name
+rather than a bare UUID (web-ui review note #2).
+
+Regression guard for the fix: the match auto-save now records okh_title +
+facility_name, and storage persists/returns them through save -> list.
+
+The test builds its own local-backed StorageService rather than reusing the
+process-wide singleton, so it stays hermetic regardless of what provider an
+earlier test left configured (StorageService keeps its own `_instance`, which
+the integration `client` fixture does not reset).
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from src.core.models.supply_trees import SupplyTree, SupplyTreeSolution
+from src.core.services.storage_service import StorageService
+from src.core.storage.base import StorageConfig
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_saved_solution_lists_with_design_title_and_facility(tmp_path):
+    storage = StorageService()
+    await storage.configure(StorageConfig(provider="local", bucket_name=str(tmp_path)))
+    assert storage._configured, "local storage provider should configure"
+
+    tree = SupplyTree(
+        facility_name="FabLab Drome",
+        okh_reference="okh-vent",
+        okw_reference=str(uuid4()),
+        confidence_score=0.95,
+        match_type="direct",
+        metadata={"okh_title": "Open Ventilator", "facility_name": "FabLab Drome"},
+    )
+    solution = SupplyTreeSolution(
+        all_trees=[tree],
+        score=0.95,
+        metadata={
+            "okh_id": "okh-vent",
+            "okh_title": "Open Ventilator",
+            "facility_name": "FabLab Drome",
+            "matching_mode": "single-level",
+        },
+    )
+
+    solution_id = await storage.save_supply_tree_solution(
+        solution, ttl_days=1, tags=["friendly-name-test"]
+    )
+    try:
+        solutions = await storage.list_supply_tree_solutions(limit=200)
+        saved = next(s for s in solutions if s["id"] == str(solution_id))
+        assert saved["okh_title"] == "Open Ventilator"
+        assert saved["facility_name"] == "FabLab Drome"
+    finally:
+        await storage.delete_supply_tree_solution(solution_id)


### PR DESCRIPTION
## What

Auto-saved supply-tree solutions only recorded `okh_id` + `matching_mode` in their metadata, so the web UI's Solutions list rendered each saved solution by a bare UUID with a null title (web-ui review note #2 — "solutions listed by UUID need friendly names").

## Changes

- **`match.py`** — the single-level auto-save now records `okh_title` (from the supply-tree metadata) and `facility_name` (from the matched solution) alongside `okh_id`, so a solution carries a human-readable identity the moment it's saved.
- **`storage_service.py`** — persists `facility_name` in the saved metadata and returns it in the list summary, next to the `okh_title` it already read (the null was flowing from the match-save gap above, not the storage layer).
- **regression test** — `tests/integration/test_solution_friendly_name.py` round-trips a solution through `save -> list` on a local-backed `StorageService` and asserts both `okh_title` and `facility_name` survive. It constructs its own service rather than the process-wide singleton (`StorageService` keeps its own `_instance` that the integration `client` fixture does not reset), keeping it hermetic against whatever provider an earlier test left configured.

## Verification

`make ready` — all gates green (523 passed, parity 4/4, docs ✓).

The frontend Solutions-list display of `okh_title → facility_name` lands separately on `frontend-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)