### PR TITLE
feat(config): env.template schema block + staleness gate (#238) — re-target to main

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -42,6 +42,11 @@ jobs:
           uv run python scripts/generate_repo_map.py
           git diff --exit-code .repo-map.md
 
+      - name: Verify env.template is up to date
+        run: |
+          uv run python scripts/generate_env_template.py
+          git diff --exit-code env.template
+
   test:
     name: Test (stable CI subset)
     runs-on: ubuntu-latest

--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 440
+Total Python files: 442
 
 ├── deploy/
 │   ├── __init__.py
@@ -105,6 +105,11 @@ Total Python files: 440
 │   │       def _generate_raw_facilities()
 │   │       def _safe_name()
 │   │       def save_facilities()
+│   │       def main()
+│   ├── generate_env_template.py
+│   │       def _is_secret()
+│   │       def render_block()
+│   │       def render_template()
 │   │       def main()
 │   ├── generate_openapi_routes_md.py
 │   │       def _escape_cell()
@@ -1830,6 +1835,13 @@ Total Python files: 440
         ├── test_dev_env_spacy_model.py
         │       def _load_verifier()
         │       def test_spacy_model_is_installed_and_loadable()
+        ├── test_env_template_generation.py
+        │       def _load_generator()
+        │       def test_block_is_deterministic()
+        │       def test_block_covers_every_schema_field()
+        │       def test_secret_field_is_commented_and_labeled()
+        │       def test_non_secret_default_is_active()
+        │       def test_committed_template_is_not_stale()
         ├── test_geographic_facility_filtering.py
         │       def _make_facility()
         │       def matches_filters()
@@ -2079,7 +2091,7 @@ Total Python files: 440
 
 ## Overview
 
-Total files analyzed: 440
+Total files analyzed: 442
 
 ## Entry Points
 
@@ -4571,6 +4583,22 @@ For multi-step sets the files are na...
 - `main()`
 
 **Internal Dependencies:** 5 imports
+
+### `scripts/generate_env_template.py`
+> Regenerate the schema-owned block of ``env.template`` from the config schema.
+
+The typed schema (:cl...
+
+**Exports:** render_block, render_template, main
+
+**Functions:**
+- `render_block()`
+  - Render the generated block body (between, but excluding, the markers)....
+- `render_template(current)`
+  - Return ``current`` with the marked block replaced by a fresh render....
+- `main()`
+
+**Internal Dependencies:** 1 imports
 
 ### `scripts/generate_openapi_routes_md.py`
 > Write a Markdown route table for MkDocs from the versioned FastAPI app OpenAPI schema.
@@ -7927,6 +7955,22 @@ src/config/settings.py defaul...
   - deploy_gcp.py (the only real, non-test deploy script in this repo)
 constructs co...
 - `test_azure_with_defaults_defaults_cors_origins()`
+
+### `tests/unit/test_env_template_generation.py`
+> Tests for the env.template generator (config Slice 1 / #238).
+
+Pin the lockfile behaviour: the gener...
+
+**Exports:** test_block_is_deterministic, test_block_covers_every_schema_field, test_secret_field_is_commented_and_labeled, test_non_secret_default_is_active, test_committed_template_is_not_stale
+
+**Functions:**
+- `test_block_is_deterministic()`
+- `test_block_covers_every_schema_field()`
+- `test_secret_field_is_commented_and_labeled()`
+- `test_non_secret_default_is_active()`
+- `test_committed_template_is_not_stale()`
+
+**Internal Dependencies:** 1 imports
 
 ### `tests/unit/test_geographic_facility_filtering.py`
 > Unit tests for geographic facility filtering (issue #172)....

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Code style and project map via uv-managed environment.
-.PHONY: format format-check lint test check black ruff repo-map validate-docs parity ready setup verify-env frontend-setup frontend-ready
+.PHONY: format format-check lint test check black ruff repo-map env-template env-template-check validate-docs parity ready setup verify-env frontend-setup frontend-ready
 
 # Web frontend verification harness (the frontend analogue of `ready`).
 # See frontend/harness/README.md. Runs typecheck, lint, unit, build, and the
@@ -26,7 +26,7 @@ setup:
 verify-env:
 	uv run python scripts/verify_dev_env.py
 
-format: black ruff repo-map
+format: black ruff repo-map env-template
 
 black:
 	uv run black .
@@ -47,6 +47,14 @@ check: lint format-check test
 
 repo-map:
 	uv run python scripts/generate_repo_map.py
+
+# Regenerate the schema-owned block of env.template from src/config/schema.py.
+env-template:
+	uv run python scripts/generate_env_template.py
+
+# Staleness gate (lockfile pattern): fails if the generated block is out of date.
+env-template-check:
+	uv run python scripts/generate_env_template.py --check
 
 validate-docs:
 	uv run python scripts/validate_docs.py

--- a/env.template
+++ b/env.template
@@ -2,11 +2,34 @@
 # Copy this file to .env and customize the values for your environment
 
 # =============================================================================
-# Environment Configuration
+# Schema-owned settings (typed config — see src/config/schema.py)
 # =============================================================================
-# Environment: "development" or "production"
-# In production, encryption credentials and API keys are required
+# === BEGIN GENERATED: schema-owned settings — regenerate with 'make env-template' ===
+# Managed by scripts/generate_env_template.py — do not edit by hand.
+# Non-secret values are also checked in per environment under
+# config/environments/<ENVIRONMENT>.toml; anything set here overrides them.
+
+# Runtime environment; selects config/environments/<env>.toml.
 ENVIRONMENT=development
+
+# Storage backend: local | azure_blob | aws_s3 | gcs.
+STORAGE_PROVIDER=local
+
+# Azure Blob storage account name (when storage_provider=azure_blob).
+# AZURE_STORAGE_ACCOUNT=
+
+# Azure Blob container name.
+# AZURE_STORAGE_CONTAINER=
+
+# Azure Blob access key.
+# AZURE_STORAGE_KEY=   # SECRET — set in .env / secretRef, never commit
+
+# OKW facility source: storage | mom. Unset resolves to storage (Slice 1).
+# OKW_SOURCE=
+
+# CORS allowed origins: '*' or a comma-separated list.
+# CORS_ORIGINS=
+# === END GENERATED ===
 
 # =============================================================================
 # API Configuration
@@ -15,11 +38,6 @@ DEBUG=false
 API_HOST=0.0.0.0
 # Standardized default port (matches CLI default)
 API_PORT=8001
-
-# CORS Configuration
-# Use "*" to allow all origins, or specify comma-separated list of allowed origins
-# In production, defaults to empty (no CORS) if not set
-CORS_ORIGINS=*
 
 # API Authentication
 # Comma-separated list of API keys for authentication (backward compatibility)
@@ -57,10 +75,10 @@ LOG_FILE=logs/app.log
 # - Self-hosted deployments
 # - Network-attached storage (NAS) setups
 #
-# Simply set STORAGE_PROVIDER=local and specify a path below.
-# The system will automatically create the directory structure on first use.
+# Simply set STORAGE_PROVIDER=local (in the schema-owned block at the top of this
+# file) and specify a path below. The system creates the directory structure on
+# first use.
 #
-STORAGE_PROVIDER=local
 
 # Local storage path - where OHM will store data files
 # Supports multiple path formats:
@@ -93,10 +111,8 @@ AWS_DEFAULT_REGION=us-east-1  # Region for AWS services
 AWS_S3_BUCKET=your-s3-bucket
 
 # Azure Blob Storage Configuration (if using azure_blob)
-# Note: Code uses AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_KEY
-AZURE_STORAGE_ACCOUNT=your-storage-account  # Used in code
-AZURE_STORAGE_KEY=your-storage-key  # Used in code
-AZURE_STORAGE_CONTAINER=your-container  # Used in code
+# AZURE_STORAGE_ACCOUNT / AZURE_STORAGE_CONTAINER live in the schema-owned block at
+# the top of this file; AZURE_STORAGE_KEY is the secret — set it there, never commit.
 # Legacy/alternative names (for backward compatibility)
 AZURE_STORAGE_ACCOUNT_NAME=your-storage-account
 AZURE_STORAGE_ACCOUNT_KEY=your-storage-key

--- a/scripts/generate_env_template.py
+++ b/scripts/generate_env_template.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Regenerate the schema-owned block of ``env.template`` from the config schema.
+
+The typed schema (:class:`src.config.schema.Settings`) is the source of truth for
+Slice-1 settings. This script emits one entry per schema field — name, one-line
+description, default, and secret-vs-not — into the marked block of ``env.template``,
+leaving the hand-maintained remainder untouched. As later slices migrate more
+settings onto the schema, the block grows automatically.
+
+Usage:
+    python scripts/generate_env_template.py           # rewrite the block in place
+    python scripts/generate_env_template.py --check    # exit 1 if the block is stale
+
+CI runs the in-place form followed by ``git diff --exit-code env.template``
+(the same lockfile pattern used for the repository map).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.config.schema import Settings  # noqa: E402
+
+_ENV_TEMPLATE = _REPO_ROOT / "env.template"
+_BEGIN = "# === BEGIN GENERATED: schema-owned settings — regenerate with 'make env-template' ==="
+_END = "# === END GENERATED ==="
+
+
+def _is_secret(field) -> bool:
+    extra = field.json_schema_extra or {}
+    return bool(isinstance(extra, dict) and extra.get("secret"))
+
+
+def render_block() -> str:
+    """Render the generated block body (between, but excluding, the markers)."""
+    lines = [
+        "# Managed by scripts/generate_env_template.py — do not edit by hand.",
+        "# Non-secret values are also checked in per environment under",
+        "# config/environments/<ENVIRONMENT>.toml; anything set here overrides them.",
+        "",
+    ]
+    for name, field in Settings.model_fields.items():
+        env_name = name.upper()
+        if field.description:
+            lines.append(f"# {field.description}")
+        if _is_secret(field):
+            lines.append(
+                f"# {env_name}=   # SECRET — set in .env / secretRef, never commit"
+            )
+        elif field.default is None:
+            # Optional (no default): comment out so a copied .env stays minimal.
+            lines.append(f"# {env_name}=")
+        else:
+            lines.append(f"{env_name}={field.default}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_template(current: str) -> str:
+    """Return ``current`` with the marked block replaced by a fresh render."""
+    if _BEGIN not in current or _END not in current:
+        raise SystemExit(
+            f"env.template is missing the generated-block markers.\n"
+            f"Add these two lines where the block should live:\n{_BEGIN}\n{_END}"
+        )
+    head, rest = current.split(_BEGIN, 1)
+    _, tail = rest.split(_END, 1)
+    return f"{head}{_BEGIN}\n{render_block()}{_END}{tail}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if env.template's generated block is stale.",
+    )
+    args = parser.parse_args()
+
+    current = _ENV_TEMPLATE.read_text(encoding="utf-8")
+    updated = render_template(current)
+
+    if args.check:
+        if current != updated:
+            print(
+                "env.template is stale. Run `make env-template` and commit the result.",
+                file=sys.stderr,
+            )
+            return 1
+        print("env.template is up to date.")
+        return 0
+
+    if current != updated:
+        _ENV_TEMPLATE.write_text(updated, encoding="utf-8")
+        print("Regenerated env.template schema block.")
+    else:
+        print("env.template already up to date.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import List, Optional, Tuple
 
 from dotenv import load_dotenv
-from pydantic import field_validator
+from pydantic import Field, field_validator
 from pydantic_settings import (
     BaseSettings,
     EnvSettingsSource,
@@ -138,13 +138,35 @@ class Settings(BaseSettings):
 
     model_config = SettingsConfigDict(case_sensitive=False, extra="ignore")
 
-    environment: str = "development"
-    storage_provider: str = "local"
-    azure_storage_account: Optional[str] = None
-    azure_storage_container: Optional[str] = None
-    azure_storage_key: Optional[str] = None  # secret: env/.env only, never TOML
-    okw_source: Optional[str] = None  # unset resolves via okw_source_resolved
-    cors_origins: Optional[str] = None  # raw; parse via cors_allow_origins
+    environment: str = Field(
+        default="development",
+        description="Runtime environment; selects config/environments/<env>.toml.",
+    )
+    storage_provider: str = Field(
+        default="local",
+        description="Storage backend: local | azure_blob | aws_s3 | gcs.",
+    )
+    azure_storage_account: Optional[str] = Field(
+        default=None,
+        description="Azure Blob storage account name (when storage_provider=azure_blob).",
+    )
+    azure_storage_container: Optional[str] = Field(
+        default=None,
+        description="Azure Blob container name.",
+    )
+    azure_storage_key: Optional[str] = Field(
+        default=None,
+        description="Azure Blob access key.",
+        json_schema_extra={"secret": True},  # env/.env / secretRef only, never TOML
+    )
+    okw_source: Optional[str] = Field(
+        default=None,  # unset resolves via okw_source_resolved
+        description="OKW facility source: storage | mom. Unset resolves to storage (Slice 1).",
+    )
+    cors_origins: Optional[str] = Field(
+        default=None,  # raw; parse via cors_allow_origins
+        description="CORS allowed origins: '*' or a comma-separated list.",
+    )
 
     @field_validator("environment")
     @classmethod

--- a/tests/unit/test_env_template_generation.py
+++ b/tests/unit/test_env_template_generation.py
@@ -1,0 +1,54 @@
+"""Tests for the env.template generator (config Slice 1 / #238).
+
+Pin the lockfile behaviour: the generated block is deterministic, covers every
+schema field, and the committed env.template is not stale.
+"""
+
+import importlib.util
+from pathlib import Path
+
+from src.config.schema import Settings
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO_ROOT / "scripts" / "generate_env_template.py"
+
+
+def _load_generator():
+    spec = importlib.util.spec_from_file_location("generate_env_template", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gen = _load_generator()
+
+
+def test_block_is_deterministic():
+    assert gen.render_block() == gen.render_block()
+
+
+def test_block_covers_every_schema_field():
+    block = gen.render_block()
+    for name in Settings.model_fields:
+        assert name.upper() in block, f"{name} missing from generated block"
+
+
+def test_secret_field_is_commented_and_labeled():
+    block = gen.render_block()
+    # The one secret in Slice 1 must be commented out and flagged, never active.
+    assert "# AZURE_STORAGE_KEY=" in block
+    assert "SECRET" in block
+    assert "\nAZURE_STORAGE_KEY=" not in block  # not an active assignment
+
+
+def test_non_secret_default_is_active():
+    block = gen.render_block()
+    assert "\nENVIRONMENT=development" in "\n" + block
+    assert "\nSTORAGE_PROVIDER=local" in "\n" + block
+
+
+def test_committed_template_is_not_stale():
+    current = gen._ENV_TEMPLATE.read_text(encoding="utf-8")
+    assert (
+        gen.render_template(current) == current
+    ), "env.template is stale — run `make env-template` and commit the result."


### PR DESCRIPTION
Lands **#238** on `main`. Closes #238.

Re-targets the #238 work to `main`. The original PR #243 was stacked on `feat/config-schema-slice1` and got merged into that branch *after* #237 (#242) had already merged to `main`, so #238's single commit never reached `main`. `main` currently has #237's schema but not the `env.template` generator.

This PR's diff is exactly that one commit (`73860d9`): `scripts/generate_env_template.py`, the schema-owned block in `env.template`, `make env-template` + CI staleness step, the staleness unit test, and schema field descriptions/secret markers. `make ready` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)