### PR TITLE
chore(release): 0.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.7] - 2026-07-06
+
 ### Added
 
 - **Typed configuration schema + per-environment files (config Slice 1):** a `pydantic-settings` schema (`src/config/schema.py`) is now the single source of truth for the storage target (provider / account / container), the runtime `environment`, `OKW_SOURCE`, and CORS. Non-secret values are checked in per environment at `config/environments/{development,test,production}.toml` and layered under process env vars (env wins); secrets (`AZURE_STORAGE_KEY`, `API_KEYS`, `LLM_*`) stay env/`secretRef`-only. `settings.py` and `storage_config.py` consumers read the schema; the old inline env-read paths were removed. Behaviour-preserving — the `docker --env-file` quote-stripping quirk is consolidated into one normalizing env source, and characterization tests pin per-setting equivalence.
@@ -28,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **MoM integration documentation and test coverage:** `docs/runbooks/mom-integration-e2e-validation.md` — CLI/API demo runbook verified against the live MoM SPARQL endpoint, plus unit tests for `mom_bridge.py`, taxonomy `wikidata_qid` lookups, and `OKW_SOURCE` routing (none existed since the integration shipped in `#181`).
 
+[0.8.7]: https://github.com/helpfulengineering/supply-graph-ai/compare/v0.8.6...v0.8.7
 [0.8.6]: https://github.com/helpfulengineering/supply-graph-ai/compare/v0.8.5...v0.8.6
 
 ## [0.8.5] - 2026-06-29

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "supply-graph-ai"
-version = "0.8.6"
+version = "0.8.7"
 description = "Open Hardware Manager (OHM) - A flexible, domain-agnostic framework for matching requirements with capabilities"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Version bump **0.8.6 → 0.8.7** + CHANGELOG finalization. No code changes — all v0.8.7 work already merged (#237, #238, #239, #241).

## Release contents (config Slice 1 — drift hardening)

- **#237** typed `pydantic-settings` schema + per-environment TOMLs
- **#238** generated `env.template` + staleness gate
- **#239** deploy pipeline applies non-secret per-env config from the repo
- **#241** drift guards: startup posture (hard-fail prod / warn dev), `/health` storage fingerprint, release deploy-gate

## Release procedure (after this merges)

Tag `v0.8.7` on the merge commit and push it → `release.yml` runs: validate → test → docker-smoke → **publish multi-arch to Docker Hub** → **deploy-azure** (gated by the `production` GitHub Environment; applies `production.toml` config + runs the new deploy-gate) → GitHub Release.

Live prod is already seeded + pointed at the `production` container, so the new deploy-gate (live container == `production.toml` AND counts > 0) and startup posture will pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)