### PR TITLE
feat(frontend): show designs a facility can make on OKW detail

### DIFF
--- a/frontend/e2e/okw-detail.spec.ts
+++ b/frontend/e2e/okw-detail.spec.ts
@@ -11,6 +11,21 @@ test("shows OKW facility detail (mocked)", async ({ page }, testInfo) => {
   await expect(page.getByText("Laser Cutter")).toBeVisible();
 });
 
+test("lists the designs the facility can make and links to them (mocked)", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "asserts fixture data");
+  await page.goto("/facilities/okw-1");
+  await expect(
+    page.getByRole("heading", { name: /designs this facility can make/i }),
+  ).toBeVisible();
+  // Reverse-match result links into the design detail.
+  const link = page.getByRole("link", { name: /open ventilator/i });
+  await expect(link).toBeVisible();
+  await link.click();
+  await expect(page).toHaveURL(/\/okh\/okh-0001/);
+});
+
 test("validate surfaces a validation result (mocked)", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name === "real-api", "uses fixtures");
   await page.goto("/facilities/okw-1");

--- a/frontend/src/api/ohm/client.ts
+++ b/frontend/src/api/ohm/client.ts
@@ -21,8 +21,13 @@ const origin =
     ? window.location.origin
     : "http://localhost";
 
+/** Versioned API base (origin + /v1). Exported for the rare call that must
+ * bypass the generated client — e.g. an endpoint not yet in the committed
+ * schema. Prefer `apiClient` (typed) for everything covered by the spec. */
+export const apiBaseUrl = `${origin}/v1`;
+
 export const apiClient = createClient<paths>({
-  baseUrl: `${origin}/v1`,
+  baseUrl: apiBaseUrl,
   // Defer to the *current* global fetch on each call rather than the reference
   // captured at module load, so test-time interceptors (MSW) that replace
   // globalThis.fetch after import are honored. No-op difference in the browser.

--- a/frontend/src/api/ohm/match.test.ts
+++ b/frontend/src/api/ohm/match.test.ts
@@ -2,7 +2,7 @@ import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
 import { server } from "../../test/msw/server";
 import { ApiError } from "./client";
-import { runMatch } from "./match";
+import { runMatch, fetchDesignsForFacility } from "./match";
 
 describe("runMatch", () => {
   it("posts okh_id and returns the raw envelope", async () => {
@@ -25,5 +25,37 @@ describe("runMatch", () => {
       ),
     );
     await expect(runMatch({ okhId: "x" })).rejects.toBeInstanceOf(ApiError);
+  });
+});
+
+describe("fetchDesignsForFacility", () => {
+  it("posts okw_id and narrows the data envelope to ranked designs", async () => {
+    let body: { okw_id?: string; min_confidence?: number } | null = null;
+    server.use(
+      http.post("*/v1/api/match/facility", async ({ request }) => {
+        body = (await request.json()) as { okw_id?: string; min_confidence?: number };
+        return HttpResponse.json({
+          data: {
+            facility_name: "Laser Fab Lab",
+            designs: [{ okh_id: "okh-0001", okh_title: "Open Ventilator", confidence: 0.9, rank: 1 }],
+            total_designs: 1,
+          },
+        });
+      }),
+    );
+    const res = await fetchDesignsForFacility("okw-1");
+    expect(body!.okw_id).toBe("okw-1");
+    expect(body!.min_confidence).toBe(0.1);
+    expect(res.facility_name).toBe("Laser Fab Lab");
+    expect(res.designs.map((d) => d.okh_title)).toContain("Open Ventilator");
+  });
+
+  it("throws ApiError on failure", async () => {
+    server.use(
+      http.post("*/v1/api/match/facility", () =>
+        HttpResponse.json({ detail: "nope" }, { status: 404 }),
+      ),
+    );
+    await expect(fetchDesignsForFacility("missing")).rejects.toBeInstanceOf(ApiError);
   });
 });

--- a/frontend/src/api/ohm/match.ts
+++ b/frontend/src/api/ohm/match.ts
@@ -1,4 +1,4 @@
-import { apiClient, ApiError, errorMessage } from "./client";
+import { apiBaseUrl, apiClient, ApiError, errorMessage } from "./client";
 
 export interface RunMatchParams {
   okhId: string;
@@ -64,4 +64,53 @@ export async function runMatch(params: RunMatchParams): Promise<RawMatchResponse
     );
   }
   return (data ?? {}) as RawMatchResponse;
+}
+
+/** A design a facility can produce (reverse-match result row). */
+export interface FacilityDesign {
+  okh_id: string;
+  okh_title: string | null;
+  confidence: number;
+  rank: number;
+}
+
+export interface FacilityDesignsResult {
+  facility_name: string | null;
+  designs: FacilityDesign[];
+  total_designs: number;
+}
+
+/**
+ * Reverse match: the designs a facility can produce, ranked by confidence.
+ *
+ * Uses a raw fetch (not the generated client) because POST /api/match/facility
+ * is newer than the committed OpenAPI schema; swap to `apiClient` once the
+ * schema is regenerated. Goes through globalThis.fetch so MSW still intercepts.
+ */
+export async function fetchDesignsForFacility(
+  okwId: string,
+  opts: { minConfidence?: number; maxResults?: number } = {},
+): Promise<FacilityDesignsResult> {
+  const response = await globalThis.fetch(`${apiBaseUrl}/api/match/facility`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      okw_id: okwId,
+      min_confidence: opts.minConfidence ?? 0.1,
+      max_results: opts.maxResults ?? 10,
+    }),
+  });
+  const body = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new ApiError(
+      response.status,
+      errorMessage(body, `Failed to load producible designs (HTTP ${response.status})`),
+    );
+  }
+  const data = (body as { data?: Partial<FacilityDesignsResult> })?.data ?? {};
+  return {
+    facility_name: data.facility_name ?? null,
+    designs: (data.designs ?? []) as FacilityDesign[],
+    total_designs: data.total_designs ?? (data.designs?.length ?? 0),
+  };
 }

