### PR TITLE
build: guard version references and uv.lock against drift from pyproject

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Verify version references are in sync
         run: uv run python scripts/bump_version.py --check
 
+      - name: Verify uv.lock is up to date
+        run: uv lock --check
+
   test:
     name: Test (stable CI subset)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -47,6 +47,9 @@ jobs:
           uv run python scripts/generate_env_template.py
           git diff --exit-code env.template
 
+      - name: Verify version references are in sync
+        run: uv run python scripts/bump_version.py --check
+
   test:
     name: Test (stable CI subset)
     runs-on: ubuntu-latest

--- a/.repo-map.md
+++ b/.repo-map.md
@@ -74,6 +74,12 @@ Total Python files: 443
 │   │       def _expected_remote_blob_keys()
 │   │       def main()
 │   ├── bump_version.py
+│   │       class Site
+│   │       def read_pyproject_version()
+│   │       def _swap_version()
+│   │       def _scan_site()
+│   │       def check()
+│   │       def bump()
 │   │       def main()
 │   ├── clear_storage.py
 │   ├── compare_storage_containers.py
@@ -4495,14 +4501,23 @@ Round-tri...
 **Internal Dependencies:** 12 imports
 
 ### `scripts/bump_version.py`
-> Bump the package version in pyproject.toml (single source of truth).
+> Bump the OHM version everywhere it is claimed, from one source of truth.
 
-Usage:
-    python scripts/bump...
+`pyproject.toml` is the ca...
 
-**Exports:** main
+**Exports:** Site, read_pyproject_version, check, bump, main
+
+**Classes:**
+- `Site`
+  - A file location that states the current release as literal text.
+
+``pattern`` mu...
 
 **Functions:**
+- `read_pyproject_version()`
+- `check(target)`
+  - Fail if any registered site disagrees with `target` (pyproject version)....
+- `bump(new_version)`
 - `main()`
 
 ### `scripts/clear_storage.py`

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Code style and project map via uv-managed environment.
-.PHONY: format format-check lint test check black ruff repo-map env-template env-template-check validate-docs parity ready setup verify-env frontend-setup frontend-ready
+.PHONY: format format-check lint test check black ruff repo-map env-template env-template-check validate-docs version-check parity ready setup verify-env frontend-setup frontend-ready
 
 # Web frontend verification harness (the frontend analogue of `ready`).
 # See frontend/harness/README.md. Runs typecheck, lint, unit, build, and the
@@ -59,6 +59,11 @@ env-template-check:
 validate-docs:
 	uv run python scripts/validate_docs.py
 
+# Version drift gate (lockfile pattern): fails if any "current release" claim
+# in the registry (scripts/bump_version.py) drifts from pyproject.toml.
+version-check:
+	uv run python scripts/bump_version.py --check
+
 # Service <-> API <-> CLI parity gate. Fails when a service, route, or CLI
 # group drifts from the declared contract in tests/parity/manifest.py.
 parity:
@@ -67,10 +72,11 @@ parity:
 # Definition of done. Green tests are not "ready to merge"; this is.
 # Each step verifies (does not mutate) and fails fast. Run before any MR.
 ready:
-	@echo "==> [1/6] env verify";      $(MAKE) verify-env
-	@echo "==> [2/6] format check";    $(MAKE) format-check
-	@echo "==> [3/6] lint";            $(MAKE) lint
-	@echo "==> [4/6] unit tests";      $(MAKE) test
-	@echo "==> [5/6] service parity";  $(MAKE) parity
-	@echo "==> [6/6] docs ↔ code";     $(MAKE) validate-docs
+	@echo "==> [1/7] env verify";      $(MAKE) verify-env
+	@echo "==> [2/7] format check";    $(MAKE) format-check
+	@echo "==> [3/7] lint";            $(MAKE) lint
+	@echo "==> [4/7] unit tests";      $(MAKE) test
+	@echo "==> [5/7] service parity";  $(MAKE) parity
+	@echo "==> [6/7] docs ↔ code";     $(MAKE) validate-docs
+	@echo "==> [7/7] version sync";    $(MAKE) version-check
 	@echo "==> READY: all gates passed."

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Code style and project map via uv-managed environment.
-.PHONY: format format-check lint test check black ruff repo-map env-template env-template-check validate-docs version-check parity ready setup verify-env frontend-setup frontend-ready
+.PHONY: format format-check lint test check black ruff repo-map env-template env-template-check validate-docs version-check lock-check parity ready setup verify-env frontend-setup frontend-ready
 
 # Web frontend verification harness (the frontend analogue of `ready`).
 # See frontend/harness/README.md. Runs typecheck, lint, unit, build, and the
