### PR TITLE
feat(match): reverse matching — designs a facility can produce

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 433
+Total Python files: 435
 
 ├── deploy/
 │   ├── __init__.py
@@ -452,6 +452,7 @@ Total Python files: 433
 │       │   │   │   │       class OptimizationCriteria
 │       │   │   │   │       class MatchRequest (validate_input)
 │       │   │   │   │       class ValidateMatchRequest
+│       │   │   │   │       class FacilityMatchRequest
 │       │   │   │   │       class SimulationParameters
 │       │   │   │   │       class SimulateRequest
 │       │   │   │   ├── response.py
@@ -1676,6 +1677,10 @@ Total Python files: 433
     │   │       def _classify()
     │   │       def test_matching_ab_report_remote_okw()
     │   ├── test_matching_baseline.py
+    │   ├── test_reverse_facility_match_route.py
+    │   │       def _facility_content()
+    │   │       def test_reverse_match_unknown_facility_returns_404()
+    │   │       def test_reverse_match_returns_ranked_envelope()
     │   └── test_solution_friendly_name.py
     ├── parity/
     │   ├── __init__.py
@@ -1982,6 +1987,9 @@ Total Python files: 433
         │       class TestDeriveAction (_cs, test_none_state_returns_assess, test_unknown_condition_returns_assess...)
         │       class TestDeriveFlags (test_harvest_sets_harvest_viable_true, test_source_new_sets_source_required_true, test_repair_in_place_sets_repair_feasible_true...)
         │       class TestTriageReport (_item, test_summary_counts, test_to_dict_shape...)
+        ├── test_reverse_facility_matching.py
+        │       def _manifest()
+        │       def _sol()
         ├── test_salvage_model.py
         │       class _C (__init__)
         │       class TestIsSalvageMatch (test_not_harvest_viable_excluded, test_name_substring_match, test_name_case_insensitive...)
@@ -2023,7 +2031,7 @@ Total Python files: 433
 
 ## Overview
 
-Total files analyzed: 433
+Total files analyzed: 435
 
 ## Entry Points
 
@@ -2694,7 +2702,7 @@ This module provides Pydantic models for LLM API responses....
 
 ### `src/core/api/models/match/request.py`
 
-**Exports:** OptimizationCriteria, MatchRequest, ValidateMatchRequest, SimulationParameters, SimulateRequest
+**Exports:** OptimizationCriteria, MatchRequest, ValidateMatchRequest, FacilityMatchRequest, SimulationParameters
 
 **Classes:**
 - `OptimizationCriteria` (inherits: BaseModel)
@@ -2704,6 +2712,8 @@ This module provides Pydantic models for LLM API responses....
   - Consolidated match request with standardized fields and LLM support...
 - `ValidateMatchRequest` (inherits: BaseModel)
   - Request model for validating an existing supply tree...
+- `FacilityMatchRequest` (inherits: BaseAPIRequest)
+  - Reverse-match request: which designs can a given facility produce?...
 - `SimulationParameters` (inherits: BaseModel)
   - Parameters for simulation...
 - `SimulateRequest` (inherits: BaseModel)
@@ -7579,6 +7589,17 @@ Uses a minima...
 
 **Internal Dependencies:** 4 imports
 
