### PR TITLE
feat(config): typed settings schema + per-environment files (#237)

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 438
+Total Python files: 440
 
 ├── deploy/
 │   ├── __init__.py
@@ -319,6 +319,13 @@ Total Python files: 438
 │   │   │       def get_available_providers()
 │   │   │       def get_available_models()
 │   │   │       def validate_llm_config()
+│   │   ├── schema.py
+│   │   │       class _NormalizingEnvSource (prepare_field_value)
+│   │   │       class Settings (_normalize_environment, okw_source_resolved, cors_allow_origins...)
+│   │   │       def _find_project_env()
+│   │   │       def strip_quotes()
+│   │   │       def resolve_cors_origins()
+│   │   │       def get_settings()
 │   │   ├── settings.py
 │   │   │       def _get_secret_or_env()
 │   │   ├── storage_config.py
@@ -1804,6 +1811,14 @@ Total Python files: 438
         │       def test_validate_includes_component_count_zero()
         │       def test_validate_includes_component_count_nonzero()
         │       def test_validate_field_presence_tracks_components()
+        ├── test_config_schema.py
+        │       class TestTomlLayering (test_development_defaults_from_toml, test_production_target_from_toml, test_env_overrides_toml...)
+        │       class TestQuoteStripping (test_quoted_env_values_stripped, test_empty_quoted_value_becomes_none)
+        │       class TestEnvironmentNormalization (test_default_is_development, test_uppercase_lowercased, test_whitespace_stripped)
+        │       class TestOkwSourceResolution (test_unset_defaults_to_storage, test_explicit_storage, test_explicit_mom...)
+        │       class TestCorsResolution (test_pure_resolver_dev_unset_allows_all, test_pure_resolver_prod_unset_denies_all, test_pure_resolver_explicit_wildcard...)
+        │       class TestInitOverride (test_init_kwargs_win)
+        │       def clean_env()
         ├── test_deploy_cors_default.py
         │       def _data()
         │       def test_cors_origins_defaults_to_wildcard_when_omitted()
@@ -2064,7 +2079,7 @@ Total Python files: 438
 
 ## Overview
 
-Total files analyzed: 438
+Total files analyzed: 440
 
 ## Entry Points
 
@@ -4126,6 +4141,41 @@ This module provides configuration management for L...
 - `get_available_models()`
   - Get list of available LLM models...
 
+**Internal Dependencies:** 1 imports
+
+### `src/config/schema.py`
+> Typed application configuration — Slice 1.
+
+Single source of truth for a first, narrow slice of sett...
+
+**Exports:** strip_quotes, resolve_cors_origins, Settings, get_settings
+
+**Classes:**
+- `_NormalizingEnvSource` (inherits: EnvSettingsSource)
+  - Methods: prepare_field_value
+  - Env source that strips surrounding quotes/whitespace from every value.
+
+Keeps ``...
+- `Settings` (inherits: BaseSettings)
+  - Methods: okw_source_resolved, cors_allow_origins, settings_customise_sources
+  - Slice-1 typed configuration.
+
+Field names map case-insensitively to their histor...
+
+**Functions:**
+- `strip_quotes(value)`
+  - Strip surrounding whitespace + quotes; empty becomes ``None``.
+
+``docker run --e...
+- `resolve_cors_origins(raw, environment)`
+  - Resolve the raw ``CORS_ORIGINS`` string into a list of allowed origins.
+
+Behavio...
+- `get_settings()`
+  - Build a fresh :class:`Settings` from the current environment + TOML.
+
+Intentiona...
+
 ### `src/config/settings.py`
 
 **Internal Dependencies:** 2 imports
@@ -4142,7 +4192,7 @@ This module provides configuration management for L...
 
 **Functions:**
 - `get_azure_credentials()`
-  - Get Azure Blob Storage credentials from environment variables...
+  - Get Azure Blob Storage credentials from the typed settings schema....
 - `get_aws_credentials()`
   - Get AWS S3 credentials from environment variables...
 - `get_gcp_credentials()`
@@ -4159,7 +4209,7 @@ Args:
 
 The defau...
 
-**Internal Dependencies:** 1 imports
+**Internal Dependencies:** 5 imports
 
 ### `src/config/validation.py`
 > Configuration validation for the Open Hardware Manager
@@ -4189,6 +4239,32 @@ This module provides validation for all conf...
   - Validate configuration for a specific LLM provider...
 - `check_configuration_health()`
   - Check the overall health of the configuration...
+
+### `tests/unit/test_config_schema.py`
+> Characterization tests for the typed config schema (Slice 1).
+
+These pin the schema's behaviour to t...
+
+**Exports:** clean_env, TestTomlLayering, TestQuoteStripping, TestEnvironmentNormalization, TestOkwSourceResolution
+
+**Classes:**
+- `TestTomlLayering`
+  - Methods: test_development_defaults_from_toml, test_production_target_from_toml, test_env_overrides_toml, test_unknown_environment_has_no_toml_but_still_loads
+- `TestQuoteStripping`
+  - Methods: test_quoted_env_values_stripped, test_empty_quoted_value_becomes_none
+- `TestEnvironmentNormalization`
+  - Methods: test_default_is_development, test_uppercase_lowercased, test_whitespace_stripped
+- `TestOkwSourceResolution`
+  - Methods: test_unset_defaults_to_storage, test_explicit_storage, test_explicit_mom, test_unknown_falls_back_to_storage, test_tristate_distinguishes_unset_from_storage
+- `TestCorsResolution`
+  - Methods: test_pure_resolver_dev_unset_allows_all, test_pure_resolver_prod_unset_denies_all, test_pure_resolver_explicit_wildcard, test_pure_resolver_comma_list, test_pure_resolver_empty_string_dev
+- `TestInitOverride`
+  - Methods: test_init_kwargs_win
+
+**Functions:**
+- `clean_env(monkeypatch)`
+
+**Internal Dependencies:** 3 imports
 
 ### `tests/unit/test_storage_config_env_parsing.py`
 > Regression tests for storage_config._env quote-stripping.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Typed configuration schema + per-environment files (config Slice 1):** a `pydantic-settings` schema (`src/config/schema.py`) is now the single source of truth for the storage target (provider / account / container), the runtime `environment`, `OKW_SOURCE`, and CORS. Non-secret values are checked in per environment at `config/environments/{development,test,production}.toml` and layered under process env vars (env wins); secrets (`AZURE_STORAGE_KEY`, `API_KEYS`, `LLM_*`) stay env/`secretRef`-only. `settings.py` and `storage_config.py` consumers read the schema; the old inline env-read paths were removed. Behaviour-preserving — the `docker --env-file` quote-stripping quirk is consolidated into one normalizing env source, and characterization tests pin per-setting equivalence.
+
 ## [0.8.6] - 2026-06-30
 
 ### Fixed

--- a/config/environments/development.toml
+++ b/config/environments/development.toml
@@ -1,0 +1,11 @@
+# Non-secret configuration for the `development` environment (ENVIRONMENT=development).
+#
+# This file is the checked-in source of truth for non-secret settings; process
+# environment variables (and .env) override anything here. NEVER put secrets in
+# this file — AZURE_STORAGE_KEY, API_KEYS, and LLM_* belong in .env / secretRef.
+
+storage_provider = "local"
+
+# Optional overrides (unset here; resolved by code defaults):
+#   okw_source    = "storage"   # "storage" | "mom"; unset -> storage (Slice 1)
+#   cors_origins  = "*"         # unset in development -> allow-all ("*")

--- a/config/environments/production.toml
+++ b/config/environments/production.toml
@@ -1,0 +1,12 @@
+# Non-secret configuration for the `production` environment (ENVIRONMENT=production).
+#
+# This is the checked-in source of truth for the production storage target. The
+# deploy pipeline will apply these values authoritatively (issue #239); until
+# then the live container app's env vars still take precedence.
+#
+# NEVER put secrets here. AZURE_STORAGE_KEY stays an Azure `secretRef`; API_KEYS
+# and LLM_* stay secret. CORS_ORIGINS is supplied by the deployment environment.
+
+storage_provider = "azure_blob"
+azure_storage_account = "projdatablobstorage"
+azure_storage_container = "production"

--- a/config/environments/test.toml
+++ b/config/environments/test.toml
@@ -1,0 +1,6 @@
+# Non-secret configuration for the `test` environment (ENVIRONMENT=test).
+#
+# Kept local + isolated so the suite never depends on cloud storage. Process
+# environment variables override anything here. No secrets in this file.
+
+storage_provider = "local"

--- a/docs/development/developer-guide.md
+++ b/docs/development/developer-guide.md
@@ -40,6 +40,15 @@ cp env.template .env
 docker compose up --build ohm-api
 ```
 
+> **Configuration layering.** Non-secret settings for the storage target,
+> `OKW_SOURCE`, and CORS are keyed by `ENVIRONMENT` in
+> `config/environments/{development,test,production}.toml` (checked in). At
+> startup these are layered *under* your process environment / `.env`, so an env
+> var always overrides the file. Secrets (`AZURE_STORAGE_KEY`, `API_KEYS`,
+> `LLM_*`) are never in those files — keep them in `.env` locally or an Azure
+> `secretRef` in production. `ENVIRONMENT` (default `development`) selects which
+> file loads.
+
 ### Verify Installation
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "python-multipart>=0.0.31",
     # Data modeling
     "pydantic[email]>=2.0.0,<3.0.0",
+    "pydantic-settings>=2.2.0,<3.0.0",
     # Graph
     "networkx",
     # Storage / cloud

--- a/src/config/llm_config.py
+++ b/src/config/llm_config.py
@@ -209,8 +209,9 @@ class CredentialManager:
         else:
             # Generate key from environment or create new one
             # Check if we're in production mode
-            environment = os.getenv("ENVIRONMENT", "development").lower()
-            is_production = environment == "production"
+            from src.config.schema import get_settings
+
+            is_production = get_settings().environment == "production"
 
             # Get encryption credentials from environment
             salt_env = os.getenv("LLM_ENCRYPTION_SALT")

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -1,0 +1,202 @@
+"""Typed application configuration — Slice 1.
+
+Single source of truth for a first, narrow slice of settings: the storage
+target (provider / account / container), the runtime ``environment``, the OKW
+facility source, and CORS. Non-secret values are layered from the checked-in
+per-environment file ``config/environments/<environment>.toml``; process
+environment variables (secrets and overrides) take precedence.
+
+Layering (highest priority first): init kwargs → process env → per-env TOML →
+field defaults. Secrets (``AZURE_STORAGE_KEY`` and friends) live only in the
+process environment / ``.env`` / Azure ``secretRef`` — never in the TOML files.
+
+This module deliberately covers only Slice 1. The remaining settings still live
+in :mod:`src.config.settings`; they migrate incrementally in later slices.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from dotenv import load_dotenv
+from pydantic import field_validator
+from pydantic_settings import (
+    BaseSettings,
+    EnvSettingsSource,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+    TomlConfigSettingsSource,
+)
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_ENV_DIR = (
+    Path(__file__).resolve().parent.parent.parent / "config" / "environments"
+)
+
+
+def _find_project_env() -> Optional[Path]:
+    """Find .env by walking up from this file (mirrors storage_config)."""
+    try:
+        current = Path(__file__).resolve().parent
+        for _ in range(6):
+            env_file = current / ".env"
+            if env_file.is_file():
+                return env_file
+            current = current.parent
+            if not current or current == current.parent:
+                break
+    except Exception:
+        pass
+    return None
+
+
+# Populate os.environ from the project-root .env regardless of cwd, so config is
+# correct when `ohm` runs from any directory.
+_env_path = _find_project_env()
+if _env_path:
+    load_dotenv(dotenv_path=_env_path)
+else:
+    load_dotenv()
+
+
+def strip_quotes(value: Optional[str]) -> Optional[str]:
+    """Strip surrounding whitespace + quotes; empty becomes ``None``.
+
+    ``docker run --env-file`` passes values verbatim (quotes included), while
+    python-dotenv (docker-compose, ``load_dotenv``) strips them. Normalising
+    here makes both invocation styles produce identical values.
+    """
+    if value is None:
+        return None
+    stripped = value.strip().strip("\"'")
+    return stripped if stripped else None
+
+
+def resolve_cors_origins(
+    raw: Optional[str], environment: str, *, log: bool = False
+) -> List[str]:
+    """Resolve the raw ``CORS_ORIGINS`` string into a list of allowed origins.
+
+    Behaviour mirrors the historical logic in ``settings.py``: unset defaults to
+    ``[]`` in production (deny) and ``["*"]`` elsewhere (allow-all for dev
+    convenience); ``"*"`` is an explicit wildcard; otherwise a comma-separated
+    allowlist. Pass ``log=True`` to emit the operational warnings once.
+    """
+    if raw is None or raw.strip() == "":
+        if environment == "production":
+            if log:
+                logger.warning(
+                    "CORS_ORIGINS not set in production. No CORS origins allowed "
+                    "by default. Set CORS_ORIGINS to allow specific origins."
+                )
+            return []
+        if log:
+            logger.info(
+                "CORS_ORIGINS not set. Allowing all origins in development mode. "
+                "Set CORS_ORIGINS to restrict origins."
+            )
+        return ["*"]
+
+    if raw.strip() == "*":
+        if environment == "production" and log:
+            logger.warning(
+                "CORS_ORIGINS is set to '*' in production. This allows all origins. "
+                "Consider restricting to specific origins for better security."
+            )
+        return ["*"]
+
+    origins = [origin.strip() for origin in raw.split(",") if origin.strip()]
+    if not origins and log:
+        logger.warning("CORS_ORIGINS is set but empty. No CORS origins allowed.")
+    return origins
+
+
+class _NormalizingEnvSource(EnvSettingsSource):
+    """Env source that strips surrounding quotes/whitespace from every value.
+
+    Keeps ``docker --env-file`` and dotenv invocations byte-identical (see
+    :func:`strip_quotes`).
+    """
+
+    def prepare_field_value(self, field_name, field, value, value_is_complex):
+        return super().prepare_field_value(
+            field_name, field, strip_quotes(value), value_is_complex
+        )
+
+
+class Settings(BaseSettings):
+    """Slice-1 typed configuration.
+
+    Field names map case-insensitively to their historical env-var names
+    (``storage_provider`` ← ``STORAGE_PROVIDER``) and to the snake_case keys in
+    the per-environment TOML files.
+    """
+
+    model_config = SettingsConfigDict(case_sensitive=False, extra="ignore")
+
+    environment: str = "development"
+    storage_provider: str = "local"
+    azure_storage_account: Optional[str] = None
+    azure_storage_container: Optional[str] = None
+    azure_storage_key: Optional[str] = None  # secret: env/.env only, never TOML
+    okw_source: Optional[str] = None  # unset resolves via okw_source_resolved
+    cors_origins: Optional[str] = None  # raw; parse via cors_allow_origins
+
+    @field_validator("environment")
+    @classmethod
+    def _normalize_environment(cls, value: str) -> str:
+        return (value or "development").strip().lower()
+
+    @property
+    def okw_source_resolved(self) -> str:
+        """The effective OKW facility source: ``"storage"`` or ``"mom"``.
+
+        Unset falls back to ``"storage"``; unknown values fall back to
+        ``"storage"`` with a warning (behaviour-preserving for Slice 1).
+        """
+        source = self.okw_source or "storage"
+        if source not in ("storage", "mom"):
+            logger.warning(
+                "Unknown OKW_SOURCE value %r — falling back to 'storage'", source
+            )
+            return "storage"
+        return source
+
+    @property
+    def cors_allow_origins(self) -> List[str]:
+        return resolve_cors_origins(self.cors_origins, self.environment)
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls,
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> Tuple[PydanticBaseSettingsSource, ...]:
+        # Resolve the environment (env var wins) to pick the per-env TOML file.
+        env_name = (
+            strip_quotes(os.environ.get("ENVIRONMENT")) or "development"
+        ).lower()
+        normalized_env = _NormalizingEnvSource(settings_cls)
+
+        toml_path = _CONFIG_ENV_DIR / f"{env_name}.toml"
+        if toml_path.is_file():
+            toml_source = TomlConfigSettingsSource(settings_cls, toml_file=toml_path)
+            return (init_settings, normalized_env, toml_source)
+        return (init_settings, normalized_env)
+
+
+def get_settings() -> Settings:
+    """Build a fresh :class:`Settings` from the current environment + TOML.
+
+    Intentionally uncached: reading is cheap and callers (and tests that
+    ``monkeypatch`` env vars) expect live reads, matching the pre-schema
+    functions this replaces.
+    """
+    return Settings()

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -8,6 +8,7 @@ from src.core.storage.base import StorageConfig
 
 from .auth_constants import AUTH_MODE_HYBRID
 from .llm_config import get_llm_config, is_llm_enabled, validate_llm_config
+from .schema import get_settings, resolve_cors_origins
 from .storage_config import StorageConfigError, get_default_storage_config
 
 # Import secrets manager (lazy import to avoid circular dependencies)
@@ -110,43 +111,14 @@ else:
     # Default to 8001 (matches CLI default)
     API_PORT = 8001
 
-# CORS settings
-# Parse comma-separated origins from environment variable
-CORS_ORIGINS_ENV = _get_secret_or_env("CORS_ORIGINS")
-ENVIRONMENT = _get_secret_or_env("ENVIRONMENT", "development").lower()
-
-if CORS_ORIGINS_ENV is None or CORS_ORIGINS_ENV.strip() == "":
-    # Default based on environment
-    if ENVIRONMENT == "production":
-        # In production, default to empty list (no CORS allowed)
-        # Must be explicitly configured
-        CORS_ORIGINS = []
-        logger.warning(
-            "CORS_ORIGINS not set in production. No CORS origins allowed by default. "
-            "Set CORS_ORIGINS environment variable to allow specific origins."
-        )
-    else:
-        # In development, allow all origins for convenience
-        CORS_ORIGINS = ["*"]
-        logger.info(
-            "CORS_ORIGINS not set. Allowing all origins in development mode. "
-            "Set CORS_ORIGINS environment variable to restrict origins."
-        )
-elif CORS_ORIGINS_ENV.strip() == "*":
-    # Explicit wildcard
-    if ENVIRONMENT == "production":
-        logger.warning(
-            "CORS_ORIGINS is set to '*' in production. This allows all origins. "
-            "Consider restricting to specific origins for better security."
-        )
-    CORS_ORIGINS = ["*"]
-else:
-    # Parse comma-separated list of allowed origins
-    CORS_ORIGINS = [
-        origin.strip() for origin in CORS_ORIGINS_ENV.split(",") if origin.strip()
-    ]
-    if not CORS_ORIGINS:
-        logger.warning("CORS_ORIGINS is set but empty. No CORS origins allowed.")
+# CORS + environment now come from the typed config schema (Slice 1). The
+# schema layers per-environment TOML defaults under process env vars; CORS
+# posture warnings are logged once here.
+_schema_settings = get_settings()
+ENVIRONMENT = _schema_settings.environment
+CORS_ORIGINS = resolve_cors_origins(
+    _schema_settings.cors_origins, ENVIRONMENT, log=True
+)
 
 # API Keys (backward compatibility - used for environment variable keys)
 # This is a sensitive value, so it will try secrets manager if enabled

--- a/src/config/storage_config.py
+++ b/src/config/storage_config.py
@@ -62,9 +62,12 @@ def _env(key: str, default: Optional[str] = None) -> Optional[str]:
 
 
 def get_azure_credentials() -> Dict[str, str]:
-    """Get Azure Blob Storage credentials from environment variables"""
-    account_name = _env("AZURE_STORAGE_ACCOUNT")
-    account_key = _env("AZURE_STORAGE_KEY")
+    """Get Azure Blob Storage credentials from the typed settings schema."""
+    from src.config.schema import get_settings
+
+    settings = get_settings()
+    account_name = settings.azure_storage_account
+    account_key = settings.azure_storage_key
 
     if not account_name or not account_key:
         raise MissingCredentialsError(
@@ -157,7 +160,9 @@ def create_storage_config(
     if provider == "azure_blob":
         credentials = get_azure_credentials()
         if not bucket_name:
-            bucket_name = _env("AZURE_STORAGE_CONTAINER")
+            from src.config.schema import get_settings
+
+            bucket_name = get_settings().azure_storage_container
     elif provider == "aws_s3":
         credentials = get_aws_credentials()
         if not bucket_name:
@@ -202,7 +207,9 @@ def get_default_storage_config() -> StorageConfig:
     Raises:
         StorageConfigError: If configuration is invalid or credentials are missing
     """
-    provider = _env("STORAGE_PROVIDER") or "local"
+    from src.config.schema import get_settings
+
+    provider = get_settings().storage_provider
     return create_storage_config(provider)
 
 
@@ -237,13 +244,9 @@ def get_okw_source() -> str:
         ``"storage"`` or ``"mom"``. Unknown values fall back to
         ``"storage"`` with a warning log.
     """
-    source = _env("OKW_SOURCE") or "storage"
-    if source not in ("storage", "mom"):
-        logger.warning(
-            "Unknown OKW_SOURCE value %r — falling back to 'storage'", source
-        )
-        return "storage"
-    return source
+    from src.config.schema import get_settings
+
+    return get_settings().okw_source_resolved
 
 
 def get_mom_config() -> Dict[str, str]:

--- a/tests/unit/test_config_schema.py
+++ b/tests/unit/test_config_schema.py
@@ -1,0 +1,144 @@
+"""Characterization tests for the typed config schema (Slice 1).
+
+These pin the schema's behaviour to the pre-migration semantics of
+``settings.py`` / ``storage_config.py``: quote-stripping, per-environment TOML
+layering (env overrides file), CORS resolution, OKW source resolution, and
+environment normalization.
+"""
+
+import pytest
+
+from src.config.schema import Settings, get_settings, resolve_cors_origins
+
+# Slice-1 env vars that must be neutralized for deterministic tests (the
+# developer's .env is loaded at import time and would otherwise leak in).
+_SLICE1_ENV = (
+    "ENVIRONMENT",
+    "STORAGE_PROVIDER",
+    "AZURE_STORAGE_ACCOUNT",
+    "AZURE_STORAGE_CONTAINER",
+    "AZURE_STORAGE_KEY",
+    "OKW_SOURCE",
+    "CORS_ORIGINS",
+)
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    for key in _SLICE1_ENV:
+        monkeypatch.delenv(key, raising=False)
+    return monkeypatch
+
+
+class TestTomlLayering:
+    def test_development_defaults_from_toml(self, clean_env):
+        s = get_settings()
+        assert s.environment == "development"
+        assert s.storage_provider == "local"
+
+    def test_production_target_from_toml(self, clean_env):
+        clean_env.setenv("ENVIRONMENT", "production")
+        s = get_settings()
+        assert s.storage_provider == "azure_blob"
+        assert s.azure_storage_account == "projdatablobstorage"
+        assert s.azure_storage_container == "production"
+
+    def test_env_overrides_toml(self, clean_env):
+        clean_env.setenv("ENVIRONMENT", "production")
+        clean_env.setenv("AZURE_STORAGE_CONTAINER", "override-container")
+        assert get_settings().azure_storage_container == "override-container"
+
+    def test_unknown_environment_has_no_toml_but_still_loads(self, clean_env):
+        clean_env.setenv("ENVIRONMENT", "does-not-exist")
+        s = get_settings()
+        assert s.environment == "does-not-exist"
+        assert s.storage_provider == "local"  # field default (no file)
+
+
+class TestQuoteStripping:
+    def test_quoted_env_values_stripped(self, clean_env):
+        clean_env.setenv("STORAGE_PROVIDER", '"azure_blob"')
+        clean_env.setenv("AZURE_STORAGE_ACCOUNT", '"myaccount"')
+        clean_env.setenv("AZURE_STORAGE_CONTAINER", "'mycontainer'")
+        s = get_settings()
+        assert s.storage_provider == "azure_blob"
+        assert s.azure_storage_account == "myaccount"
+        assert s.azure_storage_container == "mycontainer"
+
+    def test_empty_quoted_value_becomes_none(self, clean_env):
+        clean_env.setenv("AZURE_STORAGE_CONTAINER", '""')
+        assert get_settings().azure_storage_container is None
+
+
+class TestEnvironmentNormalization:
+    def test_default_is_development(self, clean_env):
+        assert get_settings().environment == "development"
+
+    def test_uppercase_lowercased(self, clean_env):
+        clean_env.setenv("ENVIRONMENT", "PRODUCTION")
+        assert get_settings().environment == "production"
+
+    def test_whitespace_stripped(self, clean_env):
+        clean_env.setenv("ENVIRONMENT", "  Test  ")
+        assert get_settings().environment == "test"
+
+
+class TestOkwSourceResolution:
+    def test_unset_defaults_to_storage(self, clean_env):
+        assert get_settings().okw_source_resolved == "storage"
+
+    def test_explicit_storage(self, clean_env):
+        clean_env.setenv("OKW_SOURCE", "storage")
+        assert get_settings().okw_source_resolved == "storage"
+
+    def test_explicit_mom(self, clean_env):
+        clean_env.setenv("OKW_SOURCE", "mom")
+        assert get_settings().okw_source_resolved == "mom"
+
+    def test_unknown_falls_back_to_storage(self, clean_env):
+        clean_env.setenv("OKW_SOURCE", "nonsense")
+        assert get_settings().okw_source_resolved == "storage"
+
+    def test_tristate_distinguishes_unset_from_storage(self, clean_env):
+        # Raw field preserves the None-vs-"storage" distinction for #240.
+        assert get_settings().okw_source is None
+        clean_env.setenv("OKW_SOURCE", "storage")
+        assert get_settings().okw_source == "storage"
+
+
+class TestCorsResolution:
+    def test_pure_resolver_dev_unset_allows_all(self):
+        assert resolve_cors_origins(None, "development") == ["*"]
+
+    def test_pure_resolver_prod_unset_denies_all(self):
+        assert resolve_cors_origins(None, "production") == []
+
+    def test_pure_resolver_explicit_wildcard(self):
+        assert resolve_cors_origins("*", "production") == ["*"]
+
+    def test_pure_resolver_comma_list(self):
+        assert resolve_cors_origins("https://a.com, https://b.com ", "production") == [
+            "https://a.com",
+            "https://b.com",
+        ]
+
+    def test_pure_resolver_empty_string_dev(self):
+        assert resolve_cors_origins("   ", "development") == ["*"]
+
+    def test_schema_dev_unset(self, clean_env):
+        assert get_settings().cors_allow_origins == ["*"]
+
+    def test_schema_prod_unset(self, clean_env):
+        clean_env.setenv("ENVIRONMENT", "production")
+        assert get_settings().cors_allow_origins == []
+
+    def test_schema_comma_list(self, clean_env):
+        clean_env.setenv("CORS_ORIGINS", "https://x.io,https://y.io")
+        assert get_settings().cors_allow_origins == ["https://x.io", "https://y.io"]
+
+
+class TestInitOverride:
+    def test_init_kwargs_win(self, clean_env):
+        # init > env > toml precedence
+        clean_env.setenv("STORAGE_PROVIDER", "azure_blob")
+        assert Settings(storage_provider="gcs").storage_provider == "gcs"

--- a/uv.lock
+++ b/uv.lock
@@ -2623,6 +2623,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
+]
+
+[[package]]
 name = "pydeck"
 version = "0.9.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3199,6 +3213,7 @@ dependencies = [
     { name = "pandas" },
     { name = "psutil" },
     { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
     { name = "pydeck" },
     { name = "pypdf" },
     { name = "python-docx" },
@@ -3262,6 +3277,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=1.5.0" },
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.0.0,<3.0.0" },
+    { name = "pydantic-settings", specifier = ">=2.2.0,<3.0.0" },
     { name = "pydeck", specifier = ">=0.8.0" },
     { name = "pypdf", specifier = ">=6.13.3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },


### PR DESCRIPTION
Closes #237. Config Slice 1 (v0.8.7) — behaviour-preserving.

## What to build

A `pydantic-settings` schema (`src/config/schema.py`) is now the single source of truth for the first slice of settings: storage target (provider / account / container), runtime `ENVIRONMENT`, `OKW_SOURCE`, and CORS. Non-secret values are checked in per environment at `config/environments/{development,test,production}.toml` and layered **under** process env vars (`init > env > TOML > defaults`); secrets (`AZURE_STORAGE_KEY`, `API_KEYS`, `LLM_*`) stay env/`secretRef`-only. `settings.py` and `storage_config.py` consumers read the schema and the old inline env-read paths are removed. The `docker --env-file` quote-stripping quirk is consolidated into one normalizing env source.

## Acceptance criteria

- [x] Schema covers storage provider/account/container, `ENVIRONMENT`, `OKW_SOURCE`, CORS
- [x] `config/environments/{development,test,production}.toml` exist with non-secret values
- [x] Loader precedence: env-file defaults → process env overrides
- [x] Consumers read the schema; old read paths in `settings.py` / `storage_config.py` deleted
- [x] Env-var names preserved (case-insensitive schema field matching)
- [x] Characterization tests prove per-setting equivalence (`tests/unit/test_config_schema.py`, 23 tests)
- [x] `make ready` passes (588 passed / 178 skipped; parity ✓; docs ✓)

## Design notes (approved)

- `okw_source` / `cors_origins` are left **resolution-defaulted**, not written into the TOMLs, so this stays behaviour-preserving and does not pre-empt #240's union default. TOMLs carry the storage target only.
- `get_settings()` is **uncached** (fresh read per call) to match the pre-schema live-env-read semantics; `settings.py` snapshots its module constants once at import as before.

## Follow-ups (separate issues, blocked by this)

#238 (env.template from schema), #239 (deploy-pipeline reversal), #241 (drift-catching trio), #240 (OKW_SOURCE union, v0.8.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)