--- a/frontend/src/features/okw/FacilityDesigns.tsx
+++ b/frontend/src/features/okw/FacilityDesigns.tsx
@@ -1,0 +1,66 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { fetchDesignsForFacility } from "../../api/ohm/match";
+import { LoadingState, EmptyState, ErrorState } from "../../components/ui/states";
+import { Badge } from "../../components/ui/Badge";
+
+/**
+ * "Designs this facility can make" — reverse matching (review #7). Runs the
+ * design catalog against this one facility and lists the producible designs,
+ * ranked by confidence, each linking to the design detail.
+ */
+export function FacilityDesigns({ okwId }: { okwId: string }) {
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: ["facility-designs", okwId],
+    queryFn: () => fetchDesignsForFacility(okwId),
+    staleTime: 60_000,
+  });
+
+  const designs = data?.designs ?? [];
+
+  return (
+    <section className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900">
+      <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        Designs this facility can make
+      </h2>
+
+      {isLoading && <LoadingState message="Checking which designs this facility can make…" />}
+      {isError && (
+        <ErrorState
+          description={error instanceof Error ? error.message : "Failed to load producible designs."}
+          onRetry={() => refetch()}
+        />
+      )}
+
+      {!isLoading && !isError && designs.length === 0 && (
+        <EmptyState
+          icon="🔍"
+          title="No producible designs found"
+          description="None of the catalog designs currently match this facility’s capabilities."
+        />
+      )}
+
+      {!isLoading && !isError && designs.length > 0 && (
+        <ul className="space-y-2">
+          {designs.map((d) => (
+            <li key={d.okh_id}>
+              <Link
+                to={`/okh/${d.okh_id}`}
+                className="group flex items-center justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 no-underline hover:border-indigo-300 hover:bg-indigo-50/40 dark:border-slate-700 dark:hover:border-indigo-700 dark:hover:bg-indigo-950/20"
+              >
+                <span className="text-sm font-medium text-slate-700 group-hover:text-indigo-600 dark:text-slate-200 dark:group-hover:text-indigo-400">
+                  {d.okh_title || d.okh_id}
+                </span>
+                <Badge
+                  variant={d.confidence >= 0.8 ? "green" : d.confidence >= 0.5 ? "yellow" : "red"}
+                >
+                  {Math.round(d.confidence * 100)}%
+                </Badge>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/features/okw/OkwDetailView.tsx
+++ b/frontend/src/features/okw/OkwDetailView.tsx
@@ -7,6 +7,7 @@ import { Button } from "../../components/ui/button";
 import { Badge } from "../../components/ui/Badge";
 import type { OkwFacility } from "../../types/okw";
 import { humanizeProcess } from "./processDisplay";
+import { FacilityDesigns } from "./FacilityDesigns";
 
 function locationLabel(f: OkwFacility): string | null {
   const a = f.location?.address;
@@ -174,6 +175,8 @@ export function OkwDetailView({ id }: { id: string }) {
           </div>
         </section>
       )}
+
+      <FacilityDesigns okwId={id} />
     </div>
   );
 }

--- a/frontend/src/test/fixtures/index.ts
+++ b/frontend/src/test/fixtures/index.ts
@@ -148,6 +148,24 @@ export const okwDetailFixture = {
 };
 
 /** Match response envelope: solutions + summary + coverage gaps under `data`. */
+/** Reverse-match: designs a facility can produce (data.designs[]). */
+export const facilityDesignsFixture = {
+  data: {
+    okw_id: "okw-1",
+    facility_name: "Laser Fab Lab",
+    designs: [
+      { okh_id: "okh-0001", okh_title: "Open Ventilator", confidence: 0.95, rank: 1 },
+      { okh_id: "okh-0002", okh_title: "Face Shield", confidence: 0.62, rank: 2 },
+    ],
+    total_designs: 2,
+    designs_considered: 3,
+  },
+};
+
+export const facilityDesignsEmptyFixture = {
+  data: { okw_id: "okw-1", facility_name: "Laser Fab Lab", designs: [], total_designs: 0, designs_considered: 3 },
+};
+
 export const matchResponseFixture = {
   data: {
     solutions: [
@@ -268,6 +286,7 @@ export const fixturesByPath: Record<string, unknown> = {
   "/v1/api/okw/okw-1": okwDetailFixture,
   "/v1/api/okw/validate": validationResultFixture,
   "/v1/api/match": matchResponseFixture,
+  "/v1/api/match/facility": facilityDesignsFixture,
   "/v1/api/supply-tree/solutions": solutionsListFixture,
   "/v1/api/supply-tree/solution/sol-1/visualization": vizBundleFixture,
 };

--- a/frontend/src/test/msw/handlers.ts
+++ b/frontend/src/test/msw/handlers.ts
@@ -4,6 +4,7 @@ import {
   healthFixture,
   metricsFixture,
   matchResponseFixture,
+  facilityDesignsFixture,
   solutionsListFixture,
   vizBundleFixture,
   okhDetailFixture,
@@ -25,6 +26,7 @@ export const handlers = [
   http.get("*/v1/api/okw/search", () => HttpResponse.json(okwSearchFixture)),
   http.get("*/v1/api/okw/:id", () => HttpResponse.json(okwDetailFixture)),
   http.post("*/v1/api/okw/validate", () => HttpResponse.json(validationResultFixture)),
+  http.post("*/v1/api/match/facility", () => HttpResponse.json(facilityDesignsFixture)),
   http.post("*/v1/api/match", () => HttpResponse.json(matchResponseFixture)),
   http.get("*/v1/api/supply-tree/solutions", () => HttpResponse.json(solutionsListFixture)),
   http.get("*/v1/api/supply-tree/solution/:id/visualization", () =>


### PR DESCRIPTION
## What

The consumer of the reverse-match endpoint (review note #7): a **"Designs this facility can make"** section on the OKW detail page. It lists the designs the facility can produce, ranked by confidence, each linking into the design detail.

## Changes

- **`fetchDesignsForFacility(okwId)`** posts `/api/match/facility` and narrows the `data` envelope to `{facility_name, designs[{okh_id, okh_title, confidence, rank}], total_designs}`. It uses a raw `globalThis.fetch` (still MSW-interceptable) rather than the generated client, because the endpoint is **newer than the committed OpenAPI schema**; `apiBaseUrl` is now exported from the client for exactly this escape hatch. Swap to the typed client once the schema is regenerated post-deploy.
- **`FacilityDesigns`** section component with full loading / empty / error states; wired into `OkwDetailView` below equipment/certifications.
- Fixtures + MSW handler + Playwright path for `/api/match/facility` (populated and empty variants); `fetchDesignsForFacility` unit tests + a mocked E2E asserting the list renders and links to `/okh/:id`.

## Verification

`make frontend-ready` — all stages green (67 unit, 47 E2E incl. the new reverse-match section case, axe, build, screenshots).

## Depends on

Backend reverse-match endpoint — PR #223. Until it's deployed, the section shows its error state (endpoint 404/unavailable) but doesn't break the rest of the detail page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)