### PR TITLE
feat(okw): typed coordinate accessor + structured lat/lon in API

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 435
+Total Python files: 436
 
 ├── deploy/
 │   ├── __init__.py
@@ -1134,7 +1134,8 @@ Total Python files: 435
 │       │   │       class BatchSize
 │       │   │       class Address (to_dict)
 │       │   │       class What3Words
-│       │   │       class Location (to_dict)
+│       │   │       class Coordinates (to_dict)
+│       │   │       class Location (coordinates, to_dict)
 │       │   │       class Contact (to_dict)
 │       │   │       class SocialMedia (to_dict)
 │       │   │       class Agent (to_dict)
@@ -1145,6 +1146,7 @@ Total Python files: 435
 │       │   │       class Equipment (to_dict)
 │       │   │       class RecordData (to_dict)
 │       │   │       class ManufacturingFacility (to_dict, from_dict, validate...)
+│       │   │       def parse_decimal_degrees()
 │       │   ├── package.py
 │       │   │       class BuildOptions (to_dict, from_dict)
 │       │   │       class FileInfo (to_dict, from_dict)
@@ -1928,6 +1930,14 @@ Total Python files: 435
         │       def test_is_okh_bom_sidecar_bom_json_filename()
         │       def test_minimal_okh_manifest_dict_rejects_bom_only()
         │       def test_minimal_okh_manifest_dict_accepts_full_minimal_okh()
+        ├── test_okw_coordinates.py
+        │       def test_parse_valid_decimal_degrees()
+        │       def test_parse_invalid_returns_none()
+        │       def test_location_accessor_matches_parser()
+        │       def test_location_without_coords_returns_none()
+        │       def test_to_dict_emits_structured_coordinates()
+        │       def test_to_dict_omits_coordinates_when_absent_or_invalid()
+        │       def test_spaceapi_uses_the_shared_accessor()
         ├── test_okw_id_subset_filtering.py
         │       def _make_facility()
         │       def _patch_for_filtered_facilities()
@@ -2031,7 +2041,7 @@ Total Python files: 435
 
 ## Overview
 
-Total files analyzed: 435
+Total files analyzed: 436
 
 ## Entry Points
 
@@ -3465,8 +3475,11 @@ Provides structured and human-readable...
   - Location address information...
 - `What3Words`
   - What3Words geolocation reference...
-- `Location`
+- `Coordinates`
   - Methods: to_dict
+  - Geographic coordinates parsed from the OKW decimal-degrees string....
+- `Location`
+  - Methods: coordinates, to_dict
   - Location information with multiple addressing options...
 - `Contact`
   - Methods: to_dict
@@ -3498,6 +3511,12 @@ Provides structured and human-readable...
 - `ManufacturingFacility`
   - Methods: to_dict, from_dict, validate, from_toml, to_toml
   - Primary OKW Manufacturing Facility class...
+
+**Functions:**
+- `parse_decimal_degrees(value)`
+  - Parse an OKW ``gps_coordinates`` string into typed ``Coordinates``.
+
+The OKW sta...
 
 ### `src/core/models/package.py`
 
@@ -7999,6 +8018,22 @@ no MATCHING_LOCA...
 - `test_minimal_okh_manifest_dict_accepts_full_minimal_okh()`
 
 **Internal Dependencies:** 2 imports
