### PR TITLE
feat(deploy): apply non-secret per-env config from the repo (#239)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,8 +184,10 @@ jobs:
   # Azure token while running under that environment, and any required-reviewer
   # protection rule configured on it (Settings → Environments → production) blocks
   # the job until approved. Uses --set-env-vars (additive) on an existing app, so
-  # it only ever touches the image tag + ENVIRONMENT/CORS_ORIGINS -- storage and
-  # LLM encryption secrets configured directly on the container are untouched.
+  # it applies the image tag + the non-secret per-env config (ENVIRONMENT,
+  # CORS_ORIGINS, and the storage target -- provider/account/container) from
+  # config/environments/production.toml. Secrets (storage key, LLM encryption)
+  # stay secretRefs configured directly on the container and are untouched.
   deploy-azure:
     name: Deploy to Azure Container Apps
     runs-on: ubuntu-latest

--- a/.repo-map.md
+++ b/.repo-map.md
@@ -331,6 +331,8 @@ Total Python files: 442
 │   │   │       def strip_quotes()
 │   │   │       def resolve_cors_origins()
 │   │   │       def get_settings()
+│   │   │       def _secret_field_names()
+│   │   │       def deploy_env_vars()
 │   │   ├── settings.py
 │   │   │       def _get_secret_or_env()
 │   │   ├── storage_config.py
@@ -1823,6 +1825,7 @@ Total Python files: 442
         │       class TestOkwSourceResolution (test_unset_defaults_to_storage, test_explicit_storage, test_explicit_mom...)
         │       class TestCorsResolution (test_pure_resolver_dev_unset_allows_all, test_pure_resolver_prod_unset_denies_all, test_pure_resolver_explicit_wildcard...)
         │       class TestInitOverride (test_init_kwargs_win)
+        │       class TestDeployEnvVars (test_production_applies_storage_target, test_development_is_local, test_missing_environment_returns_empty...)
         │       def clean_env()
         ├── test_deploy_cors_default.py
         │       def _data()
@@ -4160,7 +4163,7 @@ This module provides configuration management for L...
 
 Single source of truth for a first, narrow slice of sett...
 
-**Exports:** strip_quotes, resolve_cors_origins, Settings, get_settings
+**Exports:** strip_quotes, resolve_cors_origins, Settings, get_settings, deploy_env_vars
 
 **Classes:**
 - `_NormalizingEnvSource` (inherits: EnvSettingsSource)
@@ -4187,6 +4190,10 @@ Behavio...
   - Build a fresh :class:`Settings` from the current environment + TOML.
 
 Intentiona...
+- `deploy_env_vars(environment)`
+  - Non-secret env vars to apply to ``<environment>``'s container app.
+
+Reads ``conf...
 
 ### `src/config/settings.py`
 
@@ -4272,11 +4279,13 @@ These pin the schema's behaviour to t...
   - Methods: test_pure_resolver_dev_unset_allows_all, test_pure_resolver_prod_unset_denies_all, test_pure_resolver_explicit_wildcard, test_pure_resolver_comma_list, test_pure_resolver_empty_string_dev
 - `TestInitOverride`
   - Methods: test_init_kwargs_win
+- `TestDeployEnvVars`
+  - Methods: test_production_applies_storage_target, test_development_is_local, test_missing_environment_returns_empty, test_keys_are_uppercased_env_names, test_secret_keys_are_refused
 
 **Functions:**
 - `clean_env(monkeypatch)`
 
-**Internal Dependencies:** 3 imports
+**Internal Dependencies:** 5 imports
 
 ### `tests/unit/test_storage_config_env_parsing.py`
 > Regression tests for storage_config._env quote-stripping.
@@ -4379,6 +4388,8 @@ This script uses the Azure deployer to update th...
 **Functions:**
 - `main()`
   - Deploy to Azure Container Apps....
+
+**Internal Dependencies:** 1 imports
 
 ### `deploy/scripts/deploy_gcp.py`
 > Manual deployment script for GCP Cloud Run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Typed configuration schema + per-environment files (config Slice 1):** a `pydantic-settings` schema (`src/config/schema.py`) is now the single source of truth for the storage target (provider / account / container), the runtime `environment`, `OKW_SOURCE`, and CORS. Non-secret values are checked in per environment at `config/environments/{development,test,production}.toml` and layered under process env vars (env wins); secrets (`AZURE_STORAGE_KEY`, `API_KEYS`, `LLM_*`) stay env/`secretRef`-only. `settings.py` and `storage_config.py` consumers read the schema; the old inline env-read paths were removed. Behaviour-preserving — the `docker --env-file` quote-stripping quirk is consolidated into one normalizing env source, and characterization tests pin per-setting equivalence.
+- **Generated `env.template` + staleness gate:** `scripts/generate_env_template.py` emits the schema-owned settings into a marked block of `env.template` (name, default, secret-vs-not). `make env-template` regenerates it (part of `make format`), and a CI step + unit test fail if the committed block drifts from the schema — the lockfile pattern already used for the repository map.
+
+### Changed
+
+- **Deploy pipeline now applies the non-secret storage target from the repo.** `deploy/scripts/deploy_azure.py` previously only set `ENVIRONMENT` + `CORS_ORIGINS` and left `STORAGE_*` configured directly on the container app (invisible to the repo — the drift that caused live zero-match). It now authoritatively applies every non-secret value from `config/environments/<environment>.toml` (incl. `AZURE_STORAGE_CONTAINER`) via additive `--set-env-vars`. Secrets are refused by `deploy_env_vars()` and existing `secretRef`s (e.g. `AZURE_STORAGE_KEY`) are left untouched.
 
 ## [0.8.6] - 2026-06-30
 

--- a/deploy/scripts/deploy_azure.py
+++ b/deploy/scripts/deploy_azure.py
@@ -2,11 +2,12 @@
 """
 Manual deployment script for Azure Container Apps.
 
-This script uses the Azure deployer to update the running container app's
-image (and a small set of non-sensitive config vars) without touching
-credentials already configured on the container directly via `az` (storage
-keys, LLM encryption secrets) -- the update path is additive
-(--set-env-vars), so anything not listed here is left alone.
+This script uses the Azure deployer to update the running container app's image
+and to authoritatively apply the **non-secret** per-environment configuration
+from ``config/environments/<environment>.toml`` (storage provider / account /
+container, etc.) via ``--set-env-vars``. Secrets (storage keys, LLM encryption
+secrets, API keys) are never applied here -- they stay Azure ``secretRef`` /
+``.env`` only, and the additive update path leaves them untouched.
 """
 
 import argparse
@@ -24,6 +25,7 @@ from deploy.providers.azure import (
     AzureDeploymentConfig,
     DeploymentError,
 )
+from src.config.schema import deploy_env_vars
 
 logging.basicConfig(
     level=logging.INFO,
@@ -59,6 +61,11 @@ def main():
         "--image",
         required=True,
         help="Docker image to deploy (e.g., touchthesun/openhardwaremanager:0.8.6)",
+    )
+    parser.add_argument(
+        "--environment",
+        default=os.getenv("ENVIRONMENT", "production"),
+        help="Target environment; selects config/environments/<env>.toml (default: production)",
     )
     parser.add_argument(
         "--cors-origins",
@@ -97,20 +104,33 @@ def main():
         )
         return 1
 
+    # Authoritatively apply the non-secret per-environment config (storage
+    # provider / account / container, etc.) from config/environments/<env>.toml,
+    # plus the runtime ENVIRONMENT and CORS_ORIGINS. Secrets are NOT included:
+    # deploy_env_vars() refuses schema-secret keys, and the additive
+    # --set-env-vars update leaves existing secretRefs (e.g. AZURE_STORAGE_KEY)
+    # untouched.
+    environment_vars = deploy_env_vars(args.environment)
+    environment_vars["ENVIRONMENT"] = args.environment
+    environment_vars["CORS_ORIGINS"] = args.cors_origins
+
     print("=" * 80)
     print("Azure Container Apps Deployment")
     print("=" * 80)
     print(f"Resource Group: {args.resource_group}")
     print(f"Container App: {args.container_app_name}")
     print(f"Image: {args.image}")
-    print(f"CORS_ORIGINS: {args.cors_origins}")
+    print(f"Environment: {args.environment}")
+    print("Applying non-secret env vars (secrets stay secretRef, untouched):")
+    for key, value in environment_vars.items():
+        print(f"  {key}={value}")
     print("=" * 80)
 
     try:
         config = AzureDeploymentConfig.from_dict(
             {
                 "provider": "azure",
-                "environment": "production",
+                "environment": args.environment,
                 "region": args.region,
                 "service": {
                     "name": args.container_app_name,
@@ -119,15 +139,11 @@ def main():
                     "cpu": args.cpu,
                     "min_instances": args.min_instances,
                     "max_instances": args.max_instances,
-                    # Deliberately minimal: this is an UPDATE to an existing
-                    # container app via --set-env-vars (additive). Storage
-                    # credentials and LLM encryption secrets are already
-                    # configured on the container outside this deployer and
-                    # are left untouched -- only image + these vars change.
-                    "environment_vars": {
-                        "ENVIRONMENT": "production",
-                        "CORS_ORIGINS": args.cors_origins,
-                    },
+                    # UPDATE to an existing container app via --set-env-vars
+                    # (additive): applies the non-secret per-env values below and
+                    # leaves everything else (secretRefs incl. AZURE_STORAGE_KEY,
+                    # LLM encryption secrets) untouched.
+                    "environment_vars": environment_vars,
                 },
                 "providers": {
                     "azure": {

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -18,8 +18,9 @@ from __future__ import annotations
 
 import logging
 import os
+import tomllib
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from dotenv import load_dotenv
 from pydantic import Field, field_validator
@@ -222,3 +223,39 @@ def get_settings() -> Settings:
     functions this replaces.
     """
     return Settings()
+
+
+def _secret_field_names() -> set[str]:
+    return {
+        name
+        for name, field in Settings.model_fields.items()
+        if isinstance(field.json_schema_extra, dict)
+        and field.json_schema_extra.get("secret")
+    }
+
+
+def deploy_env_vars(environment: str) -> Dict[str, str]:
+    """Non-secret env vars to apply to ``<environment>``'s container app.
+
+    Reads ``config/environments/<environment>.toml`` — the checked-in source of
+    truth for non-secret config — and returns ``{ENV_VAR: value}`` (snake_case
+    keys mapped to their upper-case env-var names). Schema fields marked secret
+    are refused: the deploy pipeline never applies secrets, which stay an Azure
+    ``secretRef`` / ``.env`` only. Returns ``{}`` when the file is absent.
+    """
+    path = _CONFIG_ENV_DIR / f"{environment}.toml"
+    if not path.is_file():
+        return {}
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    secret_fields = _secret_field_names()
+    env_vars: Dict[str, str] = {}
+    for key, value in data.items():
+        if key in secret_fields:
+            logger.warning(
+                "Refusing to deploy secret %r from %s — use a secretRef instead.",
+                key,
+                path.name,
+            )
+            continue
+        env_vars[key.upper()] = str(value)
+    return env_vars

--- a/tests/unit/test_config_schema.py
+++ b/tests/unit/test_config_schema.py
@@ -8,7 +8,13 @@ environment normalization.
 
 import pytest
 
-from src.config.schema import Settings, get_settings, resolve_cors_origins
+import src.config.schema as schema_mod
+from src.config.schema import (
+    Settings,
+    deploy_env_vars,
+    get_settings,
+    resolve_cors_origins,
+)
 
 # Slice-1 env vars that must be neutralized for deterministic tests (the
 # developer's .env is loaded at import time and would otherwise leak in).
@@ -142,3 +148,33 @@ class TestInitOverride:
         # init > env > toml precedence
         clean_env.setenv("STORAGE_PROVIDER", "azure_blob")
         assert Settings(storage_provider="gcs").storage_provider == "gcs"
+
+
+class TestDeployEnvVars:
+    def test_production_applies_storage_target(self):
+        env = deploy_env_vars("production")
+        assert env["STORAGE_PROVIDER"] == "azure_blob"
+        assert env["AZURE_STORAGE_ACCOUNT"] == "projdatablobstorage"
+        assert env["AZURE_STORAGE_CONTAINER"] == "production"
+
+    def test_development_is_local(self):
+        assert deploy_env_vars("development") == {"STORAGE_PROVIDER": "local"}
+
+    def test_missing_environment_returns_empty(self):
+        assert deploy_env_vars("does-not-exist") == {}
+
+    def test_keys_are_uppercased_env_names(self):
+        # TOML uses snake_case; deploy needs upper-case env-var names.
+        assert all(k == k.upper() for k in deploy_env_vars("production"))
+
+    def test_secret_keys_are_refused(self, tmp_path, monkeypatch):
+        # A secret accidentally placed in a per-env file must never be deployed.
+        (tmp_path / "sneaky.toml").write_text(
+            'storage_provider = "azure_blob"\n'
+            'azure_storage_key = "leaked-secret-key"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(schema_mod, "_CONFIG_ENV_DIR", tmp_path)
+        env = deploy_env_vars("sneaky")
+        assert env == {"STORAGE_PROVIDER": "azure_blob"}
+        assert "AZURE_STORAGE_KEY" not in env


### PR DESCRIPTION
Closes #239. Config Slice 1 (v0.8.7). Builds on #237 (now on `main`).

## What to build

Reverses `deploy/scripts/deploy_azure.py`'s stance on storage config. It previously set only `ENVIRONMENT` + `CORS_ORIGINS` and left `STORAGE_*` configured directly on the container app — invisible to the repo, which is exactly how prod drifted onto the wrong container (the live zero-match). It now **authoritatively applies every non-secret value** from `config/environments/<environment>.toml` (incl. `AZURE_STORAGE_CONTAINER`) via additive `--set-env-vars`.

New `schema.deploy_env_vars(environment)` reads the per-env TOML and returns the `{ENV_VAR: value}` map, **refusing any schema-secret key** — secrets stay `secretRef` / `.env` only, and the additive update leaves existing secretRefs (e.g. `AZURE_STORAGE_KEY`) untouched. Adds `--environment` (default `production`) and logs the applied vars.

## Acceptance criteria

- [x] `deploy_azure.py` reads `config/environments/<env>.toml` and sets the non-secret storage vars (provider, account, container) via `--set-env-vars`
- [x] Deploy never sets/overwrites secret values (secrets remain `secretRef`; `deploy_env_vars()` refuses them)
- [x] Redeploy is idempotent (re-applying the same per-env file is a no-op on env vars)
- [x] `make ready` passes

## Live status

The `production` container is **seeded and already live** (manual repoint done + verified: `/v1/api/okw` 1→79 facilities). This PR makes that container assignment come authoritatively from `production.toml` on the next release, retiring the manual `--set-env-vars`. Safe to merge — the release job's default `--environment production` reads `production.toml`, which already points at the seeded `production` container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)