### PR TITLE
feat(match): match a design against the filtered network (local ∪ MoM)

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -1282,6 +1282,7 @@ Total Python files: 438
 │       │   │       def _normalize_status()
 │       │   │       def _canonical_processes()
 │       │   │       def _local_facility_to_space()
+│       │   │       def _mom_stub_facility()
 │       │   │       def _mom_space_to_space()
 │       │   │       def _ci()
 │       │   │       def filter_network_spaces()
@@ -8113,7 +8114,7 @@ Covers the enriched M...
 - `test_local_only_axis_keeps_ambiguous_and_ranks_last()`
 - `test_local_only_axis_excludes_definite_non_match_keeps_ambiguous()`
 
-**Internal Dependencies:** 14 imports
+**Internal Dependencies:** 17 imports
 
 ### `tests/unit/test_package_pin.py`
 > Unit tests for OKH package pin record creation and verification (issue #174)....

--- a/docs/api/routes.md
+++ b/docs/api/routes.md
@@ -303,6 +303,27 @@ async def match_with_filters():
         return response.json()
 ```
 
+**Matching against the unified network (local ∪ Maps of Making):**
+
+Pass `network_filter` to match a design against the same filtered network the
+browse surface (`GET /api/okw/spaces`) shows — local OKW facilities unioned with
+Maps of Making spaces, narrowed by the given filters. MoM spaces match at the
+process level (they have no equipment detail), surfacing "spaces that claim these
+processes — worth contacting". Equivalent CLI: `ohm match requirements … --network --network-country FR`.
+
+```python
+async def match_against_network():
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            "http://localhost:8001/v1/api/match",
+            json={
+                "okh_id": "…",
+                "network_filter": {"include_mom": True, "country": "FR", "process": "laser_cutting"},
+            },
+        )
+        return response.json()
+```
+
 **Matching against a chosen subset of facilities:**
 
 Pass `okw_ids` to restrict matching to specific facilities the caller has already

--- a/src/cli/match.py
+++ b/src/cli/match.py
@@ -98,6 +98,18 @@ def match_group() -> None:
         "Omit to match against all facilities."
     ),
 )
+@click.option(
+    "--network",
+    is_flag=True,
+    help=(
+        "Match against the unified network (local OKW ∪ Maps of Making) instead of "
+        "just local facilities. Combine with --network-country / --network-process."
+    ),
+)
+@click.option("--network-country", help="Network match: filter to this country.")
+@click.option(
+    "--network-process", help="Network match: filter to this canonical process id."
+)
 @click.option("--location", help="Filter by location (city, country, or region)")
 @click.option(
     "--country", help="Filter facilities by country (exact match, case-insensitive)"
@@ -291,6 +303,9 @@ async def requirements(
     access_type: Optional[str],
     facility_status: Optional[str],
     okw_ids: tuple[str, ...],
+    network: bool,
+    network_country: Optional[str],
+    network_process: Optional[str],
     location: Optional[str],
     country: Optional[str],
     region: Optional[str],
@@ -384,6 +399,16 @@ async def requirements(
             max_results,
             okw_ids,
         )
+
+        # Network-match mode: match against local ∪ Maps of Making, optionally
+        # narrowed by country/process (same contract as GET /api/okw/spaces).
+        if network or network_country or network_process:
+            network_filter = {"include_mom": True}
+            if network_country:
+                network_filter["country"] = network_country
+            if network_process:
+                network_filter["process"] = network_process
+            filters["network_filter"] = network_filter
 
         # Add nested matching parameters
         nested_params = {

--- a/src/core/api/models/match/request.py
+++ b/src/core/api/models/match/request.py
@@ -209,6 +209,16 @@ class MatchRequest(BaseAPIRequest, LLMRequestMixin):
             "IDs before matching. An empty or omitted list means match against all facilities."
         ),
     )
+    network_filter: Optional[Dict[str, Any]] = Field(
+        None,
+        description=(
+            "Match against the unified network surface (local OKW ∪ Maps of Making) "
+            "narrowed by these filters — same keys as GET /api/okw/spaces "
+            "(include_mom, country, city, process, source, status, region, access_type). "
+            "When set, it supersedes the storage/okw_ids candidate pool so a design can "
+            "be matched against exactly the filtered set the network browse view shows."
+        ),
+    )
 
     model_config = ConfigDict(
         json_schema_extra={

--- a/src/core/api/routes/match.py
+++ b/src/core/api/routes/match.py
@@ -2387,6 +2387,36 @@ async def _get_filtered_facilities(
     candidate pool before matching begins.
     """
     try:
+        # Network-match mode: match against the unified network surface (local ∪
+        # MoM) narrowed by the same filters as the browse view. Supersedes the
+        # storage/okw_ids pool; the requirement-aware prefilter + candidate cap
+        # downstream keep the (potentially large MoM) pool bounded.
+        network_filter = getattr(request, "network_filter", None)
+        if network_filter:
+            allowed = {
+                "include_mom",
+                "force_refresh",
+                "country",
+                "city",
+                "process",
+                "source",
+                "status",
+                "region",
+                "access_type",
+            }
+            kwargs = {
+                k: v
+                for k, v in network_filter.items()
+                if k in allowed and v is not None
+            }
+            okw_service = await OKWService.get_instance()
+            facilities = await okw_service.get_network_match_facilities(**kwargs)
+            logger.info(
+                "Network-match candidate pool built",
+                extra={"request_id": request_id, "facility_count": len(facilities)},
+            )
+            return facilities
+
         if domain == "manufacturing":
             expected_type = ManufacturingFacility
             type_label = "ManufacturingFacility"

--- a/src/core/services/okw_service.py
+++ b/src/core/services/okw_service.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from uuid import UUID
 
 from ..domains.cooking.models import KitchenCapability
-from ..models.okw import ManufacturingFacility
+from ..models.okw import FacilityStatus, Location, ManufacturingFacility
 from ..storage.smart_discovery import SmartFileDiscovery
 from ..taxonomy import taxonomy
 from ..utils.logging import get_logger
@@ -71,6 +71,21 @@ def _local_facility_to_space(f: ManufacturingFacility) -> Optional[Dict[str, Any
         "access_type": f.access_type.value if getattr(f, "access_type", None) else None,
         "url": getattr(owner, "website", None),
     }
+
+
+def _mom_stub_facility(s: Dict[str, Any]) -> ManufacturingFacility:
+    """Build a matchable ManufacturingFacility stub from a cached MoM space.
+
+    MoM spaces have no equipment detail, so matching against them is process-level
+    (their canonical processes vs the design's requirements) — i.e. "spaces that
+    claim these processes, worth contacting".
+    """
+    return ManufacturingFacility(
+        name=s["name"],
+        location=Location(gps_coordinates=f"{s['lat']}, {s['lon']}"),
+        facility_status=FacilityStatus.ACTIVE,
+        manufacturing_processes=s.get("processes", []),
+    )
 
 
 def _mom_space_to_space(s: Dict[str, Any]) -> Dict[str, Any]:
@@ -472,7 +487,40 @@ class OKWService(BaseService["OKWService"]):
             Dict with ``spaces`` (filtered/ranked), ``total``, per-source counts,
             ``dropped_no_coords``, and ``mom_available``.
         """
-        local_spaces: List[Dict[str, Any]] = []
+        candidates, dropped_no_coords, mom_available = (
+            await self._load_network_candidates(
+                include_mom=include_mom, force_refresh=force_refresh
+            )
+        )
+        filtered = filter_network_spaces(
+            candidates,
+            country=country,
+            city=city,
+            process=process,
+            source=source,
+            status=status,
+            region=region,
+            access_type=access_type,
+        )
+        # Strip the internal facility back-reference from the browse payload.
+        spaces = [{k: v for k, v in sp.items() if k != "_facility"} for sp in filtered]
+        return {
+            "spaces": spaces,
+            "total": len(spaces),
+            "local_count": sum(1 for s in spaces if s["source"] == "local"),
+            "mom_count": sum(1 for s in spaces if s["source"] == "mom"),
+            "dropped_no_coords": dropped_no_coords,
+            "mom_available": mom_available,
+        }
+
+    async def _load_network_candidates(
+        self, *, include_mom: bool, force_refresh: bool
+    ) -> Tuple[List[Dict[str, Any]], int, bool]:
+        """Load local ∪ MoM as unified space dicts, each carrying its ``_facility``
+        (the matchable object) under a private key. Shared by the browse surface
+        and the network-match candidate pool so filtering stays identical.
+        """
+        candidates: List[Dict[str, Any]] = []
         dropped_no_coords = 0
         page = 1
         page_size = 500
@@ -484,22 +532,47 @@ class OKWService(BaseService["OKWService"]):
                 space = _local_facility_to_space(f)
                 if space is None:
                     dropped_no_coords += 1
-                else:
-                    local_spaces.append(space)
+                    continue
+                space["_facility"] = f
+                candidates.append(space)
             if len(facilities) < page_size:
                 break
             page += 1
 
-        mom_spaces: List[Dict[str, Any]] = []
         mom_available = False
         if include_mom:
             from .mom_bridge import mom_spaces_cache
 
             raw, mom_available = await mom_spaces_cache.get(force_refresh=force_refresh)
-            mom_spaces = [_mom_space_to_space(s) for s in raw]
+            for s in raw:
+                space = _mom_space_to_space(s)
+                space["_facility"] = _mom_stub_facility(s)
+                candidates.append(space)
 
+        return candidates, dropped_no_coords, mom_available
+
+    async def get_network_match_facilities(
+        self,
+        *,
+        include_mom: bool = True,
+        force_refresh: bool = False,
+        country: Optional[str] = None,
+        city: Optional[str] = None,
+        process: Optional[str] = None,
+        source: Optional[str] = None,
+        status: Optional[str] = None,
+        region: Optional[str] = None,
+        access_type: Optional[str] = None,
+    ) -> List[ManufacturingFacility]:
+        """Return the filtered network as matchable facilities (local full objects
+        ∪ MoM process stubs), for matching a design against the same filtered set
+        the browse surface shows. Uses the identical filter as ``get_network_spaces``.
+        """
+        candidates, _, _ = await self._load_network_candidates(
+            include_mom=include_mom, force_refresh=force_refresh
+        )
         filtered = filter_network_spaces(
-            local_spaces + mom_spaces,
+            candidates,
             country=country,
             city=city,
             process=process,
@@ -508,15 +581,7 @@ class OKWService(BaseService["OKWService"]):
             region=region,
             access_type=access_type,
         )
-
-        return {
-            "spaces": filtered,
-            "total": len(filtered),
-            "local_count": sum(1 for s in filtered if s["source"] == "local"),
-            "mom_count": sum(1 for s in filtered if s["source"] == "mom"),
-            "dropped_no_coords": dropped_no_coords,
-            "mom_available": mom_available,
-        }
+        return [sp["_facility"] for sp in filtered]
 
     async def list_kitchens(self) -> List[KitchenCapability]:
         """Return all kitchen capabilities found under the ``okw/`` prefix.

--- a/tests/unit/test_okw_spaces.py
+++ b/tests/unit/test_okw_spaces.py
@@ -328,3 +328,48 @@ async def test_get_network_spaces_applies_source_filter(monkeypatch):
     result = await svc.get_network_spaces(source="local")
     assert result["mom_count"] == 0
     assert all(s["source"] == "local" for s in result["spaces"])
+
+
+@pytest.mark.asyncio
+async def test_get_network_match_facilities_returns_facilities(monkeypatch):
+    from uuid import uuid4
+    from src.core.services.okw_service import OKWService
+    from src.core.models.okw import ManufacturingFacility
+    import src.core.services.mom_bridge as mom
+
+    svc = OKWService()
+    svc.list = AsyncMock(
+        return_value=([_facility(uuid4(), "Local A", "40.0, -70.0", [])], 1)
+    )
+
+    async def fake_get(force_refresh=False):
+        return (
+            [
+                {
+                    "space": "urn:z",
+                    "name": "MoM Z",
+                    "lat": 1.0,
+                    "lon": 2.0,
+                    "city": "Rome",
+                    "country": "IT",
+                    "status": "confirmed",
+                    "url": None,
+                    "processes": ["laser_cutting"],
+                }
+            ],
+            True,
+        )
+
+    monkeypatch.setattr(mom.mom_spaces_cache, "get", fake_get)
+
+    # Full network → both local + MoM as matchable ManufacturingFacility objects.
+    facilities = await svc.get_network_match_facilities()
+    assert all(isinstance(f, ManufacturingFacility) for f in facilities)
+    assert {f.name for f in facilities} == {"Local A", "MoM Z"}
+    # The MoM stub carries its canonical processes for process-level matching.
+    mom_stub = next(f for f in facilities if f.name == "MoM Z")
+    assert mom_stub.manufacturing_processes == ["laser_cutting"]
+
+    # source=local drops MoM from the candidate pool.
+    local_only = await svc.get_network_match_facilities(source="local")
+    assert [f.name for f in local_only] == ["Local A"]


### PR DESCRIPTION
Full network match — the "and matching" half of the network-filtering slice (#230, Option A). A design can be matched against the **same filtered network the browse surface shows**: local OKW facilities ∪ Maps of Making spaces.

## Changes

- **`MatchRequest.network_filter`** — same keys as `GET /api/okw/spaces` (`include_mom`, `country`, `city`, `process`, `source`, `status`, `region`, `access_type`). When set, `_get_filtered_facilities` builds the candidate pool from the filtered network and returns early. The existing **requirement-aware prefilter + `max_candidate_facilities` cap** downstream keep the (potentially ~3,200-space MoM) pool bounded.
- **`OKWService.get_network_match_facilities`** returns the filtered network as **matchable facilities**: local **full** objects ∪ MoM **process stubs** (`_mom_stub_facility`). It shares a `_load_network_candidates` loader with `get_network_spaces` — each unified space carries its `_facility` back-reference — so **browse and match filter identically** (same `filter_network_spaces`, same ambiguous/soft-filter behavior). MoM matches at the **process level** (no equipment detail): "spaces that claim these processes — worth contacting", exactly the contract-candidate use case.
- **CLI:** `ohm match requirements … --network [--network-country --network-process]`.
- Docs (network-match example) + unit tests (candidate pool = local ∪ MoM as facilities; `source` filter drops MoM; MoM stub carries canonical processes).

## Verification

`make ready` — 565 passed, parity 4/4, docs ✓. Leanness pass: my additions are F401/F811/F841-clean (the 12 the checker flags are pre-existing `except … as e` in match.py/cli, untouched).

## Scope

Backend. The frontend hand-off — a "Match a design against these" action on the network surface that carries the active filter into the match flow — is the **follow-on frontend PR**.

Refs #230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)