### PR TITLE
feat(frontend): pre-filter facilities before matching

### DIFF
--- a/frontend/e2e/match.spec.ts
+++ b/frontend/e2e/match.spec.ts
@@ -45,3 +45,44 @@ test("System Mode selector controls the match request (mocked)", async ({ page }
   expect(body!.quality_level).toBe("medical");
   expect(body!.strict_mode).toBe(true);
 });
+
+test("selecting a facility subset sends okw_ids in the match request (mocked)", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "inspects the request body");
+  let body: { okw_ids?: string[] } | null = null;
+  await page.route("**/v1/api/match", async (route) => {
+    body = route.request().postDataJSON();
+    await route.fulfill({ json: matchResponseFixture });
+  });
+
+  await page.goto("/match");
+  await page.getByLabel("Design to match").selectOption({ label: "Open Ventilator" });
+
+  // Narrow matching to a single facility via the optional facility filter.
+  await page.getByRole("button", { name: /facilities/i }).click();
+  await page.getByLabel("Laser Fab Lab").check();
+  await expect(page.getByText(/limited to 1 facility/i)).toBeVisible();
+
+  await page.getByRole("button", { name: /run match/i }).click();
+  await expect(page.getByRole("heading", { name: "FabLab Drome" })).toBeVisible();
+  expect(body!.okw_ids).toEqual(["okw-1"]);
+});
+
+test("with no facility subset the request omits okw_ids (matches all, mocked)", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "inspects the request body");
+  let body: Record<string, unknown> | null = null;
+  await page.route("**/v1/api/match", async (route) => {
+    body = route.request().postDataJSON();
+    await route.fulfill({ json: matchResponseFixture });
+  });
+
+  await page.goto("/match");
+  await page.getByLabel("Design to match").selectOption({ label: "Open Ventilator" });
+  await page.getByRole("button", { name: /run match/i }).click();
+
+  await expect(page.getByRole("heading", { name: "FabLab Drome" })).toBeVisible();
+  expect(body).not.toHaveProperty("okw_ids");
+});

--- a/frontend/src/api/ohm/match.ts
+++ b/frontend/src/api/ohm/match.ts
@@ -5,6 +5,8 @@ export interface RunMatchParams {
   maxResults?: number;
   qualityLevel?: string;
   strictMode?: boolean;
+  /** Restrict matching to these facility IDs; empty/undefined means all. */
+  okwIds?: string[];
 }
 
 export interface RawSolution {
@@ -49,6 +51,10 @@ export async function runMatch(params: RunMatchParams): Promise<RawMatchResponse
       save_solution: true,
       quality_level: params.qualityLevel,
       strict_mode: params.strictMode,
+      // Omit when empty so the server matches against all facilities.
+      ...(params.okwIds && params.okwIds.length > 0
+        ? { okw_ids: params.okwIds }
+        : {}),
     } as never,
   });
   if (error || !response.ok) {

--- a/frontend/src/features/match/FacilityFilter.test.tsx
+++ b/frontend/src/features/match/FacilityFilter.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { FacilityFilter, type FacilityOption } from "./FacilityFilter";
+
+const facilities: FacilityOption[] = [
+  { id: "okw-1", name: "Laser Fab Lab" },
+  { id: "okw-2", name: "Community Makerspace" },
+  { id: "okw-3", name: "Precision CNC Shop" },
+];
+
+describe("FacilityFilter", () => {
+  it("summarizes matching against all facilities when nothing is selected", () => {
+    render(
+      <FacilityFilter facilities={facilities} selectedIds={[]} onChange={() => {}} />,
+    );
+    expect(screen.getByText(/matching against all facilities/i)).toBeInTheDocument();
+  });
+
+  it("toggling a facility reports the new selection", async () => {
+    const onChange = vi.fn();
+    render(
+      <FacilityFilter facilities={facilities} selectedIds={[]} onChange={onChange} />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /facilities/i }));
+    await userEvent.click(screen.getByLabelText("Precision CNC Shop"));
+    expect(onChange).toHaveBeenCalledWith(["okw-3"]);
+  });
+
+  it("filters the checklist by the search query", async () => {
+    render(
+      <FacilityFilter facilities={facilities} selectedIds={[]} onChange={() => {}} />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /facilities/i }));
+    await userEvent.type(screen.getByLabelText(/filter facilities/i), "cnc");
+    expect(screen.getByLabelText("Precision CNC Shop")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Laser Fab Lab")).not.toBeInTheDocument();
+  });
+
+  it("select all reports every facility id; clear empties it", async () => {
+    const onChange = vi.fn();
+    render(
+      <FacilityFilter facilities={facilities} selectedIds={["okw-1"]} onChange={onChange} />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /facilities/i }));
+    await userEvent.click(screen.getByRole("button", { name: /select all/i }));
+    expect(onChange).toHaveBeenLastCalledWith(["okw-1", "okw-2", "okw-3"]);
+    await userEvent.click(screen.getByRole("button", { name: /clear/i }));
+    expect(onChange).toHaveBeenLastCalledWith([]);
+  });
+});