+### `tests/integration/test_reverse_facility_match_route.py`
+> Integration tests for POST /api/match/facility (reverse matching, review #7).
+
+Runs the full ASGI ap...
+
+**Exports:** test_reverse_match_unknown_facility_returns_404, test_reverse_match_returns_ranked_envelope
+
+**Functions:**
+- `test_reverse_match_unknown_facility_returns_404(client)`
+- `test_reverse_match_returns_ranked_envelope(client)`
+
 ### `tests/integration/test_solution_friendly_name.py`
 > Saved supply-tree solutions must carry a human-readable identity — the design
 title and primary faci...
@@ -8069,6 +8090,13 @@ A caller can pre-select which...
 - `test_looks_like_bare_release_version()`
 
 **Internal Dependencies:** 2 imports
+
+### `tests/unit/test_reverse_facility_matching.py`
+> Unit tests for reverse matching — designs a facility can produce (review #7).
+
+`find_designs_for_fac...
+
+**Internal Dependencies:** 1 imports
 
 ### `tests/unit/test_smart_discovery_strategy_cascade.py`
 > Tests for SmartFileDiscovery strategy cascade behaviour.

--- a/docs/api/routes.md
+++ b/docs/api/routes.md
@@ -323,6 +323,23 @@ async def match_selected_facilities():
         return response.json()
 ```
 
+**Reverse matching (designs a facility can produce):**
+
+`POST /api/match/facility` is the inverse of `POST /api/match`: given an OKW
+facility, it returns the OKH designs that facility can produce, ranked by
+confidence. It evaluates every design in the catalog against the single facility
+using the same matching logic. Equivalent CLI: `ohm match facility <okw-id>`.
+
+```python
+async def designs_for_facility():
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            "http://localhost:8001/v1/api/match/facility",
+            json={"okw_id": "…", "min_confidence": 0.1, "max_results": 10},
+        )
+        return response.json()  # data.designs[] = [{okh_id, okh_title, confidence, rank}]
+```
+
 **Matching from URL:**
 ```python
 async def match_from_url():

--- a/src/cli/match.py
+++ b/src/cli/match.py
@@ -1152,6 +1152,92 @@ async def requirements(
 
 
 @match_group.command()
+@click.argument("okw_id", type=str)
+@click.option(
+    "--min-confidence",
+    type=float,
+    default=0.1,
+    show_default=True,
+    help="Minimum solution score for a design to be reported (0.0-1.0).",
+)
+@click.option(
+    "--max-results",
+    type=int,
+    default=10,
+    show_default=True,
+    help="Maximum number of designs to return.",
+)
+@click.option(
+    "--domain",
+    type=click.Choice(["manufacturing", "cooking"]),
+    help="Domain override (skips content-based detection).",
+)
+@standard_cli_command(
+    help_text="""
+    Reverse match: list the designs a given facility can produce.
+
+    This is the inverse of `ohm match requirements` — instead of finding
+    facilities for a design, it finds designs a facility (OKW_ID) can make,
+    ranked by confidence.
+    """,
+    async_cmd=True,
+    track_performance=True,
+    handle_errors=True,
+    format_output=True,
+    add_llm_config=False,
+)
+@click.pass_context
+async def facility(
+    ctx: Context,
+    okw_id: str,
+    min_confidence: float,
+    max_results: int,
+    domain: Optional[str],
+    verbose: bool,
+    output_format: str,
+    # Always-injected LLM options (unused here; reverse matching is deterministic).
+    use_llm: bool,
+    llm_provider: str,
+    llm_model: Optional[str],
+    quality_level: str,
+    strict_mode: bool,
+) -> None:
+    """List the designs a facility can produce (reverse match)."""
+    cli_ctx = ctx.obj
+
+    request_data: dict[str, Any] = {
+        "okw_id": okw_id,
+        "min_confidence": min_confidence,
+        "max_results": max_results,
+    }
+    if domain:
+        request_data["domain"] = domain
+
+    response = await cli_ctx.api_client.request(
+        "POST",
+        "/api/match/facility",
+        json_data=request_data,
+    )
+    data = response.get("data", response)
+
+    if output_format == "json":
+        click.echo(json.dumps(data, indent=2))
+        return
+
+    designs = data.get("designs", [])
+    facility_name = data.get("facility_name") or okw_id
+    if not designs:
+        click.echo(f"No designs can currently be produced by {facility_name}.")
+        return
+
+    click.echo(f"Designs {facility_name} can produce:")
+    for d in designs:
+        pct = round((d.get("confidence") or 0.0) * 100)
+        title = d.get("okh_title") or d.get("okh_id")
+        click.echo(f"  {d.get('rank')}. {title} ({d.get('okh_id')}) — {pct}%")
+
+
+@match_group.command()
 @click.argument("input_file", type=str)
 @click.option(
     "--domain",

--- a/src/core/api/models/match/request.py
+++ b/src/core/api/models/match/request.py
@@ -303,6 +303,27 @@ class ValidateMatchRequest(BaseModel):
     )
 
 
+class FacilityMatchRequest(BaseAPIRequest):
+    """Reverse-match request: which designs can a given facility produce?"""
+
+    okw_id: UUID = Field(
+        ..., description="Facility (OKW) to find producible designs for"
+    )
+    domain: Optional[str] = Field(
+        None,
+        description="Optional explicit domain; skips content-based domain detection.",
+    )
+    min_confidence: Optional[float] = Field(
+        0.1,
+        ge=0.0,
+        le=1.0,
+        description="Minimum solution score for a design to be reported.",
+    )
+    max_results: Optional[int] = Field(
+        10, ge=1, description="Maximum number of designs to return."
+    )
+
+
 class SimulationParameters(BaseModel):
     """Parameters for simulation"""
 

--- a/src/core/api/routes/match.py
+++ b/src/core/api/routes/match.py
@@ -66,7 +66,12 @@ from ..models.base import (
 )
 
 # Import existing models and services
-from ..models.match.request import MatchRequest, SimulateRequest, ValidateMatchRequest
+from ..models.match.request import (
+    FacilityMatchRequest,
+    MatchRequest,
+    SimulateRequest,
+    ValidateMatchRequest,
+)
 from ..models.match.response import SimulateResponse
 from ..models.match.suggestion_codes import MATCH_SUGGESTION_CODES
 
@@ -106,6 +111,11 @@ async def get_storage_service() -> StorageService:
 async def get_okh_service() -> OKHService:
     """Get OKH service instance."""
     return await OKHService.get_instance()
+
+
+async def get_okw_service() -> OKWService:
+    """Get OKW service instance."""
+    return await OKWService.get_instance()
 
 
 # Main matching endpoint (enhanced version)
@@ -966,6 +976,104 @@ async def match_requirements_from_file(
             suggestion="Please try again or contact support if the issue persists",
         )
         logger.error(f"Error in file upload matching: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=error_response.model_dump(mode="json"),
+        )
+
+
+# Reverse matching: designs a facility can produce
+@router.post(
+    "/facility",
+    status_code=status.HTTP_200_OK,
+    summary="Reverse Match (Designs a Facility Can Produce)",
+    description="""
+    Reverse matching: given an OKW facility, return the OKH designs it can produce.
+
+    This is the inverse of `POST /api/match` (which finds facilities for a design).
+    It evaluates every design in the catalog against the single target facility
+    using the same matching logic, and returns the designs the facility can make,
+    ranked by confidence.
+
+    **Body:**
+    - `okw_id` (required): the facility to find producible designs for
+    - `min_confidence` (default 0.1): minimum solution score to report a design
+    - `max_results` (default 10): cap on the number of designs returned
+    - `domain` (optional): explicit domain override
+    """,
+)
+@api_endpoint(
+    success_message="Reverse matching completed successfully", include_metrics=True
+)
+@track_performance("reverse_facility_matching")
+async def match_designs_for_facility(
+    request: FacilityMatchRequest,
+    http_request: Request,
+    matching_service: MatchingService = Depends(get_matching_service),
+    okh_service: OKHService = Depends(get_okh_service),
+    okw_service: OKWService = Depends(get_okw_service),
+) -> dict[str, Any]:
+    """Return the designs a given facility can produce, ranked by confidence."""
+    request_id = getattr(http_request.state, "request_id", None)
+    start_time = datetime.now()
+
+    try:
+        facility = await okw_service.get(request.okw_id)
+        if facility is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Facility {request.okw_id} not found",
+            )
+
+        # Load the full design catalog (list yields minimal manifests; the matcher
+        # needs full manifests to extract process requirements, so re-load each).
+        manifests: List[OKHManifest] = []
+        page = 1
+        page_size = 200
+        while True:
+            summaries, _ = await okh_service.list(page=page, page_size=page_size)
+            if not summaries:
+                break
+            for summary in summaries:
+                full = await okh_service.get(summary.id)
+                if full is not None:
+                    manifests.append(full)
+            if len(summaries) < page_size:
+                break
+            page += 1
+
+        designs = await matching_service.find_designs_for_facility(
+            facility=facility,
+            manifests=manifests,
+            min_confidence=(
+                request.min_confidence if request.min_confidence is not None else 0.1
+            ),
+            max_results=request.max_results,
+            explicit_domain=request.domain,
+        )
+
+        processing_time = (datetime.now() - start_time).total_seconds()
+        # Return the plain data payload; @api_endpoint wraps it in the standard
+        # success envelope (matching the main POST /api/match handler).
+        return {
+            "okw_id": str(request.okw_id),
+            "facility_name": getattr(facility, "name", None),
+            "designs": designs,
+            "total_designs": len(designs),
+            "designs_considered": len(manifests),
+            "processing_time": processing_time,
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        error_response = create_error_response(
+            error=e,
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            request_id=request_id,
+            suggestion="Please try again or contact support if the issue persists",
+        )
+        logger.error(f"Error in reverse facility matching: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=error_response.model_dump(mode="json"),

--- a/src/core/services/matching_service.py
+++ b/src/core/services/matching_service.py
@@ -364,6 +364,76 @@ class MatchingService:
             )
             raise
 
+    async def find_designs_for_facility(
+        self,
+        facility: ManufacturingFacility,
+        manifests: List[OKHManifest],
+        min_confidence: float = 0.1,
+        max_results: Optional[int] = None,
+        explicit_domain: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Reverse match: which of the given designs can this facility produce?
+
+        Runs the same per-facility matching used by forward matching, but with a
+        single-facility candidate pool, once per candidate design. A design is
+        reported when the facility yields a solution scoring at least
+        ``min_confidence``. Results are ranked by confidence (descending).
+
+        Args:
+            facility: The single OKW facility to evaluate designs against.
+            manifests: Candidate OKH designs (full manifests, as the matcher
+                extracts process requirements from them).
+            min_confidence: Minimum solution score for a design to be reported.
+            max_results: Optional cap on the number of designs returned.
+            explicit_domain: When set, skips content-based domain detection.
+
+        Returns:
+            A confidence-ranked list of dicts, each with ``okh_id``,
+            ``okh_title``, ``confidence``, and ``rank`` (1-based).
+
+        Raises:
+            RuntimeError: If the service was not initialized.
+        """
+        await self.ensure_initialized()
+
+        matched: List[Dict[str, Any]] = []
+        for manifest in manifests:
+            try:
+                solutions = await self.find_matches_with_manifest(
+                    manifest, [facility], explicit_domain=explicit_domain
+                )
+            except Exception as e:
+                logger.warning(
+                    "Reverse match skipped a design that failed to match",
+                    extra={
+                        "okh_id": str(getattr(manifest, "id", None)),
+                        "error": str(e),
+                    },
+                )
+                continue
+
+            if not solutions:
+                continue
+
+            best = max(s.score for s in solutions)
+            if best < min_confidence:
+                continue
+
+            matched.append(
+                {
+                    "okh_id": str(getattr(manifest, "id", None)),
+                    "okh_title": getattr(manifest, "title", None),
+                    "confidence": best,
+                }
+            )
+
+        matched.sort(key=lambda d: d["confidence"], reverse=True)
+        if max_results is not None:
+            matched = matched[:max_results]
+        for rank, entry in enumerate(matched, start=1):
+            entry["rank"] = rank
+        return matched
+
     async def find_composite_matches_with_manifest(
         self,
         okh_manifest: OKHManifest,

--- a/tests/integration/test_reverse_facility_match_route.py
+++ b/tests/integration/test_reverse_facility_match_route.py
@@ -1,0 +1,53 @@
+"""Integration tests for POST /api/match/facility (reverse matching, review #7).
+
+Runs the full ASGI app in-process (TestClient + local storage from conftest).
+The ranking logic is unit-tested separately; here we verify the endpoint is
+wired end-to-end: unknown facilities 404, and a real facility returns the
+documented response envelope.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+pytestmark = pytest.mark.integration
+
+
+def _facility_content() -> dict:
+    data_dir = Path(__file__).resolve().parents[2] / "synthetic_data"
+    facility_file = sorted(data_dir.glob("*okw*.json"))[0]
+    return json.loads(facility_file.read_text(encoding="utf-8"))
+
+
+def test_reverse_match_unknown_facility_returns_404(client):
+    resp = client.post("/api/match/facility", json={"okw_id": str(uuid4())})
+    assert resp.status_code == 404, resp.text
+
+
+def test_reverse_match_returns_ranked_envelope(client):
+    created = client.post("/api/okw/create", json={"content": _facility_content()})
+    assert created.status_code == 201, created.text
+    okw_id = created.json()["okw"]["id"]
+
+    resp = client.post(
+        "/api/match/facility",
+        json={"okw_id": okw_id, "min_confidence": 0.1, "max_results": 5},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()["data"]
+
+    assert data["okw_id"] == okw_id
+    assert isinstance(data["designs"], list)
+    assert data["total_designs"] == len(data["designs"])
+    assert "designs_considered" in data
+    # Each returned design carries a friendly identity + ranking.
+    for d in data["designs"]:
+        assert {"okh_id", "okh_title", "confidence", "rank"} <= set(d)

--- a/tests/unit/test_reverse_facility_matching.py
+++ b/tests/unit/test_reverse_facility_matching.py
@@ -1,0 +1,115 @@
+"""Unit tests for reverse matching — designs a facility can produce (review #7).
+
+`find_designs_for_facility` runs the existing per-facility matcher once per
+candidate design (single-facility pool) and returns the designs that clear the
+confidence threshold, ranked by confidence.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+def _manifest(okh_id: str, title: str):
+    return SimpleNamespace(id=okh_id, title=title)
+
+
+def _sol(score: float):
+    return SimpleNamespace(score=score)
+
+
+async def _service_with_scores(monkeypatch, scores_by_id):
+    """Build a MatchingService whose per-design match returns preset scores."""
+    from src.core.services.matching_service import MatchingService
+
+    service = MatchingService()
+    monkeypatch.setattr(service, "ensure_initialized", AsyncMock())
+
+    async def fake_match(manifest, facilities, explicit_domain=None):
+        sols = scores_by_id.get(manifest.id, [])
+        # Real matcher returns a Set[SupplyTreeSolution]; a list suffices here
+        # (find_designs_for_facility only iterates), and avoids hashing the
+        # unhashable SimpleNamespace stand-ins.
+        return [_sol(s) for s in sols]
+
+    monkeypatch.setattr(service, "find_matches_with_manifest", fake_match)
+    return service
+
+
+@pytest.mark.asyncio
+async def test_ranks_matched_designs_by_confidence(monkeypatch):
+    service = await _service_with_scores(
+        monkeypatch,
+        {"a": [0.6], "b": [0.9], "c": [0.75]},
+    )
+    facility = SimpleNamespace(name="FabLab")
+
+    designs = await service.find_designs_for_facility(
+        facility,
+        [_manifest("a", "A"), _manifest("b", "B"), _manifest("c", "C")],
+    )
+
+    assert [d["okh_id"] for d in designs] == ["b", "c", "a"]
+    assert [d["rank"] for d in designs] == [1, 2, 3]
+    assert designs[0]["okh_title"] == "B"
+
+
+@pytest.mark.asyncio
+async def test_drops_designs_below_min_confidence(monkeypatch):
+    service = await _service_with_scores(monkeypatch, {"a": [0.2], "b": [0.9]})
+    facility = SimpleNamespace(name="FabLab")
+
+    designs = await service.find_designs_for_facility(
+        facility,
+        [_manifest("a", "A"), _manifest("b", "B")],
+        min_confidence=0.5,
+    )
+
+    assert [d["okh_id"] for d in designs] == ["b"]
+
+
+@pytest.mark.asyncio
+async def test_drops_designs_with_no_solution(monkeypatch):
+    service = await _service_with_scores(monkeypatch, {"a": [], "b": [0.8]})
+    facility = SimpleNamespace(name="FabLab")
+
+    designs = await service.find_designs_for_facility(
+        facility, [_manifest("a", "A"), _manifest("b", "B")]
+    )
+
+    assert [d["okh_id"] for d in designs] == ["b"]
+
+
+@pytest.mark.asyncio
+async def test_max_results_caps_the_ranked_list(monkeypatch):
+    service = await _service_with_scores(
+        monkeypatch, {"a": [0.6], "b": [0.9], "c": [0.75]}
+    )
+    facility = SimpleNamespace(name="FabLab")
+
+    designs = await service.find_designs_for_facility(
+        facility,
+        [_manifest("a", "A"), _manifest("b", "B"), _manifest("c", "C")],
+        max_results=2,
+    )
+
+    assert [d["okh_id"] for d in designs] == ["b", "c"]
+
+
+@pytest.mark.asyncio
+async def test_uses_best_solution_score_per_design(monkeypatch):
+    service = await _service_with_scores(monkeypatch, {"a": [0.3, 0.85, 0.5]})
+    facility = SimpleNamespace(name="FabLab")
+
+    designs = await service.find_designs_for_facility(facility, [_manifest("a", "A")])
+
+    assert designs[0]["confidence"] == 0.85


### PR DESCRIPTION
## What

The inverse of forward matching (review note #7). `POST /api/match` finds facilities for a design; this finds **designs for a facility** — given an OKW facility, return the OKH designs it can produce, ranked by confidence. Useful for a "what can this makerspace build?" view.

## Approach

Rather than new matching logic, this **composes the existing matcher**: for each design in the catalog, run the same per-facility matching against a single-facility pool (the target). A design is reported when it yields a solution at or above `min_confidence`; results rank by best score. With the current corpus (~27 designs) this is cheap, and results stay consistent with forward matching by construction.

## Changes

- **Service** — `MatchingService.find_designs_for_facility(facility, manifests, min_confidence, max_results, explicit_domain)`. Mirrors `find_matches_with_manifest` by taking the candidate manifests as an argument, so it's decoupled from storage and unit-testable.
- **API** — `POST /api/match/facility` (`FacilityMatchRequest`: `okw_id` + `min_confidence` + `max_results` + optional `domain`). Loads the full design catalog and the target facility; returns `{designs[{okh_id, okh_title, confidence, rank}], total_designs, designs_considered, facility_name}`. **404** on unknown facility.
- **CLI** — `ohm match facility <okw-id>` (`--min-confidence` / `--max-results` / `--domain`), table or `--json` output.
- **Docs** — reverse-matching example in the API routes reference.
- **Tests** — service ranking / threshold / max-results / best-score-per-design (unit), plus endpoint wiring (TestClient integration: 404 + response-envelope shape).

## Verification

`make ready` — all gates green (535 passed, parity 4/4, docs ✓).

The frontend "Designs this facility can make" section on the OKW detail page lands separately on `frontend-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)