### PR TITLE
feat(okw): network map endpoint — local facilities ∪ Maps of Making

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 436
+Total Python files: 438
 
 ├── deploy/
 │   ├── __init__.py
@@ -1272,6 +1272,7 @@ Total Python files: 436
 │       │   ├── matching_service.py
 │       │   │       class MatchingService (__init__, _normalize_req_cap_lists, _normalize_capability_list...)
 │       │   ├── mom_bridge.py
+│       │   │       class MoMSpacesCache (__init__, is_fresh, invalidate)
 │       │   ├── okh_service.py
 │       │   │       class OKHService (__init__)
 │       │   ├── okw_service.py
@@ -1679,6 +1680,9 @@ Total Python files: 436
     │   │       def _classify()
     │   │       def test_matching_ab_report_remote_okw()
     │   ├── test_matching_baseline.py
+    │   ├── test_okw_map_route.py
+    │   │       def _facility_content()
+    │   │       def test_map_local_only_returns_source_labeled_points()
     │   ├── test_reverse_facility_match_route.py
     │   │       def _facility_content()
     │   │       def test_reverse_match_unknown_facility_returns_404()
@@ -1944,6 +1948,11 @@ Total Python files: 436
         │       def _request()
         │       def test_parse_match_filters_populates_okw_ids()
         │       def test_parse_match_filters_omits_okw_ids_when_empty()
+        ├── test_okw_map.py
+        │       class _FakeResponse (__init__, raise_for_status, json)
+        │       class _FakeClient (__init__)
+        │       def _bindings()
+        │       def _facility()
         ├── test_package_pin.py
         │       def _sha256()
         │       def _build_fake_package()
@@ -2041,7 +2050,7 @@ Total Python files: 436
 
 ## Overview
 
-Total files analyzed: 436
+Total files analyzed: 438
 
 ## Entry Points
 
@@ -2340,6 +2349,15 @@ Orchestrates direc...
 
 ### `src/core/services/mom_bridge.py`
 > MoM SPARQL bridge — query Maps of Making for spaces matching an OHM process....
+
+**Exports:** MoMSpacesCache
+
+**Classes:**
+- `MoMSpacesCache`
+  - Methods: is_fresh, invalidate
+  - TTL cache for the MoM all-spaces map layer.
+
+Serves the last successful fetch fo...
 
 ### `src/core/services/okh_service.py`
 
@@ -7608,6 +7626,16 @@ Uses a minima...
 
 **Internal Dependencies:** 4 imports
 
