### PR TITLE
feat(frontend): "match a design against these" network hand-off

### DIFF
--- a/frontend/e2e/match.spec.ts
+++ b/frontend/e2e/match.spec.ts
@@ -86,3 +86,25 @@ test("with no facility subset the request omits okw_ids (matches all, mocked)", 
   await expect(page.getByRole("heading", { name: "FabLab Drome" })).toBeVisible();
   expect(body).not.toHaveProperty("okw_ids");
 });
+
+test("network mode sends network_filter and shows the banner (mocked)", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "inspects the request body");
+  let body: { network_filter?: Record<string, unknown> } | null = null;
+  await page.route("**/v1/api/match", async (route) => {
+    body = route.request().postDataJSON();
+    await route.fulfill({ json: matchResponseFixture });
+  });
+
+  // Arrive from the network surface's "Match against these" hand-off.
+  await page.goto("/match?network=1&country=FR&process=laser_cutting");
+  await expect(page.getByText(/matching against the network/i)).toBeVisible();
+  await expect(page.getByText(/country: FR/)).toBeVisible();
+
+  await page.getByLabel("Design to match").selectOption({ label: "Open Ventilator" });
+  await page.getByRole("button", { name: /run match/i }).click();
+
+  await expect(page.getByRole("heading", { name: "FabLab Drome" })).toBeVisible();
+  expect(body!.network_filter).toMatchObject({ country: "FR", process: "laser_cutting", include_mom: true });
+});

--- a/frontend/e2e/network.spec.ts
+++ b/frontend/e2e/network.spec.ts
@@ -68,6 +68,16 @@ test("shows the empty state (mocked)", async ({ page }, testInfo) => {
   await expect(page.getByText("No spaces are available yet.")).toBeVisible();
 });
 
