### PR TITLE
docs(config): document the 0.8.7 config surface (setup skill, README, dev guide)

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -63,6 +63,15 @@ Save the answer as `$SETUP_PATH` and use it to gate questions in Steps 3 and 4.
 
 Collect values for all required (and relevant optional) parameters. Skip any param already present in `.env`.
 
+**Configuration model (0.8.7+).** OHM resolves config in two layers: non-secret
+defaults (storage provider / account / container, `OKW_SOURCE`, CORS) are checked
+into the repo per environment at `config/environments/<ENVIRONMENT>.toml`, and your
+process environment / `.env` is layered on top and **wins**. This skill collects
+values into `.env`, which is the correct place for both secrets and any override.
+So you only need to set in `.env` what differs from the environment's TOML defaults
+(and every secret — `AZURE_STORAGE_KEY`, `API_KEYS`, `LLM_*` — which never belong in
+the checked-in TOML files). `ENVIRONMENT` selects which TOML loads.
+
 ### 3a: Environment
 
 Ask: "Are you setting this up for local development or production?"
@@ -231,6 +240,11 @@ STORAGE_PROVIDER=<value>
 # ... only params relevant to chosen options
 ```
 
+Note on `env.template`: the block between its `BEGIN/END GENERATED` markers is
+emitted from the config schema — do not hand-edit it (run `make env-template` to
+regenerate). Everything outside the markers is hand-maintained. `.env` still
+overrides both the generated defaults and the per-environment TOML files.
+
 Rules:
 - Only write params relevant to the chosen storage provider and enabled features
 - Do not write cloud provider params for providers that are not selected
@@ -344,6 +358,15 @@ For **cloud storage**: verify credentials by making a test API call after the se
 ```bash
 curl -s http://localhost:8001/health
 ```
+
+`/health` includes a `storage` fingerprint — the resolved provider / account /
+container the app is actually using, plus `okh/` and `okw/` object counts. Use it
+to confirm you are pointed at the container you expect **and** that it has data
+(counts `0` usually means an empty or mis-pointed container). Note: in
+`ENVIRONMENT=production` the app **hard-fails on startup** if storage config is
+invalid or incomplete (e.g. `azure_blob` without account/container/key); in
+`development` it warns and continues degraded — so a failed prod boot is almost
+always a missing storage value.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ AZURE_STORAGE_CONTAINER=<your-container-name>
 
 See [Container Guide](docs/development/container-guide.md) for the full list of storage env vars and examples for AWS S3 and GCS.
 
+> **How configuration resolves.** Non-secret defaults (storage provider / account
+> / container, `OKW_SOURCE`, CORS) are checked in per environment under
+> `config/environments/<ENVIRONMENT>.toml` and selected by `ENVIRONMENT`; anything
+> you pass as an env var (or in `.env`) overrides them. Secrets — `AZURE_STORAGE_KEY`,
+> `API_KEYS`, `LLM_*` — are never in those files (use `.env` or an Azure `secretRef`).
+> In `production` the app hard-fails on missing/invalid storage config, and `/health`
+> reports the resolved storage target + object counts. See the
+> [Developer Guide](docs/development/developer-guide.md) for details.
+
 The API is at `http://localhost:8001`. Docs: `http://localhost:8001/v1/docs`. Check version: `curl -s http://localhost:8001/health`.
 
 Images support **linux/amd64** and **linux/arm64** (Apple Silicon and x86-64). Federation is **disabled by default**. Enable with `-e OHM_FEDERATION_ENABLED=true` only when you intend to run peer sync (see [federation docs](docs/development/federation-infra.md)).

--- a/docs/development/developer-guide.md
+++ b/docs/development/developer-guide.md
@@ -47,7 +47,20 @@ docker compose up --build ohm-api
 > var always overrides the file. Secrets (`AZURE_STORAGE_KEY`, `API_KEYS`,
 > `LLM_*`) are never in those files — keep them in `.env` locally or an Azure
 > `secretRef` in production. `ENVIRONMENT` (default `development`) selects which
-> file loads.
+> file loads. The typed schema lives in `src/config/schema.py`.
+>
+> A few consequences worth knowing (all added in 0.8.7):
+>
+> - **`env.template` is partly generated.** The block between the
+>   `BEGIN/END GENERATED` markers is emitted from the schema — regenerate it with
+>   `make env-template` (also part of `make format`); CI fails if it drifts.
+>   Everything outside the markers is still hand-maintained.
+> - **Startup validation.** In `production` the app hard-fails on invalid/missing
+>   storage config (e.g. `azure_blob` without account/container/key); in
+>   `development` it logs a warning and continues degraded.
+> - **`/health` reports a storage fingerprint** — the resolved provider / account
+>   / container the app is actually using plus `okh/` and `okw/` object counts.
+>   Use it to confirm you are pointed at the container you expect, with data in it.
 
 ### Verify Installation
 


### PR DESCRIPTION
Follow-up to the v0.8.7 config work (#237/#238/#239/#241): the onboarding docs didn't mention the new config surface. Additive updates only — the existing env-var instructions stay correct (behaviour-preserving), these teach the new mechanism.

## Changes

- **`.claude/skills/setup/SKILL.md`** — a "Configuration model (0.8.7+)" note at the top of Step 3 (two-layer: `config/environments/<env>.toml` non-secret defaults + `.env` overrides/secrets, env wins); a note in Step 4 that `env.template`'s `BEGIN/END GENERATED` block is emitted from the schema (`make env-template`, don't hand-edit); and a Step-7 note that `/health` exposes a storage fingerprint (provider/account/container + `okh/`/`okw/` counts) and that `production` hard-fails startup on invalid storage config.
- **`README.md`** — a concise "How configuration resolves" callout next to the storage env vars, linking to the Developer Guide.
- **`docs/development/developer-guide.md`** — expands the existing configuration-layering note with the generated `env.template` block, startup validation posture, and the `/health` fingerprint.

`make ready` green (validate-docs included).

## Note

I took "getting started guide" to mean the **Developer Guide** (the dev onboarding page linked from docs Getting Started, and the one with the `cp env.template .env` flow). If you meant a different page (e.g. `docs/CLI/quick-start.md`), say so and I'll move it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)