+
+### `tests/unit/test_okw_coordinates.py`
+> Unit tests for OKW geographic coordinates (dashboard map, review #1).
+
+The OKW standard stores GPS c...
+
+**Exports:** test_parse_valid_decimal_degrees, test_parse_invalid_returns_none, test_location_accessor_matches_parser, test_location_without_coords_returns_none, test_to_dict_emits_structured_coordinates
+
+**Functions:**
+- `test_parse_valid_decimal_degrees(value, expected)`
+- `test_parse_invalid_returns_none(value)`
+- `test_location_accessor_matches_parser()`
+- `test_location_without_coords_returns_none()`
+- `test_to_dict_emits_structured_coordinates()`
+
+**Internal Dependencies:** 5 imports
 
 ### `tests/unit/test_okw_id_subset_filtering.py`
 > Unit tests for the okw_ids facility-subset filter (web-ui review #4).

--- a/docs/models/okw-docs.md
+++ b/docs/models/okw-docs.md
@@ -131,16 +131,32 @@ class What3Words:
     language: str  # ISO 639-2 or ISO 639-3 language code
 
 @dataclass
+class Coordinates:
+    """Geographic coordinates parsed from the OKW decimal-degrees string."""
+    latitude: float
+    longitude: float
+    # to_dict() → {"lat": latitude, "lon": longitude}
+
+@dataclass
 class Location:
     """Location information with multiple addressing options"""
     address: Optional[Address] = None
-    gps_coordinates: Optional[str] = None  # Decimal degrees
+    gps_coordinates: Optional[str] = None  # Decimal degrees (spec: single string)
     directions: Optional[str] = None
     what3words: Optional[What3Words] = None
     city: Optional[str] = None
     country: Optional[str] = None
-    # to_dict() → delegates to Address.to_dict() and What3Words
+    # coordinates() → Optional[Coordinates]; the single typed accessor for the
+    #   decimal-degrees gps_coordinates string (None if absent/malformed/out-of-range).
+    # to_dict() → delegates to Address.to_dict() and What3Words, and additionally
+    #   emits a structured "coordinates": {"lat", "lon"} when gps_coordinates parses,
+    #   so consumers (e.g. the web map) get numeric lat/lon without re-parsing.
 ```
+
+The `gps_coordinates` string is the spec-compliant stored form (OKW standard §6.3,
+Decimal Degrees). `parse_decimal_degrees(value)` is the module-level helper behind
+`Location.coordinates()`; the MoM/SpaceAPI serialization (`to_spaceapi_json`) uses the
+same accessor so coordinate parsing lives in exactly one place.
 
 ### 4. Agent
 Person or organization associated with a facility.

--- a/src/core/api/routes/okw.py
+++ b/src/core/api/routes/okw.py
@@ -191,10 +191,12 @@ async def search_okw(
                             ),
                         }
                     ),
-                    "coordinates": {
-                        "latitude": getattr(facility.location, "latitude", None),
-                        "longitude": getattr(facility.location, "longitude", None),
-                    },
+                    "coordinates": (
+                        facility.location.coordinates().to_dict()
+                        if hasattr(facility.location, "coordinates")
+                        and facility.location.coordinates()
+                        else None
+                    ),
                 }
             )
 
@@ -560,10 +562,12 @@ async def list_okw(
                             ),
                         }
                     ),
-                    "coordinates": {
-                        "latitude": getattr(facility.location, "latitude", None),
-                        "longitude": getattr(facility.location, "longitude", None),
-                    },
+                    "coordinates": (
+                        facility.location.coordinates().to_dict()
+                        if hasattr(facility.location, "coordinates")
+                        and facility.location.coordinates()
+                        else None
+                    ),
                 }
             )
 

--- a/src/core/models/okw.py
+++ b/src/core/models/okw.py
@@ -59,6 +59,43 @@ class What3Words:
 
 
 @dataclass
+class Coordinates:
+    """Geographic coordinates parsed from the OKW decimal-degrees string."""
+
+    latitude: float
+    longitude: float
+
+    def to_dict(self) -> Dict:
+        """Serialize as {lat, lon} (matches the SpaceAPI/MoM convention)."""
+        return {"lat": self.latitude, "lon": self.longitude}
+
+
+def parse_decimal_degrees(value: Optional[str]) -> Optional["Coordinates"]:
+    """Parse an OKW ``gps_coordinates`` string into typed ``Coordinates``.
+
+    The OKW standard stores GPS coordinates as a single decimal-degrees string
+    (e.g. ``"42.3588, -71.0578"``). This is the one place that parsing lives, so
+    the map serialization and the MoM/SpaceAPI bridge don't each reinvent it.
+
+    Returns ``None`` when the value is absent, not a ``"lat, lon"`` pair, or out
+    of the valid latitude/longitude range.
+    """
+    if not value or not isinstance(value, str):
+        return None
+    parts = value.split(",")
+    if len(parts) != 2:
+        return None
+    try:
+        lat = float(parts[0].strip())
+        lon = float(parts[1].strip())
+    except (ValueError, TypeError):
+        return None
+    if not (-90.0 <= lat <= 90.0 and -180.0 <= lon <= 180.0):
+        return None
+    return Coordinates(latitude=lat, longitude=lon)
+
+
+@dataclass
 class Location:
     """Location information with multiple addressing options"""
 
@@ -70,6 +107,10 @@ class Location:
     region: Optional[str] = None
     country: Optional[str] = None
 
+    def coordinates(self) -> Optional["Coordinates"]:
+        """Typed view of ``gps_coordinates``; ``None`` if absent or unparseable."""
+        return parse_decimal_degrees(self.gps_coordinates)
+
     def to_dict(self) -> Dict:
         """Convert to dictionary"""
         result = {}
@@ -79,6 +120,11 @@ class Location:
                 result["address"] = addr_dict
         if self.gps_coordinates:
             result["gps_coordinates"] = self.gps_coordinates
+            # Structured coordinates alongside the raw spec string, so consumers
+            # (e.g. the web map) get numeric lat/lon without re-parsing.
+            coords = self.coordinates()
+            if coords:
+                result["coordinates"] = coords.to_dict()
         if self.directions:
             result["directions"] = self.directions
         if self.what3words:
@@ -893,15 +939,9 @@ class ManufacturingFacility:
             "state": {"open": self.facility_status == FacilityStatus.ACTIVE},
         }
 
-        if self.location.gps_coordinates:
-            try:
-                lat_str, lon_str = self.location.gps_coordinates.split(",", 1)
-                doc["location"] = {
-                    "lat": float(lat_str.strip()),
-                    "lon": float(lon_str.strip()),
-                }
-            except (ValueError, AttributeError):
-                pass
+        coords = self.location.coordinates()
+        if coords:
+            doc["location"] = {"lat": coords.latitude, "lon": coords.longitude}
 
         if self.description:
             doc["description"] = self.description

--- a/tests/unit/test_okw_coordinates.py
+++ b/tests/unit/test_okw_coordinates.py
@@ -1,0 +1,98 @@
+"""Unit tests for OKW geographic coordinates (dashboard map, review #1).
+
+The OKW standard stores GPS coordinates as a single decimal-degrees string.
+`parse_decimal_degrees` / `Location.coordinates()` is the one typed accessor for
+it, and `Location.to_dict()` surfaces a structured `{lat, lon}` for the web map.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.core.models.okw import (  # noqa: E402
+    Coordinates,
+    Location,
+    parse_decimal_degrees,
+)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("42.3588, -71.0578", Coordinates(42.3588, -71.0578)),
+        ("  42.0 ,  -71.0 ", Coordinates(42.0, -71.0)),  # tolerant of whitespace
+        ("0, 0", Coordinates(0.0, 0.0)),
+        ("-33.8688, 151.2093", Coordinates(-33.8688, 151.2093)),
+    ],
+)
+def test_parse_valid_decimal_degrees(value, expected):
+    assert parse_decimal_degrees(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        "",
+        "not coordinates",
+        "42.0",  # only one component
+        "42.0, -71.0, 5",  # three components
+        "abc, def",
+        "91, 0",  # latitude out of range
+        "0, 181",  # longitude out of range
+        "-90.1, 0",
+    ],
+)
+def test_parse_invalid_returns_none(value):
+    assert parse_decimal_degrees(value) is None
+
+
+def test_location_accessor_matches_parser():
+    loc = Location(gps_coordinates="42.3588, -71.0578")
+    assert loc.coordinates() == Coordinates(42.3588, -71.0578)
+
+
+def test_location_without_coords_returns_none():
+    assert Location(city="Boston").coordinates() is None
+
+
+def test_to_dict_emits_structured_coordinates():
+    loc = Location(gps_coordinates="42.3588, -71.0578", city="Boston")
+    d = loc.to_dict()
+    assert d["coordinates"] == {"lat": 42.3588, "lon": -71.0578}
+    # Raw spec string is retained alongside the structured form.
+    assert d["gps_coordinates"] == "42.3588, -71.0578"
+
+
+def test_to_dict_omits_coordinates_when_absent_or_invalid():
+    assert "coordinates" not in Location(city="Boston").to_dict()
+    assert "coordinates" not in Location(gps_coordinates="garbage").to_dict()
+
+
+def test_spaceapi_uses_the_shared_accessor():
+    """MoM/SpaceAPI serialization goes through the same parser (no duplicate)."""
+    from src.core.models.okw import FacilityStatus, ManufacturingFacility
+
+    with_coords = ManufacturingFacility(
+        name="FabLab",
+        location=Location(gps_coordinates="42.3588, -71.0578"),
+        facility_status=FacilityStatus.ACTIVE,
+    )
+    assert with_coords.to_spaceapi_json()["location"] == {
+        "lat": 42.3588,
+        "lon": -71.0578,
+    }
+
+    without = ManufacturingFacility(
+        name="NoCoords",
+        location=Location(city="Boston"),
+        facility_status=FacilityStatus.ACTIVE,
+    )
+    assert "location" not in without.to_spaceapi_json()


### PR DESCRIPTION
## What

Groundwork for the dashboard geographic map (review note #1): give OKW facilities a single, tested way to surface their location as numeric lat/lon, so the web map can plot them without re-parsing strings.

Turns out the OKW route already *tried* to expose coordinates (`getattr(facility.location, "latitude"/"longitude", None)`) — but `Location` has no such attributes, so it was **always `None`**. This makes that latent intent actually work.

## Changes

- **`Coordinates`** value object + **`parse_decimal_degrees()`** helper + **`Location.coordinates()`** accessor — the one place that parses the OKW spec's decimal-degrees `gps_coordinates` string. Returns `None` if absent, not a `"lat, lon"` pair, or out of latitude/longitude range.
- **`Location.to_dict()`** now emits a structured `"coordinates": {lat, lon}` alongside the raw spec string, so OKW search/detail responses carry numeric coordinates.
- Refactored **`to_spaceapi_json()`** (MoM bridge) to use the accessor — removes the duplicated ad-hoc `split`/`try-except`.
- Fixed the OKW route's **dead coordinates branch** (read a non-existent `location.latitude/longitude`); now uses the accessor.
- Unit tests: parser (valid / whitespace / malformed / out-of-range / absent), `to_dict` emission, and the SpaceAPI path sharing the accessor.

## Design notes

- `gps_coordinates` stays the **spec-compliant stored form** (OKW §6.3, Decimal Degrees) — this adds a *derived typed view*, **no data migration** (per the agreed approach).
- Two larger OKW cohesion issues found during review are **intentionally deferred** to their own focused tasks (recorded in the planning backlog): the `Location` vs `Address` city/region/country redundancy (non-spec, has match-filter blast radius), and the `from_dict`/`to_dict` round-trip asymmetry.

## Verification

`make ready` — all gates green (553 passed, parity 4/4, docs ✓).

Next: the dashboard rework (map hero + network stats + getting-started) lands on `frontend-dev` and consumes `location.coordinates`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)