@@ -64,6 +64,11 @@ validate-docs:
 version-check:
 	uv run python scripts/bump_version.py --check
 
+# Lockfile drift gate: fails if uv.lock is stale vs pyproject.toml. Non-mutating
+# (unlike `uv lock`/`uv sync`), so it is safe in the `ready` gate.
+lock-check:
+	uv lock --check
+
 # Service <-> API <-> CLI parity gate. Fails when a service, route, or CLI
 # group drifts from the declared contract in tests/parity/manifest.py.
 parity:
@@ -72,11 +77,12 @@ parity:
 # Definition of done. Green tests are not "ready to merge"; this is.
 # Each step verifies (does not mutate) and fails fast. Run before any MR.
 ready:
-	@echo "==> [1/7] env verify";      $(MAKE) verify-env
-	@echo "==> [2/7] format check";    $(MAKE) format-check
-	@echo "==> [3/7] lint";            $(MAKE) lint
-	@echo "==> [4/7] unit tests";      $(MAKE) test
-	@echo "==> [5/7] service parity";  $(MAKE) parity
-	@echo "==> [6/7] docs ↔ code";     $(MAKE) validate-docs
-	@echo "==> [7/7] version sync";    $(MAKE) version-check
+	@echo "==> [1/8] env verify";      $(MAKE) verify-env
+	@echo "==> [2/8] format check";    $(MAKE) format-check
+	@echo "==> [3/8] lint";            $(MAKE) lint
+	@echo "==> [4/8] unit tests";      $(MAKE) test
+	@echo "==> [5/8] service parity";  $(MAKE) parity
+	@echo "==> [6/8] docs ↔ code";     $(MAKE) validate-docs
+	@echo "==> [7/8] version sync";    $(MAKE) version-check
+	@echo "==> [8/8] lockfile sync";   $(MAKE) lock-check
 	@echo "==> READY: all gates passed."

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -4,22 +4,27 @@ This document describes how to cut and publish an OHM release. For the 0.8.0 pla
 
 ## Current release
 
+The canonical version lives in `pyproject.toml`. For the current release number
+and its notes, see [README.md](../README.md) and [CHANGELOG.md](../CHANGELOG.md);
+this document describes the *process*, not a specific version.
+
 | Item | Value |
 |------|-------|
-| Application version | `0.8.0` (defined in `pyproject.toml`) |
-| Git tag | `v0.8.0` |
 | Docker image | `touchthesun/openhardwaremanager` |
-| Image tags | `0.8.0`, `0.8`, `latest` |
+| Image tags | `X.Y.Z` (exact), `X.Y` (floating minor), `latest` |
 | Platforms | `linux/amd64`, `linux/arm64` (multi-arch manifest via `docker buildx`) |
 
 ### Pull and run
 
+The `:0.8` tag below floats to the latest `0.8.x` patch, so these commands never
+go stale. Pin an exact `:X.Y.Z` tag for reproducibility.
+
 ```bash
-docker pull touchthesun/openhardwaremanager:0.8.0
+docker pull touchthesun/openhardwaremanager:0.8
 docker run -p 8001:8001 \
   -e STORAGE_PROVIDER=local \
   -e LLM_ENABLED=false \
-  touchthesun/openhardwaremanager:0.8.0
+  touchthesun/openhardwaremanager:0.8
 curl -s http://localhost:8001/health
 ```
 
@@ -105,10 +110,10 @@ docker build --build-arg APP_VERSION=0.8.0 -t openhardwaremanager:0.8.0 .
 ## Post-publish smoke test
 
 ```bash
-docker pull touchthesun/openhardwaremanager:0.8.0
+docker pull touchthesun/openhardwaremanager:0.8
 docker run -d --name ohm-smoke -p 8001:8001 \
   -e STORAGE_PROVIDER=local -e LLM_ENABLED=false \
-  touchthesun/openhardwaremanager:0.8.0
+  touchthesun/openhardwaremanager:0.8
 curl -sf http://localhost:8001/health
 curl -sf http://localhost:8001/health/liveness
 # Federation disabled by default:
@@ -116,7 +121,7 @@ curl -sf http://localhost:8001/v1/api/federation/identify | head -c 200
 docker rm -f ohm-smoke
 ```
 
-Expect `"version": "0.8.0"` on `/health` and federation routes to return 404 when federation is disabled.
+Expect `/health` to report the version you just published and federation routes to return 404 when federation is disabled.
 
 ## Multi-architecture images
 