+### `tests/integration/test_okw_map_route.py`
+> Integration test for GET /api/okw/map (network map, review #1).
+
+Runs the full ASGI app in-process. ...
+
+**Exports:** test_map_local_only_returns_source_labeled_points
+
+**Functions:**
+- `test_map_local_only_returns_source_labeled_points(client)`
+
 ### `tests/integration/test_reverse_facility_match_route.py`
 > Integration tests for POST /api/match/facility (reverse matching, review #7).
 
@@ -8047,6 +8075,18 @@ A caller can pre-select which...
 - `test_parse_match_filters_omits_okw_ids_when_empty()`
 
 **Internal Dependencies:** 11 imports
+
+### `tests/unit/test_okw_map.py`
+> Unit tests for the OKW network map: MoM all-spaces fetch, TTL cache, union.
+
+Covers `fetch_all_mom_s...
+
+**Classes:**
+- `_FakeResponse`
+  - Methods: raise_for_status, json
+- `_FakeClient`
+
+**Internal Dependencies:** 13 imports
 
 ### `tests/unit/test_package_pin.py`
 > Unit tests for OKH package pin record creation and verification (issue #174)....

--- a/docs/models/okw-docs.md
+++ b/docs/models/okw-docs.md
@@ -581,6 +581,25 @@ if facility.has_process("3d printing"):
 The check searches both `manufacturing_processes` URLs and equipment capability
 descriptions.
 
+## Network Map & Maps of Making
+
+`GET /api/okw/map` (and `ohm okw map`) return the point set for the web UI's
+network map: **local OKW facilities unioned with [Maps of Making](https://mapsofmaking.org)
+(MoM) spaces**. Each point is source-labeled — `{id, name, lat, lon, source}` with
+`source` in `{"local", "mom"}` — so the map layer is source-agnostic and can grow
+to further networks.
+
+- **Coordinates** come from `Location.coordinates()` (the decimal-degrees
+  accessor). Local facilities without parseable coordinates are counted in
+  `dropped_no_coords` rather than plotted.
+- **MoM** is fetched from a **24h TTL cache** (`MoMSpacesCache` in
+  `services/mom_bridge.py`) built on the existing SPARQL bridge. It **degrades
+  gracefully**: if MoM is unreachable the response is local-only with
+  `mom_available: false`, and a stale cache keeps serving until a refresh
+  succeeds. `mom_spaces_cache.refresh()` / `.invalidate()` are the cache-refresh
+  hooks other events can call; the endpoint's `force_refresh=true` (and CLI
+  `--refresh`) trigger a refresh on demand.
+
 ## CLI Commands
 
 | Command | Description |
@@ -593,6 +612,7 @@ descriptions.
 | `ohm okw export` | Export the OKW JSON Schema |
 | `ohm okw template` | Output a blank facility template |
 | `ohm okw create-interactive` | Interactively build a new facility |
+| `ohm okw map` | Network map points: local facilities ∪ Maps of Making (`--no-mom`, `--refresh`) |
 
 ## API Endpoints
 
@@ -600,6 +620,7 @@ descriptions.
 |---|---|---|
 | `GET` | `/api/okw/export` | Export OKW JSON Schema |
 | `GET` | `/api/okw/template` | Get blank facility template |
+| `GET` | `/api/okw/map` | Network map points (local OKW ∪ Maps of Making); `include_mom`, `force_refresh` |
 | `POST` | `/api/okw/create` | Create facility from JSON body |
 | `POST` | `/api/okw/validate` | Validate a facility dict |
 | `POST` | `/api/okw/upload` | Upload a facility file |

--- a/src/cli/okw.py
+++ b/src/cli/okw.py
@@ -498,6 +498,99 @@ async def list_facilities(
         raise
 
 
+@okw_group.command(name="map")
+@click.option(
+    "--no-mom",
+    is_flag=True,
+    help="Exclude Maps of Making; show local OKW facilities only.",
+)
+@click.option(
+    "--refresh",
+    is_flag=True,
+    help="Force a refresh of the MoM cache before building the map.",
+)
+@standard_cli_command(
+    help_text="""
+    List network map points: local OKW facilities unioned with Maps of Making.
+
+    Each point is source-labeled ("local" or "mom"). Local facilities without
+    coordinates are counted but not plotted. MoM is served from a 24h cache and
+    degrades gracefully — if it is unreachable you get local-only points.
+    """,
+    epilog="""
+    Examples:
+      ohm okw map                 # local + MoM
+      ohm okw map --no-mom        # local facilities only
+      ohm okw map --refresh       # force a MoM cache refresh first
+    """,
+    async_cmd=True,
+    track_performance=True,
+    handle_errors=True,
+    format_output=True,
+    add_llm_config=False,
+)
+@click.pass_context
+async def okw_map(
+    ctx,
+    no_mom: bool,
+    refresh: bool,
+    verbose: bool,
+    output_format: str,
+    use_llm: bool,
+    llm_provider: str,
+    llm_model: Optional[str],
+    quality_level: str,
+    strict_mode: bool,
+):
+    """List network map points (local OKW facilities ∪ Maps of Making)."""
+    cli_ctx = ctx.obj
+    cli_ctx.start_command_tracking("okw-map")
+    include_mom = not no_mom
+
+    try:
+
+        async def http_map():
+            cli_ctx.log("Fetching map points via HTTP API...", "info")
+            params = {
+                "include_mom": str(include_mom).lower(),
+                "force_refresh": str(refresh).lower(),
+            }
+            return await cli_ctx.api_client.request(
+                "GET", "/api/okw/map", params=params
+            )
+
+        async def fallback_map():
+            cli_ctx.log("Building map points via direct service...", "info")
+            okw_service = await OKWService.get_instance()
+            return await okw_service.get_map_points(
+                include_mom=include_mom, force_refresh=refresh
+            )
+
+        command = SmartCommand(cli_ctx)
+        result = await command.execute_with_fallback(http_map, fallback_map)
+        data = result.get("data", result) if isinstance(result, dict) else result
+
+        if output_format == "json":
+            click.echo(json.dumps(data, indent=2))
+        else:
+            mom_state = "available" if data.get("mom_available") else "unavailable"
+            click.echo(
+                f"🗺️  {len(data.get('points', []))} map points "
+                f"({data.get('local_count', 0)} local + {data.get('mom_count', 0)} MoM)"
+            )
+            dropped = data.get("dropped_no_coords", 0)
+            if dropped:
+                click.echo(f"   {dropped} local facility(ies) omitted (no coordinates)")
+            if include_mom:
+                click.echo(f"   Maps of Making: {mom_state}")
+
+        cli_ctx.end_command_tracking()
+
+    except Exception as e:
+        cli_ctx.log(f"Map build failed: {str(e)}", "error")
+        raise
+
+
 @okw_group.command()
 @click.argument("facility_id", type=str)
 @click.option("--force", is_flag=True, help="Force deletion without confirmation")

--- a/src/core/api/routes/okw.py
+++ b/src/core/api/routes/okw.py
@@ -393,6 +393,49 @@ async def get_okw_template(http_request: Request = None) -> Any:
     }
 
 
+@router.get(
+    "/map",
+    summary="Network map points (local OKW ∪ Maps of Making)",
+    description="""
+    Return source-labeled geographic points for the network map: local OKW
+    facilities unioned with Maps of Making (MoM) spaces.
+
+    Each point is `{id, name, lat, lon, source}` where `source` is `"local"` or
+    `"mom"`. Local facilities without parseable coordinates are counted in
+    `dropped_no_coords` rather than plotted. MoM is served from a 24h TTL cache
+    and degrades gracefully — if MoM is unreachable the response is local-only
+    with `mom_available: false`.
+
+    Query params:
+    - `include_mom` (default true): set false for a local-only map.
+    - `force_refresh` (default false): force a MoM cache refresh first.
+    """,
+)
+async def get_okw_map(
+    include_mom: bool = True,
+    force_refresh: bool = False,
+    okw_service: OKWService = Depends(get_okw_service),
+) -> Any:
+    """Return network-map points (local OKW facilities ∪ MoM spaces)."""
+    try:
+        data = await okw_service.get_map_points(
+            include_mom=include_mom, force_refresh=force_refresh
+        )
+        return {"success": True, **data}
+    except Exception as e:
+        error_response = create_error_response(
+            error=e,
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            request_id=None,
+            suggestion="Please try again or contact support if the issue persists",
+        )
+        logger.error(f"Error building OKW map points: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=error_response.model_dump(mode="json"),
+        )
+
+
 @router.get("/{id}", response_model=OKWResponse)
 async def get_okw(
     id: UUID = Path(..., title="The ID of the OKW facility"),

--- a/src/core/services/mom_bridge.py
+++ b/src/core/services/mom_bridge.py
@@ -2,11 +2,22 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
+import time
+from typing import Optional
+
 import httpx
 
 from ..taxonomy import taxonomy
 
+logger = logging.getLogger(__name__)
+
 MOM_SPARQL_ENDPOINT = "https://mapsofmaking.org/sparql/query"
+
+# 24h default TTL: MoM's space directory is slow-changing, and the all-spaces
+# query is heavy (thousands of rows), so we avoid re-querying on every map load.
+MOM_CACHE_TTL_SECONDS = 24 * 60 * 60
 
 _SPARQL_TEMPLATE = """
 SELECT DISTINCT ?space ?name ?lat ?lon WHERE {{
@@ -133,3 +144,121 @@ async def fetch_mom_facilities_for_manifest(
         )
         for data in space_data.values()
     ]
+
+
+# All spaces with geographic coordinates — for the network map (not filtered by
+# process, unlike the matching queries above).
+_ALL_SPACES_SPARQL = """
+SELECT DISTINCT ?space ?name ?lat ?lon WHERE {
+  GRAPH ?g {
+    ?space a <https://nicolasdb.github.io/mapsofmaking_ontology/ns#Space> ;
+           <https://schema.org/name> ?name ;
+           <https://schema.org/geo> [ <https://schema.org/latitude> ?lat ;
+                                       <https://schema.org/longitude> ?lon ] .
+  }
+}
+"""
+
+
+async def fetch_all_mom_spaces(
+    endpoint: str = MOM_SPARQL_ENDPOINT,
+    timeout: float = 20.0,
+) -> list[dict]:
+    """Fetch every MoM space that has geographic coordinates, for the map.
+
+    Args:
+        endpoint: MoM SPARQL endpoint URL.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        List of dicts with keys: space (IRI), name, lat, lon.
+
+    Raises:
+        httpx.HTTPError: If the endpoint is unreachable or returns an error. The
+            caller (cache) is responsible for graceful degradation; raising here
+            lets the cache distinguish a genuine empty result from a fetch
+            failure and keep serving stale data.
+    """
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.post(
+            endpoint,
+            data={"query": _ALL_SPACES_SPARQL},
+            headers={"Accept": "application/sparql-results+json"},
+        )
+    response.raise_for_status()
+
+    spaces: list[dict] = []
+    for b in response.json().get("results", {}).get("bindings", []):
+        try:
+            spaces.append(
+                {
+                    "space": b["space"]["value"],
+                    "name": b["name"]["value"],
+                    "lat": float(b["lat"]["value"]),
+                    "lon": float(b["lon"]["value"]),
+                }
+            )
+        except (KeyError, ValueError, TypeError):
+            # Skip malformed rows rather than failing the whole fetch.
+            continue
+    return spaces
+
+
+class MoMSpacesCache:
+    """TTL cache for the MoM all-spaces map layer.
+
+    Serves the last successful fetch for ``ttl_seconds`` (default 24h). On a
+    refresh failure it keeps serving stale data and reports ``available=True``
+    if any data was ever fetched, so the map degrades gracefully. Other events
+    (e.g. an admin action, a new facility) can force a refresh via
+    :meth:`refresh` or drop the cache via :meth:`invalidate`.
+    """
+
+    def __init__(self, ttl_seconds: float = MOM_CACHE_TTL_SECONDS) -> None:
+        self.ttl_seconds = ttl_seconds
+        self._data: Optional[list[dict]] = None
+        self._fetched_at: float = 0.0
+        self._lock = asyncio.Lock()
+
+    def is_fresh(self) -> bool:
+        return (
+            self._data is not None
+            and (time.monotonic() - self._fetched_at) < self.ttl_seconds
+        )
+
+    async def get(self, force_refresh: bool = False) -> tuple[list[dict], bool]:
+        """Return ``(spaces, available)``.
+
+        ``available`` is True when MoM data is present (fresh or stale). A single
+        in-flight refresh is serialized so a cold cache doesn't trigger a
+        thundering herd of SPARQL queries.
+        """
+        if force_refresh or not self.is_fresh():
+            async with self._lock:
+                # Re-check under the lock: another coroutine may have refreshed.
+                if force_refresh or not self.is_fresh():
+                    await self._refresh_locked()
+        return (self._data or [], self._data is not None)
+
+    async def refresh(self) -> bool:
+        """Force a refresh (the cache-refresh hook). Returns True on success."""
+        async with self._lock:
+            return await self._refresh_locked()
+
+    async def _refresh_locked(self) -> bool:
+        try:
+            self._data = await fetch_all_mom_spaces()
+            self._fetched_at = time.monotonic()
+            return True
+        except Exception as e:  # noqa: BLE001 — degrade gracefully, keep stale data
+            logger.warning("MoM all-spaces refresh failed; keeping stale data: %s", e)
+            return False
+
+    def invalidate(self) -> None:
+        """Drop cached data so the next ``get`` refetches (cache-refresh hook)."""
+        self._data = None
+        self._fetched_at = 0.0
+
+
+# Process-wide cache instance for the map layer.
+mom_spaces_cache = MoMSpacesCache()

--- a/src/core/services/okw_service.py
+++ b/src/core/services/okw_service.py
@@ -312,6 +312,81 @@ class OKWService(BaseService["OKWService"]):
         )
         return facilities
 
+    async def get_map_points(
+        self,
+        include_mom: bool = True,
+        force_refresh: bool = False,
+    ) -> Dict[str, Any]:
+        """Build the network-map point set: local OKW facilities ∪ MoM spaces.
+
+        Each point is source-labeled (``"local"`` or ``"mom"``) so the map layer
+        is source-agnostic and can grow to further networks. Local facilities
+        without parseable coordinates are counted (``dropped_no_coords``) rather
+        than plotted. MoM is fetched from a 24h TTL cache and degrades
+        gracefully: on an unreachable endpoint the map falls back to local-only
+        and ``mom_available`` is False.
+
+        Args:
+            include_mom: When False, skip the MoM layer entirely (local only).
+            force_refresh: Force a MoM cache refresh before building the set.
+
+        Returns:
+            Dict with ``points`` and summary counts + ``mom_available``.
+        """
+        # Local facilities (paginate through the full catalog).
+        local_points: List[Dict[str, Any]] = []
+        dropped_no_coords = 0
+        page = 1
+        page_size = 500
+        while True:
+            facilities, _ = await self.list(page=page, page_size=page_size)
+            if not facilities:
+                break
+            for f in facilities:
+                coords = f.location.coordinates() if f.location else None
+                if coords is None:
+                    dropped_no_coords += 1
+                    continue
+                local_points.append(
+                    {
+                        "id": str(f.id),
+                        "name": f.name,
+                        "lat": coords.latitude,
+                        "lon": coords.longitude,
+                        "source": "local",
+                    }
+                )
+            if len(facilities) < page_size:
+                break
+            page += 1
+
+        mom_points: List[Dict[str, Any]] = []
+        mom_available = False
+        if include_mom:
+            from .mom_bridge import mom_spaces_cache
+
+            spaces, mom_available = await mom_spaces_cache.get(
+                force_refresh=force_refresh
+            )
+            mom_points = [
+                {
+                    "id": s["space"],
+                    "name": s["name"],
+                    "lat": s["lat"],
+                    "lon": s["lon"],
+                    "source": "mom",
+                }
+                for s in spaces
+            ]
+
+        return {
+            "points": local_points + mom_points,
+            "local_count": len(local_points),
+            "mom_count": len(mom_points),
+            "dropped_no_coords": dropped_no_coords,
+            "mom_available": mom_available,
+        }
+
     async def list_kitchens(self) -> List[KitchenCapability]:
         """Return all kitchen capabilities found under the ``okw/`` prefix.
 

--- a/tests/integration/test_okw_map_route.py
+++ b/tests/integration/test_okw_map_route.py
@@ -1,0 +1,46 @@
+"""Integration test for GET /api/okw/map (network map, review #1).
+
+Runs the full ASGI app in-process. Uses include_mom=false so the endpoint stays
+offline (no MoM SPARQL call); the MoM union + cache behaviour is unit-tested
+separately in tests/unit/test_okw_map.py.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+pytestmark = pytest.mark.integration
+
+
+def _facility_content() -> dict:
+    data_dir = Path(__file__).resolve().parents[2] / "synthetic_data"
+    facility_file = sorted(data_dir.glob("*okw*.json"))[0]
+    return json.loads(facility_file.read_text(encoding="utf-8"))
+
+
+def test_map_local_only_returns_source_labeled_points(client):
+    created = client.post("/api/okw/create", json={"content": _facility_content()})
+    assert created.status_code == 201, created.text
+
+    resp = client.get("/api/okw/map", params={"include_mom": "false"})
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    assert data["success"] is True
+    assert data["mom_available"] is False
+    assert data["mom_count"] == 0
+    assert isinstance(data["points"], list)
+    # The synthetic facility carries gps_coordinates, so it plots as a local point.
+    assert data["local_count"] >= 1
+    for p in data["points"]:
+        assert p["source"] == "local"
+        assert {"id", "name", "lat", "lon", "source"} <= set(p)
+        assert isinstance(p["lat"], (int, float))
+        assert isinstance(p["lon"], (int, float))

--- a/tests/unit/test_okw_map.py
+++ b/tests/unit/test_okw_map.py
@@ -1,0 +1,278 @@
+"""Unit tests for the OKW network map: MoM all-spaces fetch, TTL cache, union.
+
+Covers `fetch_all_mom_spaces` parsing, `MoMSpacesCache` freshness/refresh/
+invalidate/graceful-degradation, and `OKWService.get_map_points` unioning local
+facilities with MoM points. All network + storage is mocked.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# fetch_all_mom_spaces — SPARQL JSON parsing
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, payload):
+        self._payload = payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def post(self, *args, **kwargs):
+        return _FakeResponse(self._payload)
+
+
+def _bindings(*rows):
+    return {
+        "results": {
+            "bindings": [
+                {
+                    "space": {"value": s},
+                    "name": {"value": n},
+                    "lat": {"value": str(lat)},
+                    "lon": {"value": str(lon)},
+                }
+                for (s, n, lat, lon) in rows
+            ]
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_mom_spaces_parses_rows(monkeypatch):
+    import src.core.services.mom_bridge as mom
+
+    payload = _bindings(
+        ("urn:mak:space/a", "Space A", 41.89, 12.51),
+        ("urn:mak:space/b", "Space B", 49.65, 11.03),
+    )
+    monkeypatch.setattr(mom.httpx, "AsyncClient", lambda *a, **k: _FakeClient(payload))
+
+    spaces = await mom.fetch_all_mom_spaces()
+    assert spaces == [
+        {"space": "urn:mak:space/a", "name": "Space A", "lat": 41.89, "lon": 12.51},
+        {"space": "urn:mak:space/b", "name": "Space B", "lat": 49.65, "lon": 11.03},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_mom_spaces_skips_malformed_rows(monkeypatch):
+    import src.core.services.mom_bridge as mom
+
+    payload = {
+        "results": {
+            "bindings": [
+                {
+                    "space": {"value": "ok"},
+                    "name": {"value": "N"},
+                    "lat": {"value": "1.0"},
+                    "lon": {"value": "2.0"},
+                },
+                {
+                    "space": {"value": "bad"},
+                    "name": {"value": "N"},
+                    "lat": {"value": "not-a-number"},
+                    "lon": {"value": "2.0"},
+                },
+                {
+                    "space": {"value": "missing-lon"},
+                    "name": {"value": "N"},
+                    "lat": {"value": "1.0"},
+                },
+            ]
+        }
+    }
+    monkeypatch.setattr(mom.httpx, "AsyncClient", lambda *a, **k: _FakeClient(payload))
+
+    spaces = await mom.fetch_all_mom_spaces()
+    assert [s["space"] for s in spaces] == ["ok"]
+
+
+# ---------------------------------------------------------------------------
+# MoMSpacesCache — TTL, refresh hook, invalidate, graceful degradation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_serves_fresh_without_refetching(monkeypatch):
+    from src.core.services.mom_bridge import MoMSpacesCache
+
+    calls = {"n": 0}
+
+    async def fake_fetch():
+        calls["n"] += 1
+        return [{"space": "x", "name": "X", "lat": 1.0, "lon": 2.0}]
+
+    monkeypatch.setattr("src.core.services.mom_bridge.fetch_all_mom_spaces", fake_fetch)
+
+    cache = MoMSpacesCache(ttl_seconds=1000)
+    spaces1, avail1 = await cache.get()
+    spaces2, avail2 = await cache.get()
+    assert avail1 and avail2
+    assert spaces1 == spaces2
+    assert calls["n"] == 1  # second get served from cache
+
+
+@pytest.mark.asyncio
+async def test_cache_refetches_when_stale(monkeypatch):
+    from src.core.services.mom_bridge import MoMSpacesCache
+
+    calls = {"n": 0}
+
+    async def fake_fetch():
+        calls["n"] += 1
+        return [{"space": "x", "name": "X", "lat": 1.0, "lon": 2.0}]
+
+    monkeypatch.setattr("src.core.services.mom_bridge.fetch_all_mom_spaces", fake_fetch)
+
+    cache = MoMSpacesCache(ttl_seconds=0)  # everything is immediately stale
+    await cache.get()
+    await cache.get()
+    assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_refresh_hook_forces_fetch_and_invalidate_clears(monkeypatch):
+    from src.core.services.mom_bridge import MoMSpacesCache
+
+    calls = {"n": 0}
+
+    async def fake_fetch():
+        calls["n"] += 1
+        return [{"space": "x", "name": "X", "lat": 1.0, "lon": 2.0}]
+
+    monkeypatch.setattr("src.core.services.mom_bridge.fetch_all_mom_spaces", fake_fetch)
+
+    cache = MoMSpacesCache(ttl_seconds=1000)
+    await cache.get()
+    assert calls["n"] == 1
+    assert await cache.refresh() is True  # hook forces refetch despite fresh TTL
+    assert calls["n"] == 2
+    cache.invalidate()
+    await cache.get()
+    assert calls["n"] == 3  # invalidate forced a refetch
+
+
+@pytest.mark.asyncio
+async def test_cache_keeps_stale_data_on_failure(monkeypatch):
+    from src.core.services.mom_bridge import MoMSpacesCache
+
+    state = {"fail": False}
+
+    async def fake_fetch():
+        if state["fail"]:
+            raise RuntimeError("MoM down")
+        return [{"space": "x", "name": "X", "lat": 1.0, "lon": 2.0}]
+
+    monkeypatch.setattr("src.core.services.mom_bridge.fetch_all_mom_spaces", fake_fetch)
+
+    cache = MoMSpacesCache(ttl_seconds=0)
+    good, avail = await cache.get()
+    assert avail and good
+    state["fail"] = True
+    stale, avail2 = await cache.get()  # refetch fails → keep stale, still available
+    assert stale == good
+    assert avail2 is True
+
+
+@pytest.mark.asyncio
+async def test_cache_unavailable_when_never_fetched(monkeypatch):
+    from src.core.services.mom_bridge import MoMSpacesCache
+
+    async def fake_fetch():
+        raise RuntimeError("MoM down")
+
+    monkeypatch.setattr("src.core.services.mom_bridge.fetch_all_mom_spaces", fake_fetch)
+
+    cache = MoMSpacesCache(ttl_seconds=0)
+    spaces, avail = await cache.get()
+    assert spaces == []
+    assert avail is False
+
+
+# ---------------------------------------------------------------------------
+# OKWService.get_map_points — union + source labels + dropped count
+# ---------------------------------------------------------------------------
+
+
+def _facility(fid, name, gps):
+    from src.core.models.okw import FacilityStatus, Location, ManufacturingFacility
+
+    return ManufacturingFacility(
+        name=name,
+        location=Location(gps_coordinates=gps),
+        facility_status=FacilityStatus.ACTIVE,
+        id=fid,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_map_points_unions_local_and_mom(monkeypatch):
+    from uuid import uuid4
+    from src.core.services.okw_service import OKWService
+    import src.core.services.mom_bridge as mom
+
+    svc = OKWService()
+    a_id, b_id = uuid4(), uuid4()
+    with_coords = _facility(a_id, "Local A", "40.0, -70.0")
+    without = _facility(b_id, "Local B", None)
+    svc.list = AsyncMock(return_value=([with_coords, without], 2))
+
+    async def fake_get(force_refresh=False):
+        return (
+            [{"space": "urn:mak:space/z", "name": "MoM Z", "lat": 1.0, "lon": 2.0}],
+            True,
+        )
+
+    monkeypatch.setattr(mom.mom_spaces_cache, "get", fake_get)
+
+    result = await svc.get_map_points()
+    assert result["local_count"] == 1
+    assert result["mom_count"] == 1
+    assert result["dropped_no_coords"] == 1
+    assert result["mom_available"] is True
+    sources = {p["source"] for p in result["points"]}
+    assert sources == {"local", "mom"}
+
+
+@pytest.mark.asyncio
+async def test_get_map_points_local_only_skips_mom(monkeypatch):
+    from uuid import uuid4
+    from src.core.services.okw_service import OKWService
+
+    svc = OKWService()
+    svc.list = AsyncMock(
+        return_value=([_facility(uuid4(), "Local A", "40.0, -70.0")], 1)
+    )
+
+    result = await svc.get_map_points(include_mom=False)
+    assert result["mom_count"] == 0
+    assert result["mom_available"] is False
+    assert all(p["source"] == "local" for p in result["points"])


### PR DESCRIPTION
## What

Backend for the dashboard geographic map (review note #1). The map's whole point is showing the network — but local data is only 79 facilities. **Maps of Making (MoM) has ~3,200 geolocated spaces**, already integrated with matching via SPARQL, so this unions the two into one source-agnostic point set and serves it to the map.

## Approach

Built on the existing `mom_bridge` SPARQL work rather than reinventing it. The union is server-side (keeps SPARQL off the browser, cacheable, source-agnostic), MoM loads by default, and the map degrades gracefully when MoM is unreachable.

## Changes

- **`mom_bridge`**: `fetch_all_mom_spaces()` (all spaces with geo — a non-process-filtered variant of the existing query) + **`MoMSpacesCache`**, a **24h TTL** cache that:
  - degrades gracefully — keeps serving **stale** data if a refresh fails, and only reports `mom_available: false` when nothing was ever fetched;
  - serializes concurrent refreshes (no thundering herd on a cold cache);
  - exposes **`refresh()` / `invalidate()`** as the cache-refresh **hooks** other events can trigger (plus `force_refresh` on the endpoint / `--refresh` on the CLI).
- **`OKWService.get_map_points()`**: source-labeled union `{id, name, lat, lon, source}` of local facilities (via the `Location.coordinates()` accessor from #226) + MoM spaces. Local facilities without coordinates are counted (`dropped_no_coords`), not plotted.
- **`GET /api/okw/map`** (`include_mom`, `force_refresh`) — registered **before** `/{id}` so `map` isn't captured as a facility id. Returns `points` + counts + `mom_available`.
- **CLI**: `ohm okw map` (`--no-mom`, `--refresh`), HTTP with direct-service fallback — parity.
- **Docs**: OKW model doc gains a network-map section + CLI/endpoint table rows.
- **Tests**: fetch parsing (incl. malformed-row skipping), cache (TTL / refresh / invalidate / stale-on-failure / never-fetched), union + source labels + dropped count (unit); endpoint local-only path (TestClient integration, no network).

## Verification

`make ready` — all gates green (563 passed, parity 4/4, docs ✓). MoM endpoint confirmed reachable during design (3,193 spaces with geo).

## Scope

This is the **read/display** slice of the documented "External network integration" epic. Admin enable/disable config for networks stays deferred to that epic. The frontend map (react-leaflet + clustering) consuming `/api/okw/map` lands next on `frontend-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)