--- a/frontend/src/features/match/FacilityFilter.tsx
+++ b/frontend/src/features/match/FacilityFilter.tsx
@@ -1,0 +1,130 @@
+import { useMemo, useState } from "react";
+
+export interface FacilityOption {
+  id: string;
+  name: string;
+}
+
+/**
+ * Optional facility pre-filter for matching (web-ui review #4). A controlled,
+ * collapsible checklist: the parent owns the selected-id set. An empty set
+ * means "match against all facilities" — the default, so matching is unchanged
+ * unless the user narrows it here.
+ */
+export function FacilityFilter({
+  facilities,
+  selectedIds,
+  onChange,
+  isLoading,
+  isError,
+}: {
+  facilities: FacilityOption[];
+  selectedIds: string[];
+  onChange: (ids: string[]) => void;
+  isLoading?: boolean;
+  isError?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [q, setQ] = useState("");
+  const selected = useMemo(() => new Set(selectedIds), [selectedIds]);
+
+  const visible = useMemo(() => {
+    const needle = q.trim().toLowerCase();
+    if (!needle) return facilities;
+    return facilities.filter((f) => f.name.toLowerCase().includes(needle));
+  }, [facilities, q]);
+
+  const summary =
+    selectedIds.length === 0
+      ? "Matching against all facilities"
+      : `Limited to ${selectedIds.length} facilit${selectedIds.length === 1 ? "y" : "ies"}`;
+
+  function toggle(id: string) {
+    const next = new Set(selected);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    onChange([...next]);
+  }
+
+  return (
+    <div>
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <span aria-hidden="true">{open ? "▾" : "▸"}</span>
+        <span>Facilities</span>
+        <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-slate-600 dark:text-slate-300">
+          {summary}
+        </span>
+      </button>
+
+      {open && (
+        <fieldset className="mt-2 max-w-md rounded-md border border-input p-3">
+          <legend className="px-1 text-xs text-muted-foreground">
+            Limit which facilities to match against (optional)
+          </legend>
+
+          {isLoading && (
+            <p className="text-sm text-muted-foreground">Loading facilities…</p>
+          )}
+          {isError && (
+            <p className="text-sm text-red-600 dark:text-red-400">
+              Couldn’t load facilities — matching will use all of them.
+            </p>
+          )}
+
+          {!isLoading && !isError && (
+            <>
+              <div className="mb-2 flex items-center gap-2">
+                <input
+                  type="search"
+                  value={q}
+                  onChange={(e) => setQ(e.target.value)}
+                  placeholder="Filter facilities…"
+                  aria-label="Filter facilities"
+                  className="w-full rounded-md border border-input bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+              </div>
+              <div className="mb-2 flex gap-3 text-xs">
+                <button
+                  type="button"
+                  className="text-indigo-600 hover:underline dark:text-indigo-400"
+                  onClick={() => onChange(facilities.map((f) => f.id))}
+                >
+                  Select all
+                </button>
+                <button
+                  type="button"
+                  className="text-slate-600 hover:underline dark:text-slate-300"
+                  onClick={() => onChange([])}
+                >
+                  Clear
+                </button>
+              </div>
+              <ul className="max-h-48 space-y-1 overflow-y-auto">
+                {visible.map((f) => (
+                  <li key={f.id}>
+                    <label className="flex items-center gap-2 text-sm text-foreground">
+                      <input
+                        type="checkbox"
+                        checked={selected.has(f.id)}
+                        onChange={() => toggle(f.id)}
+                      />
+                      {f.name}
+                    </label>
+                  </li>
+                ))}
+                {visible.length === 0 && (
+                  <li className="text-sm text-muted-foreground">No facilities match “{q}”.</li>
+                )}
+              </ul>
+            </>
+          )}
+        </fieldset>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/match/MatchView.tsx
+++ b/frontend/src/features/match/MatchView.tsx
@@ -2,9 +2,11 @@ import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { fetchOkhList } from "../../api/ohm/okh";
+import { searchOkw } from "../../api/ohm/okw";
 import { runMatch } from "../../api/ohm/match";
 import { toMatchView } from "./matchViewModel";
 import { buildMatchRequest, SYSTEM_MODES, type SystemMode } from "./matchRequest";
+import { FacilityFilter } from "./FacilityFilter";
 import { MatchResultCard } from "./MatchResultCard";
 import { LoadingState, EmptyState, ErrorState } from "../../components/ui/states";
 import { Button } from "../../components/ui/button";
@@ -16,11 +18,17 @@ export function MatchView({ okhId, autoRun }: { okhId?: string; autoRun?: boolea
     queryFn: () => fetchOkhList({ page: 1, page_size: 100 }),
     staleTime: 60_000,
   });
+  const facilitiesQuery = useQuery({
+    queryKey: ["okw-search", "match-filter"],
+    queryFn: () => searchOkw({ page: 1, page_size: 100 }),
+    staleTime: 60_000,
+  });
   const [selected, setSelected] = useState(okhId ?? "");
   const [mode, setMode] = useState<SystemMode>("standard");
+  const [facilityIds, setFacilityIds] = useState<string[]>([]);
   const mutation = useMutation({
-    mutationFn: ({ id, m }: { id: string; m: SystemMode }) =>
-      runMatch(buildMatchRequest(id, m)),
+    mutationFn: ({ id, m, ids }: { id: string; m: SystemMode; ids: string[] }) =>
+      runMatch(buildMatchRequest(id, m, undefined, ids)),
   });
   const view = useMemo(
     () => (mutation.data ? toMatchView(mutation.data) : null),
@@ -28,7 +36,7 @@ export function MatchView({ okhId, autoRun }: { okhId?: string; autoRun?: boolea
   );
 
   useEffect(() => {
-    if (autoRun && okhId) mutation.mutate({ id: okhId, m: "standard" });
+    if (autoRun && okhId) mutation.mutate({ id: okhId, m: "standard", ids: [] });
     // Run once on mount; MatchPage remounts (via key) when the design changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -65,7 +73,7 @@ export function MatchView({ okhId, autoRun }: { okhId?: string; autoRun?: boolea
           </label>
           <Button
             disabled={!selected || mutation.isPending}
-            onClick={() => mutation.mutate({ id: selected, m: mode })}
+            onClick={() => mutation.mutate({ id: selected, m: mode, ids: facilityIds })}
           >
             {mutation.isPending ? "Matching…" : "⚡ Run Match"}
           </Button>
@@ -100,13 +108,24 @@ export function MatchView({ okhId, autoRun }: { okhId?: string; autoRun?: boolea
             <p className="mt-1.5 max-w-xl text-xs text-muted-foreground">{modeInfo.description}</p>
           )}
         </div>
+
+        <FacilityFilter
+          facilities={(facilitiesQuery.data?.results ?? []).map((f) => ({
+            id: f.id,
+            name: f.name,
+          }))}
+          selectedIds={facilityIds}
+          onChange={setFacilityIds}
+          isLoading={facilitiesQuery.isLoading}
+          isError={facilitiesQuery.isError}
+        />
       </div>
 
       {mutation.isPending && <LoadingState message="Matching against facilities…" />}
       {mutation.isError && (
         <ErrorState
           description={mutation.error instanceof Error ? mutation.error.message : "Match failed."}
-          onRetry={() => selected && mutation.mutate({ id: selected, m: mode })}
+          onRetry={() => selected && mutation.mutate({ id: selected, m: mode, ids: facilityIds })}
         />
       )}
 

--- a/frontend/src/features/match/matchRequest.test.ts
+++ b/frontend/src/features/match/matchRequest.test.ts
@@ -27,4 +27,16 @@ describe("buildMatchRequest", () => {
   it("passes through maxResults", () => {
     expect(buildMatchRequest("okh-1", "standard", 5).maxResults).toBe(5);
   });
+
+  it("includes okwIds when a facility subset is chosen", () => {
+    expect(buildMatchRequest("okh-1", "standard", undefined, ["a", "b"]).okwIds).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("omits okwIds when the subset is empty (match all facilities)", () => {
+    expect(buildMatchRequest("okh-1", "standard", undefined, [])).not.toHaveProperty("okwIds");
+    expect(buildMatchRequest("okh-1", "standard")).not.toHaveProperty("okwIds");
+  });
 });

--- a/frontend/src/features/match/matchRequest.ts
+++ b/frontend/src/features/match/matchRequest.ts
@@ -46,6 +46,8 @@ export function buildMatchRequest(
   okhId: string,
   mode: SystemMode,
   maxResults?: number,
+  okwIds?: string[],
 ): RunMatchParams {
-  return { okhId, ...MODE_PARAMS[mode], maxResults };
+  const okw = okwIds && okwIds.length > 0 ? { okwIds } : {};
+  return { okhId, ...MODE_PARAMS[mode], maxResults, ...okw };
 }


### PR DESCRIPTION
## What

Review note #4 — let a user **choose which facilities to match against** before running a match, instead of always matching the whole OKW pool. Adds an optional facility filter to the Match page.

## Changes

- **`FacilityFilter`** — a controlled, collapsible, searchable checklist of OKW facilities with **Select all / Clear**. Accessible: `fieldset`/`legend`, labelled checkboxes, a per-name search box, and a summary chip that reads "Matching against all facilities" or "Limited to N facilities".
- **`MatchView`** fetches the OKW list and owns the selection state. The chosen ids thread through `buildMatchRequest` → `runMatch`, which includes `okw_ids` **only when a subset is selected** — an empty selection omits the field, so matching still runs against all facilities (no default behaviour change). System Mode and auto-run paths are unaffected.
- **Tests** — component tests (toggle reports selection, search narrows the list, select-all/clear) and two mocked E2E cases asserting the request body **carries `okw_ids` for a subset** and **omits it for "all"**.

## Verification

`make frontend-ready` — all stages green (65 unit, 46 E2E incl. the 2 new facility-filter cases, axe, build, screenshots).

## Depends on

Backend `okw_ids` filter — PR #221. Until that merges, selecting a subset is a no-op server-side (the field is ignored), so there's no broken state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)