@@ -127,8 +132,8 @@ Smoke tests in CI still run a single **amd64** image loaded on the runner (`dock
 To verify locally after publish:
 
 ```bash
-docker buildx imagetools inspect touchthesun/openhardwaremanager:0.8.0
-docker pull touchthesun/openhardwaremanager:0.8.0   # uses host architecture
+docker buildx imagetools inspect touchthesun/openhardwaremanager:0.8
+docker pull touchthesun/openhardwaremanager:0.8   # uses host architecture
 ```
 
 To rebuild an already-published tag (e.g. add arm64 to `0.8.0`), re-run **Release** with `workflow_dispatch` and `dry_run: false` on `main` at the release commit, or push a new patch tag (`v0.8.1`).

--- a/docs/development/container-guide.md
+++ b/docs/development/container-guide.md
@@ -15,12 +15,13 @@ This guide covers running and deploying the Open Hardware Manager (OHM) in conta
 
 ## Quick Start
 
-### Published image (release 0.8.1)
+### Published image
 
-For a pre-built image matching CI and release automation:
+For a pre-built image matching CI and release automation. The `:0.8` tag floats
+to the latest `0.8.x` patch; pin an exact `:X.Y.Z` tag for reproducibility.
 
 ```bash
-docker pull touchthesun/openhardwaremanager:0.8.1
+docker pull touchthesun/openhardwaremanager:0.8
 ```
 
 **With local storage (no credentials needed):**
@@ -29,7 +30,7 @@ docker pull touchthesun/openhardwaremanager:0.8.1
 docker run -p 8001:8001 \
   -e STORAGE_PROVIDER=local \
   -e LLM_ENABLED=false \
-  touchthesun/openhardwaremanager:0.8.1
+  touchthesun/openhardwaremanager:0.8
 ```
 
 **With remote storage (Azure Blob, AWS S3, or GCS):**
@@ -41,7 +42,7 @@ The recommended approach is `--env-file`, which mirrors what `docker-compose` do
 ```bash
 docker run -p 8001:8001 \
   --env-file .env \
-  touchthesun/openhardwaremanager:0.8.1
+  touchthesun/openhardwaremanager:0.8
 ```
 
 You can also pass individual variables with `-e` flags:
@@ -52,11 +53,11 @@ docker run -p 8001:8001 \
   -e AZURE_STORAGE_ACCOUNT=<account-name> \
   -e AZURE_STORAGE_KEY=<account-key> \
   -e AZURE_STORAGE_CONTAINER=<container-name> \
-  touchthesun/openhardwaremanager:0.8.1
+  touchthesun/openhardwaremanager:0.8
 ```
 
 - API documentation: http://localhost:8001/v1/docs
-- Health check: http://localhost:8001/health (expect `"version": "0.8.1"`)
+- Health check: http://localhost:8001/health (the `version` field reports the running release)
 - Federation is **off by default** (`OHM_FEDERATION_ENABLED=false`). See [federation infrastructure](federation-infra.md) to enable peer sync.
 
 Other tags: `touchthesun/openhardwaremanager:0.8`, `:latest`. Images are **multi-arch** (`linux/amd64`, `linux/arm64`). See [Release process](../RELEASE.md).
@@ -491,13 +492,13 @@ For production, consider using:
 
    Fix by passing the env file explicitly:
    ```bash
-   docker run -p 8001:8001 --env-file .env touchthesun/openhardwaremanager:0.8.1
+   docker run -p 8001:8001 --env-file .env touchthesun/openhardwaremanager:0.8
    ```
 
    To verify connectivity once the container is running, use the `storage setup` CLI command (it will connect to the configured provider and report any credential errors):
    ```bash
    docker run --rm --env-file .env \
-     touchthesun/openhardwaremanager:0.8.1 \
+     touchthesun/openhardwaremanager:0.8 \
      cli storage setup --provider azure_blob
    ```
 

--- a/docs/development/local-development-setup.md
+++ b/docs/development/local-development-setup.md
@@ -279,7 +279,7 @@ curl http://localhost:7071/api/listOKHsummaries
 # Test API health
 curl http://localhost:8001/health
 
-# Expected: {"status": "ok", "domains": [...], "version": "0.8.0"}
+# Expected: {"status": "ok", "domains": [...], "version": "<current release>"}
 
 # Test API documentation
 open http://localhost:8001/v1/docs

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,13 +1,23 @@
 #!/usr/bin/env python3
-"""Bump the package version in pyproject.toml (single source of truth).
+"""Bump the OHM version everywhere it is claimed, from one source of truth.
+
+`pyproject.toml` is the canonical version. A small registry (`_SITES`) lists the
+*other* places that state the **current** release as literal text — these are the
+drift-prone spots. One command rewrites them all in lockstep; `--check` verifies
+they still match (a staleness gate for `make ready`).
+
+Only "current release" claims belong in the registry (README badge, quickstart
+docker tags). Historical facts (CHANGELOG, "added in 0.8.x") and illustrative
+examples ("e.g. v0.8.0") must NOT be listed — they are correctly pinned to a
+specific version and should never move. Docker examples in the docs float on the
+`:0.8` major.minor tag on purpose, so they never drift and are not registered.
 
 Usage:
-    python scripts/bump_version.py 0.8.0
-    uv run python scripts/bump_version.py 0.9.0
+    python scripts/bump_version.py 0.9.0     # bump pyproject + registry
+    python scripts/bump_version.py --check    # verify registry == pyproject
 
-After bumping, run:
-    uv lock
-    uv sync --extra dev
+After a bump, run:
+    uv lock && uv sync --extra dev
 """
 
 from __future__ import annotations
@@ -15,22 +25,99 @@ from __future__ import annotations
 import argparse
 import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parents[1]
 _PYPROJECT = _ROOT / "pyproject.toml"
-_VERSION_RE = re.compile(r"^version\s*=\s*\"[^\"]+\"", re.MULTILINE)
+_PYPROJECT_VERSION_RE = re.compile(r'^version\s*=\s*"([^"]+)"', re.MULTILINE)
 _SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
 
 
-def main() -> int:
-    parser = argparse.ArgumentParser(description="Bump version in pyproject.toml")
-    parser.add_argument(
-        "version",
-        help="New semver version (e.g. 0.8.0)",
-    )
-    args = parser.parse_args()
-    new_version = args.version.strip()
+@dataclass(frozen=True)
+class Site:
+    """A file location that states the current release as literal text.
+
+    ``pattern`` must contain a named group ``v`` capturing a full semver; only
+    that group is rewritten, so surrounding text is preserved verbatim.
+    """
+
+    relpath: str
+    pattern: re.Pattern[str]
+    label: str
+
+
+# The registry. Keep this list minimal — every entry is a promise to keep that
+# spot exactly equal to pyproject. Prefer floating tags / pointers over adding
+# rows here (see module docstring).
+_SITES: list[Site] = [
+    Site(
+        "README.md",
+        re.compile(r"\*\*Current release:\*\*\s+`(?P<v>\d+\.\d+\.\d+)`"),
+        "current-release line",
+    ),
+    Site(
+        "README.md",
+        re.compile(r"openhardwaremanager:(?P<v>\d+\.\d+\.\d+)"),
+        "quickstart docker tag",
+    ),
+]
+
+
+def read_pyproject_version() -> str:
+    match = _PYPROJECT_VERSION_RE.search(_PYPROJECT.read_text(encoding="utf-8"))
+    if not match:
+        raise RuntimeError(f"No version field found in {_PYPROJECT}")
+    return match.group(1)
+
+
+def _swap_version(match: re.Match[str], new_version: str) -> str:
+    """Return the full match text with only its ``v`` group set to new_version."""
+    whole = match.group(0)
+    start = match.start("v") - match.start()
+    end = match.end("v") - match.start()
+    return whole[:start] + new_version + whole[end:]
+
+
+def _scan_site(site: Site) -> tuple[str, list[str]]:
+    """Return (file text, list of versions found at this site)."""
+    text = (_ROOT / site.relpath).read_text(encoding="utf-8")
+    found = [m.group("v") for m in site.pattern.finditer(text)]
+    return text, found
+
+
+def check(target: str) -> int:
+    """Fail if any registered site disagrees with `target` (pyproject version)."""
+    problems: list[str] = []
+    for site in _SITES:
+        _, found = _scan_site(site)
+        if not found:
+            problems.append(
+                f"{site.relpath}: pattern for {site.label!r} matched nothing "
+                f"(file changed? update _SITES in scripts/bump_version.py)"
+            )
+            continue
+        stale = sorted({v for v in found if v != target})
+        if stale:
+            problems.append(
+                f"{site.relpath}: {site.label} is {', '.join(stale)}, "
+                f"expected {target}"
+            )
+    if problems:
+        print("Version drift detected (canonical = pyproject.toml):", file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}", file=sys.stderr)
+        print(
+            "Fix: run `python scripts/bump_version.py "
+            f"{target}` to resync, then commit.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"OK: {len(_SITES)} version site(s) match pyproject {target}")
+    return 0
+
+
+def bump(new_version: str) -> int:
     if not _SEMVER_RE.match(new_version):
         print(
             f"Invalid semver: {new_version!r} (expected MAJOR.MINOR.PATCH)",
@@ -39,17 +126,54 @@ def main() -> int:
         return 1
 
     text = _PYPROJECT.read_text(encoding="utf-8")
-    if not _VERSION_RE.search(text):
+    if not _PYPROJECT_VERSION_RE.search(text):
         print(f"No version field found in {_PYPROJECT}", file=sys.stderr)
         return 1
+    old = read_pyproject_version()
+    _PYPROJECT.write_text(
+        _PYPROJECT_VERSION_RE.sub(f'version = "{new_version}"', text, count=1),
+        encoding="utf-8",
+    )
+    print(f"pyproject.toml: {old} -> {new_version}")
 
-    old_match = _VERSION_RE.search(text)
-    old_line = old_match.group(0) if old_match else "?"
-    new_text = _VERSION_RE.sub(f'version = "{new_version}"', text, count=1)
-    _PYPROJECT.write_text(new_text, encoding="utf-8")
-    print(f'Updated {_PYPROJECT.name}: {old_line} -> version = "{new_version}"')
+    for site in _SITES:
+        original, found = _scan_site(site)
+        if not found:
+            print(
+                f"WARNING: {site.relpath}: pattern for {site.label!r} matched "
+                f"nothing; nothing updated there.",
+                file=sys.stderr,
+            )
+            continue
+        updated = site.pattern.sub(lambda m: _swap_version(m, new_version), original)
+        if updated != original:
+            (_ROOT / site.relpath).write_text(updated, encoding="utf-8")
+            print(f"{site.relpath}: {site.label} -> {new_version}")
+
     print("Next: uv lock && uv sync --extra dev")
     return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Bump the OHM version across pyproject and the registry."
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "version",
+        nargs="?",
+        help="New semver version (e.g. 0.9.0)",
+    )
+    group.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify registered sites match pyproject; do not write.",
+    )
+    args = parser.parse_args()
+
+    if args.check:
+        return check(read_pyproject_version())
+    return bump(args.version.strip())
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -3185,7 +3185,7 @@ wheels = [
 
 [[package]]
 name = "supply-graph-ai"
-version = "0.8.6"
+version = "0.8.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Problem

Two drift vectors, same root cause — a hand-maintained value diverging from `pyproject.toml` with nothing to catch it:

1. The README declared `0.8.2` while the release was `0.8.7` (docs prose drift). `scripts/bump_version.py` only updated `pyproject.toml`.
2. `uv.lock`'s self-version lagged at `0.8.6` (lockfile drift) — the pyproject bump never re-ran `uv lock`.

## Fix — propagate + guard, for both

**Version references.** `bump_version.py` now carries a `_SITES` registry of the *"current release"* claims (README badge + quickstart docker tags) and rewrites them in lockstep with `pyproject.toml` on bump. `bump_version.py --check` verifies they match and fails on drift (or if a registered pattern stops matching a restructured file).

**Lockfile.** `uv lock --check` (non-mutating) asserts `uv.lock` is up to date vs `pyproject.toml`.

Both are wired the same way, mirroring the existing `env-template` / `repo-map` staleness gates:
- `make ready` steps **[7/8] version sync** and **[8/8] lockfile sync**, and
- CI `quality`-job steps *"Verify version references are in sync"* and *"Verify uv.lock is up to date"*.

## Keeping the tracked set to one file

Drift-prone doc examples were floated **out of** "current release" scope so they never need propagation:

| Reference | Before | After |
|---|---|---|
| Docs docker pulls (RELEASE, container-guide) | `:0.8.1` / `:0.8.0` (stale) | `:0.8` floating minor tag |
| RELEASE.md "Current release" table | hard-coded `0.8.0` | points to README/CHANGELOG (it's a *process* doc) |
| Health-output examples | `"version": "0.8.0"` | genericized |

Historical references (CHANGELOG, "added in 0.8.x") and illustrative command samples (`--tag v0.8.0`, `APP_VERSION=` builds, rollback's deliberately-exact pin) are left untouched. The tracked prose set is now just `README.md`.

Also syncs `uv.lock`'s self-version `0.8.6` → `0.8.7`.

## Verification

- `make ready` — all 8 gates pass (608 tests + version-sync + lockfile-sync).
- Version guard negative test: injecting `0.8.2` into the README → `--check` exits 1 (`README.md: current-release line is 0.8.2, expected 0.8.7`).
- Lockfile guard negative test: bumping pyproject to `0.8.99` → `uv lock --check` exits 1 (`The lockfile at uv.lock needs to be updated`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)