### PR TITLE
fix(frontend): drop the Materials facet from the Designs catalog

### DIFF
--- a/frontend/src/features/okh/facets.test.ts
+++ b/frontend/src/features/okh/facets.test.ts
@@ -93,8 +93,8 @@ describe("deriveFacetGroups", () => {
 
   it("omits groups with no options (category always present via fallback)", () => {
     const groups = deriveFacetGroups([item("x", [], null, [])], {});
-    // process/license/material have no values → omitted; category always yields
-    // at least the Uncategorized fallback.
+    // process/license have no values → omitted; category always yields at least
+    // the Uncategorized fallback.
     expect(groups.map((g) => g.key)).toEqual(["category"]);
   });
 });

--- a/frontend/src/features/okh/facets.ts
+++ b/frontend/src/features/okh/facets.ts
@@ -7,12 +7,13 @@ import { deriveCategories } from "./categories";
  * `category` is the primary drill-down facet (provisional, derived from the
  * manifest `function`/title/keywords — see categories.ts; swaps to the
  * service-backed taxonomy in Epic #199). The rest are orthogonal facets derived
- * from fields populated across the real corpus: manufacturing process, hardware
- * license, and material. (keywords / development_stage dropped — sparse / no
- * variance.)
+ * from fields populated across the real corpus: manufacturing process and
+ * hardware license. (keywords / development_stage dropped — sparse / no variance;
+ * material dropped — generate-from-url emits noisy non-material artifacts that
+ * make it useless as a filter until the pipeline's output quality is fixed.)
  */
 
-export type FacetKey = "category" | "process" | "license" | "material";
+export type FacetKey = "category" | "process" | "license";
 
 /** The primary drill-down facet, rendered first and marked provisional. */
 export const PRIMARY_FACET: FacetKey = "category";
@@ -39,12 +40,6 @@ export const FACET_DEFS: FacetDef[] = [
     key: "license",
     label: "License",
     values: (i) => (i.license?.hardware ? [i.license.hardware] : []),
-  },
-  {
-    key: "material",
-    label: "Material",
-    values: (i) =>
-      (i.materials ?? []).map((m) => m.name).filter((n): n is string => !!n),
   },
 ];
 


### PR DESCRIPTION
## What

`generate-from-url` pollutes manifest `materials` with a large number of extraction artifacts that aren't materials at all. On the Designs page these all surfaced as **Material** filter options — a wall of noise that hurt usability rather than helping. Remove the Materials facet for now.

## Changes

- Remove the `material` `FacetDef` and its `FacetKey` member. The panel renders derived facet groups, so this drops the whole column. Facets are now **Category / Manufacturing process / License**.

## This is a symptom fix

The root cause is `generate-from-url` **output quality** (materials extraction, and likely other fields). That's logged for a dedicated deep dive — audit the extraction pipeline, add post-extraction validation/normalization + confidence gating — after which the Materials facet should be **restored**.

## Verification

`make frontend-ready` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)