+test("hands the active filter off to the match flow", async ({ page }) => {
+  await page.goto("/facilities");
+  await page.getByLabel("Source").selectOption("mom");
+  await page.getByRole("button", { name: /match a design against these/i }).click();
+  await expect(page).toHaveURL(/\/match\?.*network=1/);
+  await expect(page).toHaveURL(/source=mom/);
+  // The match view enters network mode.
+  await expect(page.getByText(/matching against the network/i)).toBeVisible();
+});
+
 test("shows the error state with retry (mocked)", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name === "real-api", "forces an error");
   await page.route("**/v1/api/okw/spaces**", (route) =>

--- a/frontend/e2e/okh-catalog.spec.ts
+++ b/frontend/e2e/okh-catalog.spec.ts
@@ -36,10 +36,19 @@ test("category facet is the primary spine and narrows results (mocked)", async (
 }, testInfo) => {
   test.skip(testInfo.project.name === "real-api", "asserts fixture data");
   await page.goto("/okh");
+  // Wait for the list (and thus the derived facets) to settle before touching a
+  // facet — otherwise the facet checkboxes can remount mid-click when the OKH
+  // query resolves, dropping the check.
+  await expect(page.getByRole("heading", { name: "Open Ventilator" })).toBeVisible();
   // Category is present as a facet group. Test Rig ("Calibration test rig") is
   // the only Test & Measurement device.
   await expect(page.getByRole("heading", { name: "Category" })).toBeVisible();
-  await page.getByRole("checkbox", { name: /Test & Measurement/ }).check();
+  // Retry until the check sticks: the facet can still remount as counts recompute,
+  // which otherwise drops the click ("did not change its state").
+  await expect(async () => {
+    await page.getByRole("checkbox", { name: /Test & Measurement/ }).check();
+    await expect(page).toHaveURL(/category=Test/);
+  }).toPass();
   await expect(page.getByRole("heading", { name: "Test Rig" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Open Ventilator" })).toBeHidden();
   await expect(page).toHaveURL(/category=Test/);

--- a/frontend/src/api/ohm/match.test.ts
+++ b/frontend/src/api/ohm/match.test.ts
@@ -18,6 +18,19 @@ describe("runMatch", () => {
     expect(res.data?.solutions).toEqual([]);
   });
 
+  it("sends network_filter for a network match", async () => {
+    let body: { network_filter?: Record<string, unknown>; okw_ids?: unknown } | null = null;
+    server.use(
+      http.post("*/v1/api/match", async ({ request }) => {
+        body = (await request.json()) as { network_filter?: Record<string, unknown> };
+        return HttpResponse.json({ data: { solutions: [] } });
+      }),
+    );
+    await runMatch({ okhId: "okh-1", okwIds: ["a"], networkFilter: { country: "FR", include_mom: true } });
+    expect(body!.network_filter).toEqual({ country: "FR", include_mom: true });
+    expect(body!.okw_ids).toBeUndefined(); // network filter supersedes the subset
+  });
+
   it("throws ApiError on failure", async () => {
     server.use(
       http.post("*/v1/api/match", () =>

--- a/frontend/src/api/ohm/match.ts
+++ b/frontend/src/api/ohm/match.ts
@@ -7,6 +7,8 @@ export interface RunMatchParams {
   strictMode?: boolean;
   /** Restrict matching to these facility IDs; empty/undefined means all. */
   okwIds?: string[];
+  /** Match against the filtered network (local ∪ MoM); supersedes okwIds. */
+  networkFilter?: Record<string, string | boolean>;
 }
 
 export interface RawSolution {
@@ -51,10 +53,12 @@ export async function runMatch(params: RunMatchParams): Promise<RawMatchResponse
       save_solution: true,
       quality_level: params.qualityLevel,
       strict_mode: params.strictMode,
-      // Omit when empty so the server matches against all facilities.
-      ...(params.okwIds && params.okwIds.length > 0
-        ? { okw_ids: params.okwIds }
-        : {}),
+      // Network match (local ∪ MoM) supersedes the local-id subset.
+      ...(params.networkFilter
+        ? { network_filter: params.networkFilter }
+        : params.okwIds && params.okwIds.length > 0
+          ? { okw_ids: params.okwIds }
+          : {}),
     } as never,
   });
   if (error || !response.ok) {

--- a/frontend/src/features/match/MatchView.tsx
+++ b/frontend/src/features/match/MatchView.tsx
@@ -10,9 +10,41 @@ import { FacilityFilter } from "./FacilityFilter";
 import { MatchResultCard } from "./MatchResultCard";
 import { LoadingState, EmptyState, ErrorState } from "../../components/ui/states";
 import { Button } from "../../components/ui/button";
+import { humanizeProcessId } from "../network/deriveFilterOptions";
 import { cn } from "@/lib/utils";
 
-export function MatchView({ okhId, autoRun }: { okhId?: string; autoRun?: boolean }) {
+const _AXIS_LABELS: Record<string, string> = {
+  country: "country",
+  city: "city",
+  process: "process",
+  source: "source",
+  status: "status",
+  region: "region",
+  access_type: "access",
+};
+
+/** Readable summary of an active network filter for the match banner. */
+function describeNetworkFilter(filter: Record<string, string | boolean>): string {
+  const parts = Object.entries(filter)
+    .filter(([key, value]) => key in _AXIS_LABELS && value)
+    .map(([key, value]) => {
+      const shown = key === "process" ? humanizeProcessId(String(value)) : String(value);
+      return `${_AXIS_LABELS[key]}: ${shown}`;
+    });
+  const scope = filter.include_mom === false ? "OHM facilities only" : "local ∪ Maps of Making";
+  return parts.length ? `${scope} — ${parts.join(" · ")}` : scope;
+}
+
+export function MatchView({
+  okhId,
+  autoRun,
+  networkFilter,
+}: {
+  okhId?: string;
+  autoRun?: boolean;
+  networkFilter?: Record<string, string | boolean>;
+}) {
+  const networkMode = !!networkFilter;
   const designs = useQuery({
     queryKey: ["okh-list"],
     queryFn: () => fetchOkhList({ page: 1, page_size: 100 }),
@@ -22,13 +54,15 @@ export function MatchView({ okhId, autoRun }: { okhId?: string; autoRun?: boolea
     queryKey: ["okw-search", "match-filter"],
     queryFn: () => searchOkw({ page: 1, page_size: 100 }),
     staleTime: 60_000,
+    // The local facility subset filter is superseded in network mode.
+    enabled: !networkMode,
   });
   const [selected, setSelected] = useState(okhId ?? "");
   const [mode, setMode] = useState<SystemMode>("standard");
   const [facilityIds, setFacilityIds] = useState<string[]>([]);
   const mutation = useMutation({
     mutationFn: ({ id, m, ids }: { id: string; m: SystemMode; ids: string[] }) =>
-      runMatch(buildMatchRequest(id, m, undefined, ids)),
+      runMatch(buildMatchRequest(id, m, undefined, ids, networkFilter)),
   });
   const view = useMemo(
     () => (mutation.data ? toMatchView(mutation.data) : null),
@@ -109,16 +143,27 @@ export function MatchView({ okhId, autoRun }: { okhId?: string; autoRun?: boolea
           )}
         </div>
 
-        <FacilityFilter
-          facilities={(facilitiesQuery.data?.results ?? []).map((f) => ({
-            id: f.id,
-            name: f.name,
-          }))}
-          selectedIds={facilityIds}
-          onChange={setFacilityIds}
-          isLoading={facilitiesQuery.isLoading}
-          isError={facilitiesQuery.isError}
-        />
+        {networkMode ? (
+          <div className="rounded-lg border border-indigo-200 bg-indigo-50/60 p-3 text-sm dark:border-indigo-800 dark:bg-indigo-950/30">
+            <p className="font-medium text-indigo-800 dark:text-indigo-300">
+              Matching against the network
+            </p>
+            <p className="mt-0.5 text-indigo-700 dark:text-indigo-400">
+              {describeNetworkFilter(networkFilter!)}
+            </p>
+          </div>
+        ) : (
+          <FacilityFilter
+            facilities={(facilitiesQuery.data?.results ?? []).map((f) => ({
+              id: f.id,
+              name: f.name,
+            }))}
+            selectedIds={facilityIds}
+            onChange={setFacilityIds}
+            isLoading={facilitiesQuery.isLoading}
+            isError={facilitiesQuery.isError}
+          />
+        )}
       </div>
 
       {mutation.isPending && <LoadingState message="Matching against facilities…" />}

--- a/frontend/src/features/match/matchRequest.test.ts
+++ b/frontend/src/features/match/matchRequest.test.ts
@@ -39,4 +39,13 @@ describe("buildMatchRequest", () => {
     expect(buildMatchRequest("okh-1", "standard", undefined, [])).not.toHaveProperty("okwIds");
     expect(buildMatchRequest("okh-1", "standard")).not.toHaveProperty("okwIds");
   });
+
+  it("a network filter supersedes okwIds", () => {
+    const req = buildMatchRequest("okh-1", "standard", undefined, ["a"], {
+      country: "FR",
+      include_mom: true,
+    });
+    expect(req.networkFilter).toEqual({ country: "FR", include_mom: true });
+    expect(req).not.toHaveProperty("okwIds");
+  });
 });

--- a/frontend/src/features/match/matchRequest.ts
+++ b/frontend/src/features/match/matchRequest.ts
@@ -47,7 +47,13 @@ export function buildMatchRequest(
   mode: SystemMode,
   maxResults?: number,
   okwIds?: string[],
+  networkFilter?: Record<string, string | boolean>,
 ): RunMatchParams {
-  const okw = okwIds && okwIds.length > 0 ? { okwIds } : {};
-  return { okhId, ...MODE_PARAMS[mode], maxResults, ...okw };
+  // A network filter (local ∪ MoM) supersedes the local-id subset.
+  const scope = networkFilter
+    ? { networkFilter }
+    : okwIds && okwIds.length > 0
+      ? { okwIds }
+      : {};
+  return { okhId, ...MODE_PARAMS[mode], maxResults, ...scope };
 }

--- a/frontend/src/features/network/NetworkView.tsx
+++ b/frontend/src/features/network/NetworkView.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { fetchNetworkSpaces, type NetworkFilters as Filters } from "../../api/ohm/network";
+import { Button } from "../../components/ui/button";
 import { deriveFilterOptions } from "./deriveFilterOptions";
 import { buildNetworkSummary } from "./networkSummary";
 import { NetworkFilters } from "./NetworkFilters";
@@ -34,9 +36,20 @@ function ViewToggle({ view, onChange }: { view: "list" | "map"; onChange: (v: "l
 }
 
 export function NetworkView() {
+  const navigate = useNavigate();
   const [filters, setFilters] = useState<Filters>({});
   const [view, setView] = useState<"list" | "map">("list");
   const [page, setPage] = useState(1);
+
+  // Carry the active filter into the match flow: pick a design there, match
+  // against exactly this filtered network (local ∪ MoM).
+  const matchAgainstThese = () => {
+    const params = new URLSearchParams({ network: "1" });
+    for (const [key, value] of Object.entries(filters)) {
+      if (value) params.set(key, String(value));
+    }
+    navigate(`/match?${params.toString()}`);
+  };
 
   const activeCount = Object.values(filters).filter(Boolean).length;
   const hasFilters = activeCount > 0;
@@ -95,7 +108,12 @@ export function NetworkView() {
         <div className="space-y-4">
           <div className="flex flex-wrap items-center justify-between gap-2">
             {data && <p className="text-sm text-slate-600 dark:text-slate-400">{buildNetworkSummary(data)}</p>}
-            <ViewToggle view={view} onChange={setView} />
+            <div className="flex items-center gap-2">
+              <Button variant="outline" size="sm" onClick={matchAgainstThese}>
+                ⚡ Match a design against these
+              </Button>
+              <ViewToggle view={view} onChange={setView} />
+            </div>
           </div>
 
           {active.isLoading && <LoadingState message="Loading network…" />}

--- a/frontend/src/pages/MatchPage.tsx
+++ b/frontend/src/pages/MatchPage.tsx
@@ -1,10 +1,27 @@
 import { useSearchParams } from "react-router-dom";
 import { MatchView } from "../features/match/MatchView";
 
+const NETWORK_AXES = ["country", "city", "process", "source", "status", "region", "access_type"] as const;
+
 export function MatchPage() {
   const [searchParams] = useSearchParams();
   const okhId = searchParams.get("okh_id") ?? undefined;
   const autoRun = searchParams.get("autorun") === "1";
-  // Remount when switching designs so match session state and autorun latch reset cleanly.
-  return <MatchView key={okhId ?? "__none__"} okhId={okhId} autoRun={autoRun} />;
+
+  // A `network` marker (from the network surface's "Match against these" action)
+  // carries the active filters into the match as a network_filter.
+  let networkFilter: Record<string, string | boolean> | undefined;
+  if (searchParams.get("network")) {
+    networkFilter = {};
+    for (const axis of NETWORK_AXES) {
+      const value = searchParams.get(axis);
+      if (value) networkFilter[axis] = value;
+    }
+    networkFilter.include_mom = searchParams.get("source") !== "local";
+  }
+
+  // Remount when switching designs/scope so match session state and the autorun
+  // latch reset cleanly.
+  const key = `${okhId ?? "__none__"}:${networkFilter ? searchParams.toString() : ""}`;
+  return <MatchView key={key} okhId={okhId} autoRun={autoRun} networkFilter={networkFilter} />;
 }


### PR DESCRIPTION
Closes the network-filtering theme (#230): the "**and matching**" half from the browse side. From the unified network surface, a user carries the active filter into the match flow and matches a design against **exactly that filtered set** (local ∪ MoM).

## Flow

Network surface (`/facilities`) → filter → **"Match a design against these"** → `/match?network=1&<filters>` → pick a design → match runs against the filtered network (consuming the backend `network_filter` from #233).

## Changes

- **`NetworkView`** — a "Match a design against these" button navigates to `/match` carrying the active filters + a `network=1` marker.
- **`MatchPage`** parses the network params into a `network_filter`; **`MatchView`** enters **network mode**: a "Matching against the network" banner with a readable filter summary (`local ∪ Maps of Making — country: FR · process: Laser Cutting`), the local facility-subset filter is **hidden** (superseded), and `network_filter` threads through `buildMatchRequest` → `runMatch`.
- **`runMatch`** sends `network_filter` (supersedes `okw_ids`) in the body.
- Unit tests (`buildMatchRequest` supersede rule, `runMatch` body) + E2E (hand-off nav + banner + `network_filter` sent).
- **Drive-by:** stabilized the pre-existing category-facet E2E flake (facet remount race) with a `toPass` retry — it was intermittently reddening the gate.

## Verification

`make frontend-ready` — green (80 unit, 52 E2E), stable across repeated runs.

Refs #230. With this, the whole "unified network browse **and** match" slice is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)