### PR TITLE
feat(match): OKW_SOURCE union default + shared facility-pool resolver (#240)

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 432
+Total Python files: 433
 
 ├── deploy/
 │   ├── __init__.py
@@ -217,6 +217,7 @@ Total Python files: 432
 │   │   │       def match_group()
 │   │   │       def _is_url()
 │   │   │       def _detect_domain_from_data()
+│   │   │       def _apply_cli_facility_filters()
 │   │   │       def _parse_match_filters()
 │   │   │       def _build_guidance_lines()
 │   │   │       def _build_human_summary_lines()
@@ -307,6 +308,7 @@ Total Python files: 432
 │   │   │       def create_storage_config()
 │   │   │       def get_default_storage_config()
 │   │   │       def get_okw_source()
+│   │   │       def resolve_effective_source()
 │   │   │       def get_mom_config()
 │   │   └── validation.py
 │   │           class ConfigurationError
@@ -576,8 +578,6 @@ Total Python files: 432
 │       │       │       def _build_optional_human_summary()
 │       │       │       def _build_match_suggestions()
 │       │       │       def _detect_domain_from_manifest()
-│       │       │       def _resolve_matching_local_okw_json_dir()
-│       │       │       def _load_facilities_from_local_okw_json_dir()
 │       │       │       def _extract_facility_process_names_for_prefilter()
 │       │       │       def _prefilter_facilities_by_required_processes()
 │       │       │       def _matches_filters()
@@ -1261,6 +1261,8 @@ Total Python files: 432
 │       │   │       def _mom_space_to_space()
 │       │   │       def _ci()
 │       │   │       def filter_network_spaces()
+│       │   │       def resolve_matching_local_okw_json_dir()
+│       │   │       def load_facilities_from_local_okw_json_dir()
 │       │   ├── package_service.py
 │       │   │       class PackageService (__init__, _verify_package_integrity)
 │       │   ├── project_audit_service.py
@@ -1783,7 +1785,7 @@ Total Python files: 432
         │       class TestTomlLayering (test_development_defaults_from_toml, test_production_target_from_toml, test_env_overrides_toml...)
         │       class TestQuoteStripping (test_quoted_env_values_stripped, test_empty_quoted_value_becomes_none)
         │       class TestEnvironmentNormalization (test_default_is_development, test_uppercase_lowercased, test_whitespace_stripped)
-        │       class TestOkwSourceResolution (test_unset_defaults_to_storage, test_explicit_storage, test_explicit_mom...)
+        │       class TestOkwSourceResolution (test_unset_defaults_to_union, test_explicit_storage, test_explicit_mom...)
         │       class TestCorsResolution (test_pure_resolver_dev_unset_allows_all, test_pure_resolver_prod_unset_denies_all, test_pure_resolver_explicit_wildcard...)
         │       class TestInitOverride (test_init_kwargs_win)
         │       class TestStartupPosture (test_azure_complete_has_no_problems, test_azure_missing_fields_reported, test_local_has_no_problems...)
@@ -1890,6 +1892,7 @@ Total Python files: 432
         │       class TestWhitespaceDifference (test_no_difference, test_extra_space_detected, test_leading_trailing_space...)
         │       class TestNormalizeProcessName (test_empty_string_returns_empty, test_lowercases_unknown_input, test_strips_whitespace...)
         ├── test_mom_okw_source_routing.py
+        │       def _mock_network()
         ├── test_okh_collection.py
         │       def _manifest()
         │       def test_export_returns_bytes()
@@ -1950,6 +1953,14 @@ Total Python files: 432
         │       def _request()
         │       def test_parse_match_filters_populates_okw_ids()
         │       def test_parse_match_filters_omits_okw_ids_when_empty()
+        ├── test_okw_source_union_resolver.py
+        │       def clean_env()
+        │       def test_resolve_effective_source()
+        │       def _mock_network()
+        │       def _facility_without_coords()
+        │       def test_coordless_dropped_when_require_coords_true()
+        │       def test_coordless_retained_when_require_coords_false()
+        │       def test_api_and_service_share_one_resolver()
         ├── test_okw_spaces.py
         │       class _FakeResponse (__init__, raise_for_status, json)
         │       class _FakeClient (__init__)
@@ -2059,7 +2070,7 @@ Total Python files: 432
 
 ## Overview
 
-Total files analyzed: 432
+Total files analyzed: 433
 
 ## Entry Points
 
@@ -2383,7 +2394,7 @@ This service provides functionality for:
 
 ### `src/core/services/okw_service.py`
 
-**Exports:** filter_network_spaces, OKWService
+**Exports:** filter_network_spaces, resolve_matching_local_okw_json_dir, load_facilities_from_local_okw_json_dir, OKWService
 
 **Classes:**
 - `OKWService` (inherits: BaseService)
@@ -2396,6 +2407,14 @@ This service provides functi...
   - Apply the network filters (pure).
 
 Cross-source axes (country/city/process/sourc...
+- `resolve_matching_local_okw_json_dir()`
+  - Resolve the optional local OKW directory from env or imported settings.
+
+Expands...
+- `load_facilities_from_local_okw_json_dir(directory, domain, request_id)`
+  - Load OKW-shaped JSON files from disk (local/dev when remote listing hangs)....
+
+**Internal Dependencies:** 1 imports
 
 ### `src/core/services/package_service.py`
 
@@ -4243,7 +4262,7 @@ These pin the schema's behaviour to t...
 - `TestEnvironmentNormalization`
   - Methods: test_default_is_development, test_uppercase_lowercased, test_whitespace_stripped
 - `TestOkwSourceResolution`
-  - Methods: test_unset_defaults_to_storage, test_explicit_storage, test_explicit_mom, test_unknown_falls_back_to_storage, test_tristate_distinguishes_unset_from_storage
+  - Methods: test_unset_defaults_to_union, test_explicit_storage, test_explicit_mom, test_explicit_union, test_unknown_falls_back_to_union
 - `TestCorsResolution`
   - Methods: test_pure_resolver_dev_unset_allows_all, test_pure_resolver_prod_unset_denies_all, test_pure_resolver_explicit_wildcard, test_pure_resolver_comma_list, test_pure_resolver_empty_string_dev
 - `TestInitOverride`
@@ -4851,7 +4870,7 @@ These commands help you...
 
 These commands allow you to insp...
 
-**Internal Dependencies:** 6 imports
+**Internal Dependencies:** 3 imports
 
 ### `src/cli/okh.py`
 > OKH (OpenKnowHow) commands for OHM CLI
@@ -5142,7 +5161,7 @@ This module combines the functionality fr...
 - `render_match_summary(match_summary)`
   - Render a compact human-readable line from a structured match summary....
 
-**Internal Dependencies:** 11 imports
+**Internal Dependencies:** 6 imports
 
 ### `src/core/api/routes/okh.py`
 
@@ -7826,7 +7845,7 @@ Pin the lockfile behaviour: the gener...
 - `test_country_filter_no_match(matches_filters)`
 - `test_region_filter_matches(matches_filters)`
 
-**Internal Dependencies:** 18 imports
+**Internal Dependencies:** 17 imports
 
 ### `tests/unit/test_github_auth_order.py`
 > Tests for unauthenticated-first GitHub supplementary metadata fetch.
@@ -7985,10 +8004,11 @@ Tests current behavior of BaseMatchingLayer uti...
 **Internal Dependencies:** 6 imports
 
 ### `tests/unit/test_mom_okw_source_routing.py`
-> Regression: match API must route to MoM SPARQL when OKW_SOURCE=mom (no inline OKWs,
-no MATCHING_LOCA...
+> OKW_SOURCE=mom routing under the unified resolver (#240).
 
-**Internal Dependencies:** 19 imports
+Since the union-default change, all sourc...
+
+**Internal Dependencies:** 10 imports
 
 ### `tests/unit/test_okh_collection.py`
 > Unit tests for OKH bulk import/export/diff (issue #176)....
@@ -8057,7 +8077,23 @@ A caller can pre-select which...
 - `test_parse_match_filters_populates_okw_ids()`
 - `test_parse_match_filters_omits_okw_ids_when_empty()`
 
-**Internal Dependencies:** 11 imports
+**Internal Dependencies:** 10 imports
+
+### `tests/unit/test_okw_source_union_resolver.py`
+> #240 — OKW_SOURCE union default + shared facility-pool resolver.
+
+Covers the tri-state (union|storag...
+
+**Exports:** clean_env, test_resolve_effective_source, test_coordless_dropped_when_require_coords_true, test_coordless_retained_when_require_coords_false, test_api_and_service_share_one_resolver
+
+**Functions:**
+- `clean_env(monkeypatch)`
+- `test_resolve_effective_source(clean_env, env, request_source)`
+- `test_coordless_dropped_when_require_coords_true()`
+- `test_coordless_retained_when_require_coords_false()`
+- `test_api_and_service_share_one_resolver()`
+
+**Internal Dependencies:** 15 imports
 
 ### `tests/unit/test_okw_spaces.py`
 > Unit tests for the unified network surface (GET /api/okw/spaces, issue #230).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.8] - 2026-07-07
+
+### Changed
+
+- **`OKW_SOURCE` unset now defaults to `union` (storage ∪ Maps of Making), not storage.** A match with no configured source is no longer silently limited to blob storage — it draws candidates from both the configured storage backend and the MoM network. `OKW_SOURCE=storage` restricts to blob only and `OKW_SOURCE=mom` to MoM only; `MATCHING_LOCAL_OKW_JSON_DIR` still yields a storage-only local pool (never unioned). Precedence: the environment sets the candidate universe and a per-request override may narrow within it but never broaden it. `okw_source_resolved` now distinguishes unset (→ union) from an explicit `storage`.
+- **One shared facility-pool resolver for API and CLI.** `POST /v1/api/match` and the `ohm match` CLI now resolve the candidate pool through a single `OKWService.resolve_match_facilities` (structural parity, not copy-paste), which routes every source through the network surface (`get_network_match_facilities`). MoM candidate loading degrades gracefully — when MoM is unavailable, `union` still returns the storage pool. Facilities without map coordinates are retained for matching (they are only dropped from the map/browse surface).
+
 ## [0.8.7] - 2026-07-06
 
 ### Added
@@ -30,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **MoM integration documentation and test coverage:** `docs/runbooks/mom-integration-e2e-validation.md` — CLI/API demo runbook verified against the live MoM SPARQL endpoint, plus unit tests for `mom_bridge.py`, taxonomy `wikidata_qid` lookups, and `OKW_SOURCE` routing (none existed since the integration shipped in `#181`).
 
+[0.8.8]: https://github.com/helpfulengineering/supply-graph-ai/compare/v0.8.7...v0.8.8
 [0.8.7]: https://github.com/helpfulengineering/supply-graph-ai/compare/v0.8.6...v0.8.7
 [0.8.6]: https://github.com/helpfulengineering/supply-graph-ai/compare/v0.8.5...v0.8.6
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Open Hardware Manager (OHM) is a flexible, domain-agnostic framework designe
 
 OHM exposes a FastAPI-based HTTP API that can be run locally via Docker Compose, from a [published Docker image](https://hub.docker.com/r/touchthesun/openhardwaremanager), or deployed serverlessly using the configurations in `deploy/`.
 
-**Current release:** `0.8.7` — see [CHANGELOG.md](CHANGELOG.md) and [Release process](docs/RELEASE.md).
+**Current release:** `0.8.8` — see [CHANGELOG.md](CHANGELOG.md) and [Release process](docs/RELEASE.md).
 
 ## Quick Start for New Users
 
@@ -28,11 +28,11 @@ After installing, open a new terminal so the tools are on your PATH.
 **Local storage (no credentials needed):**
 
 ```bash
-docker pull touchthesun/openhardwaremanager:0.8.7
+docker pull touchthesun/openhardwaremanager:0.8.8
 docker run -p 8001:8001 \
   -e STORAGE_PROVIDER=local \
   -e LLM_ENABLED=false \
-  touchthesun/openhardwaremanager:0.8.7
+  touchthesun/openhardwaremanager:0.8.8
 ```
 
 **Remote storage (Azure Blob, AWS S3, or GCS):**
@@ -43,7 +43,7 @@ The published image does not include a `.env` file — you must pass your storag
 # Copy the template, fill in your provider and credentials, then:
 docker run -p 8001:8001 \
   --env-file .env \
-  touchthesun/openhardwaremanager:0.8.7
+  touchthesun/openhardwaremanager:0.8.8
 ```
 
 The minimum `.env` keys for Azure Blob are:

--- a/docs/runbooks/mom-integration-e2e-validation.md
+++ b/docs/runbooks/mom-integration-e2e-validation.md
@@ -79,10 +79,15 @@ curl -s -X POST "https://mapsofmaking.org/sparql/query" \
 
 ## 1 — CLI demo (no server needed)
 
-The CLI's `--okw-source mom` flag always forces local fallback matching (direct
-service calls, not the HTTP API) — see `src/cli/match.py` around
-`MoM as OKW source requires fallback`. This makes it the simplest way to
-demo the integration: no Docker, no `.env` storage credentials.
+The CLI's `--okw-source mom` flag forces local fallback matching (direct service
+calls, not the HTTP API) so the client-side override is honoured — see
+`src/cli/match.py`, which takes the fallback path for any explicit OKW source.
+This makes it the simplest way to demo the integration: no Docker, no `.env`
+storage credentials.
+
+> Since 0.8.8, an **unset** `OKW_SOURCE` matches against the **union** (storage ∪
+> MoM), so MoM facilities appear in default matches too. `--okw-source mom` (or
+> `OKW_SOURCE=mom`) isolates MoM, which is what this runbook exercises.
 
 ```bash
 cd supply-graph-ai

--- a/env.template
+++ b/env.template
@@ -24,7 +24,7 @@ STORAGE_PROVIDER=local
 # Azure Blob access key.
 # AZURE_STORAGE_KEY=   # SECRET — set in .env / secretRef, never commit
 
-# OKW facility source: storage | mom. Unset resolves to storage (Slice 1).
+# OKW facility source: storage | mom. Unset → union (storage ∪ MoM).
 # OKW_SOURCE=
 
 # CORS allowed origins: '*' or a comma-separated list.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "supply-graph-ai"
-version = "0.8.7"
+version = "0.8.8"
 description = "Open Hardware Manager (OHM) - A flexible, domain-agnostic framework for matching requirements with capabilities"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -164,12 +164,13 @@ def config(ctx: Context) -> None:
         okw_source = get_okw_source()
         mom_cfg = get_mom_config()
         click.echo("OKW Facility Source:")
-        click.echo(f"  Source: {okw_source}  (OKW_SOURCE env var, default: storage)")
-        if okw_source == "mom":
+        click.echo(f"  Source: {okw_source}  (OKW_SOURCE env var, unset → union)")
+        mom_active = okw_source in ("union", "mom")
+        if mom_active:
             click.echo(f"  MoM SPARQL Endpoint: {mom_cfg['endpoint']}")
         else:
             click.echo(
-                f"  MoM SPARQL Endpoint: {mom_cfg['endpoint']}  (inactive — set OKW_SOURCE=mom to enable)"
+                f"  MoM SPARQL Endpoint: {mom_cfg['endpoint']}  (inactive — unset OKW_SOURCE or set it to mom to enable)"
             )
     except Exception:
         pass

--- a/src/cli/match.py
+++ b/src/cli/match.py
@@ -71,12 +71,11 @@ def match_group() -> None:
     default=None,
     envvar="OKW_SOURCE",
     help=(
-        "Where to load OKW facility candidates from. "
-        "'storage' (default) reads from the configured blob storage backend "
-        "(STORAGE_PROVIDER: local, azure_blob, aws_s3, gcs). "
-        "'mom' queries the Maps of Making public SPARQL endpoint, resolving each "
-        "required process to a Wikidata IRI — no credentials required. "
-        "Override the MoM endpoint with MOM_SPARQL_ENDPOINT."
+        "Where to load OKW facility candidates from. Omitted → union (storage ∪ "
+        "Maps of Making). 'storage' reads only from the configured blob storage "
+        "backend (STORAGE_PROVIDER: local, azure_blob, aws_s3, gcs). 'mom' queries "
+        "only the Maps of Making network — no credentials required. Override the "
+        "MoM endpoint with MOM_SPARQL_ENDPOINT."
     ),
 )
 @click.option(
@@ -497,17 +496,20 @@ async def requirements(
 
                 raise httpx.ConnectError("Use fallback for local facility file")
 
-            # MoM as OKW source requires fallback (API route loads from blob storage only)
-            from src.config.storage_config import get_okw_source
-
-            if (okw_source or get_okw_source()) == "mom":
+            # An explicit --okw-source (or OKW_SOURCE env) is a client-side override:
+            # the HTTP API resolves the source from the *server's* environment, so to
+            # honour the override we take the local fallback path (which applies the
+            # same shared resolver). With no override, the API's union default applies.
+            if okw_source:
                 cli_ctx.log(
-                    "OKW source is MoM — SPARQL discovery not supported by HTTP API, using fallback",
+                    f"OKW source override ({okw_source}) — resolving locally via fallback",
                     "info",
                 )
                 import httpx
 
-                raise httpx.ConnectError("Use fallback for MoM OKW source")
+                raise httpx.ConnectError(
+                    "Use fallback for explicit OKW source override"
+                )
 
             # If nested matching with local file, use fallback (BOM file resolution needs manifest path)
             if max_depth > 0 and not is_url:
@@ -567,59 +569,30 @@ async def requirements(
                         "info",
                     )
                 else:
-                    from src.config.storage_config import get_mom_config, get_okw_source
+                    from src.config.storage_config import resolve_effective_source
 
-                    effective_source = okw_source or get_okw_source()
+                    from ..core.services.okw_service import resolve_match_facilities
 
-                    if effective_source == "mom":
-                        from ..core.services.mom_bridge import (
-                            fetch_mom_facilities_for_manifest,
-                        )
-
-                        mom_cfg = get_mom_config()
-                        cli_ctx.log(
-                            f"Loading facilities from MoM SPARQL endpoint: {mom_cfg['endpoint']}",
-                            "info",
-                        )
-                        facilities = await fetch_mom_facilities_for_manifest(
-                            manifest, endpoint=mom_cfg["endpoint"]
-                        )
-                        cli_ctx.log(
-                            f"Loaded {len(facilities)} facility(ies) from MoM",
-                            "info",
-                        )
-                    else:
-                        from ..core.services.okw_service import OKWService
-
-                        okw_service = await OKWService.get_instance()
-                        try:
-                            from src.config.storage_config import (
-                                get_default_storage_config,
-                            )
-
-                            cfg = get_default_storage_config()
-                            cli_ctx.log(
-                                f"Loading facilities from storage: provider={cfg.provider}, container/bucket={cfg.bucket_name}",
-                                "info",
-                            )
-                        except Exception:
-                            pass
-                        filter_params = {}
-                        if filters.get("access_type"):
-                            filter_params["access_type"] = filters.get("access_type")
-                        if filters.get("facility_status"):
-                            filter_params["facility_status"] = filters.get(
-                                "facility_status"
-                            )
-                        if filters.get("location"):
-                            filter_params["location"] = filters.get("location")
-                        facilities, _ = await okw_service.list(
-                            filter_params=filter_params if filter_params else None
-                        )
-                        cli_ctx.log(
-                            f"Loaded {len(facilities)} facility(ies) from storage",
-                            "info",
-                        )
+                    # Same shared resolver the API uses: env sets the universe
+                    # (union → storage ∪ MoM, storage → blob only, mom → MoM only),
+                    # --okw-source narrows within it but cannot broaden it.
+                    effective_source = resolve_effective_source(okw_source)
+                    cli_ctx.log(
+                        f"Resolving OKW candidates (effective source: {effective_source})",
+                        "info",
+                    )
+                    facilities = await resolve_match_facilities(
+                        effective_source=effective_source,
+                        domain="manufacturing",
+                        request_id="cli",
+                    )
+                    # CLI-only pre-match narrowing (the HTTP API has no equivalent);
+                    # applied client-side so the resolver stays source-selection only.
+                    facilities = _apply_cli_facility_filters(facilities, filters)
+                    cli_ctx.log(
+                        f"Loaded {len(facilities)} facility(ies) from {effective_source}",
+                        "info",
+                    )
 
                 # Apply additional filters that aren't supported by okw_service.list()
                 # (e.g., capabilities, materials would need more complex matching logic)
@@ -1658,6 +1631,53 @@ def _detect_domain_from_data(data: dict[str, Any]) -> str:
     from src.core.utils.domain_detection import detect_domain
 
     return detect_domain(data)
+
+
+def _apply_cli_facility_filters(facilities: list, filters: dict) -> list:
+    """Apply the CLI's pre-match narrowing (``--access-type``/``--facility-status``/
+    ``--location``) to a resolved candidate pool, client-side.
+
+    The shared resolver returns a source-selected pool (matching the API's classic
+    path, which applies none of these). These are CLI-only conveniences. A facility
+    that cannot express a field (value is ``None``) is kept, so MoM stubs are not
+    dropped for lacking, e.g., an access type; matches are case-insensitive, and
+    location is a substring across city/region/country/name.
+    """
+
+    def _val(obj, attr):
+        v = getattr(obj, attr, None)
+        return getattr(v, "value", v)
+
+    access_type = (filters.get("access_type") or "").strip().lower() or None
+    status = (filters.get("facility_status") or "").strip().lower() or None
+    location = (filters.get("location") or "").strip().lower() or None
+
+    def _keep(f) -> bool:
+        if access_type:
+            at = _val(f, "access_type")
+            if at is not None and str(at).strip().lower() != access_type:
+                return False
+        if status:
+            st = _val(f, "facility_status")
+            if st is not None and str(st).strip().lower() != status:
+                return False
+        if location:
+            loc = getattr(f, "location", None)
+            haystack = " ".join(
+                str(x)
+                for x in (
+                    getattr(loc, "city", None),
+                    getattr(loc, "region", None),
+                    getattr(loc, "country", None),
+                    getattr(f, "name", None),
+                )
+                if x
+            ).lower()
+            if location not in haystack:
+                return False
+        return True
+
+    return [f for f in facilities if _keep(f)]
 
 
 def _parse_match_filters(

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -162,7 +162,7 @@ class Settings(BaseSettings):
     )
     okw_source: Optional[str] = Field(
         default=None,  # unset resolves via okw_source_resolved
-        description="OKW facility source: storage | mom. Unset resolves to storage (Slice 1).",
+        description="OKW facility source: storage | mom. Unset → union (storage ∪ MoM).",
     )
     cors_origins: Optional[str] = Field(
         default=None,  # raw; parse via cors_allow_origins
@@ -176,18 +176,22 @@ class Settings(BaseSettings):
 
     @property
     def okw_source_resolved(self) -> str:
-        """The effective OKW facility source: ``"storage"`` or ``"mom"``.
+        """The effective OKW facility source: ``"union"``, ``"storage"``, or ``"mom"``.
 
-        Unset falls back to ``"storage"``; unknown values fall back to
-        ``"storage"`` with a warning (behaviour-preserving for Slice 1).
+        Unset (or empty) resolves to ``"union"`` (storage ∪ MoM) — matches are not
+        silently empty when the operator has not chosen a source. Explicit
+        ``"storage"`` / ``"mom"`` restrict the universe. ``"union"`` is also accepted
+        explicitly. Unknown values fall back to ``"union"`` with a warning.
         """
-        source = self.okw_source or "storage"
-        if source not in ("storage", "mom"):
+        raw = (self.okw_source or "").strip().lower()
+        if not raw:
+            return "union"
+        if raw not in ("union", "storage", "mom"):
             logger.warning(
-                "Unknown OKW_SOURCE value %r — falling back to 'storage'", source
+                "Unknown OKW_SOURCE value %r — falling back to 'union'", self.okw_source
             )
-            return "storage"
-        return source
+            return "union"
+        return raw
 
     @property
     def cors_allow_origins(self) -> List[str]:

--- a/src/config/storage_config.py
+++ b/src/config/storage_config.py
@@ -227,26 +227,60 @@ def get_okw_source() -> str:
 
     Values
     ------
-    storage (default)
+    union (default — when ``OKW_SOURCE`` is unset)
+        Match against **storage ∪ MoM**: the configured blob storage backend
+        combined with the Maps of Making network. Chosen as the default so a
+        match is not silently empty when no source has been selected.
+
+    storage
         Load facilities from the configured blob storage backend
-        (``STORAGE_PROVIDER``). Supports local, Azure Blob, AWS S3, GCS.
+        (``STORAGE_PROVIDER``) only. Supports local, Azure Blob, AWS S3, GCS.
 
     mom
-        Query the Maps of Making public SPARQL endpoint. No credentials
-        required. Endpoint configured by ``MOM_SPARQL_ENDPOINT``
-        (see :func:`get_mom_config`). OHM translates each OKH process
-        requirement to a Wikidata IRI via the taxonomy and issues a
-        SPARQL query against MoM's Oxigraph store.
+        Query the Maps of Making network only. No credentials required.
+        Endpoint configured by ``MOM_SPARQL_ENDPOINT`` (see
+        :func:`get_mom_config`).
 
     Returns
     -------
     str
-        ``"storage"`` or ``"mom"``. Unknown values fall back to
-        ``"storage"`` with a warning log.
+        ``"union"``, ``"storage"``, or ``"mom"``. Unknown values fall back to
+        ``"union"`` with a warning log.
     """
     from src.config.schema import get_settings
 
     return get_settings().okw_source_resolved
+
+
+def resolve_effective_source(request_source: Optional[str] = None) -> str:
+    """Combine the env-configured OKW source with an optional per-request override.
+
+    Precedence: **the environment sets the universe; the request may narrow
+    within it but never broaden it.**
+
+    - env ``union`` → a request of ``"storage"``/``"mom"`` narrows the pool;
+      otherwise the effective source stays ``union``.
+    - env ``storage`` / ``mom`` are absolute — a request cannot broaden back to
+      ``union`` or cross to the other source; the env value wins.
+
+    Parameters
+    ----------
+    request_source
+        Per-request override in OKW-source vocabulary (``"storage"``, ``"mom"``,
+        ``"union"``, or ``None``). Unknown/empty values are treated as ``None``.
+
+    Returns
+    -------
+    str
+        The effective source: ``"union"``, ``"storage"``, or ``"mom"``.
+    """
+    env_source = get_okw_source()
+    req = (request_source or "").strip().lower() or None
+    if env_source != "union":
+        return env_source
+    if req in ("storage", "mom"):
+        return req
+    return "union"
 
 
 def get_mom_config() -> Dict[str, str]:

--- a/src/core/api/routes/match.py
+++ b/src/core/api/routes/match.py
@@ -36,7 +36,12 @@ from ...registry.domain_registry import DomainRegistry
 from ...services.domain_service import DomainDetector
 from ...services.matching_service import MatchingService
 from ...services.okh_service import OKHService
-from ...services.okw_service import OKWService
+from ...services.okw_service import (
+    OKWService,
+    load_facilities_from_local_okw_json_dir,
+    resolve_match_facilities,
+    resolve_matching_local_okw_json_dir,
+)
 from ...services.storage_service import StorageService
 from ...matching.match_modes import MATCH_MODE_NESTED, MATCH_MODE_SINGLE_LEVEL
 from ...taxonomy import taxonomy as _process_taxonomy
@@ -2181,95 +2186,6 @@ async def _extract_recipe(
         )
 
 
-def _resolve_matching_local_okw_json_dir() -> Optional[str]:
-    """Resolve optional local OKW directory from runtime env or imported settings.
-
-    Expands ``~`` and resolves relative paths against the process working directory.
-    Logs a warning when the variable is set but does not point at a directory so
-    misconfiguration is visible in API logs.
-    """
-    from src.config import settings as _settings
-
-    val = getattr(_settings, "MATCHING_LOCAL_OKW_JSON_DIR", None)
-    raw = str(val).strip() if val else ""
-    if not raw:
-        raw = (os.getenv("MATCHING_LOCAL_OKW_JSON_DIR") or "").strip()
-
-    if not raw:
-        return None
-
-    path = Path(raw).expanduser()
-    if not path.is_absolute():
-        path = Path.cwd() / path
-    try:
-        resolved = path.resolve()
-    except OSError as e:
-        logger.warning(
-            "MATCHING_LOCAL_OKW_JSON_DIR could not be resolved; using remote OKW listing",
-            extra={"raw": raw, "error": str(e)},
-        )
-        return None
-
-    if not resolved.is_dir():
-        logger.warning(
-            "MATCHING_LOCAL_OKW_JSON_DIR is not a directory; using remote OKW listing",
-            extra={"path": str(resolved), "raw": raw},
-        )
-        return None
-    logger.info(
-        "MATCHING_LOCAL_OKW_JSON_DIR resolved successfully",
-        extra={"directory": str(resolved), "raw_input": raw},
-    )
-    return str(resolved)
-
-
-def _load_facilities_from_local_okw_json_dir(
-    directory: str,
-    domain: str,
-    request_id: str,
-) -> List[Any]:
-    """Load OKW-shaped JSON files from disk for local/dev when remote listing would hang."""
-    from src.core.validation.uuid_validator import UUIDValidator
-
-    root = Path(directory)
-    if not root.is_dir():
-        return []
-
-    facilities_by_id: Dict[UUID, Any] = {}
-
-    for path in sorted(root.rglob("*.json")):
-        try:
-            raw = json.loads(path.read_text(encoding="utf-8"))
-        except Exception as e:
-            logger.warning(
-                "Skipping unreadable OKW JSON file",
-                extra={"request_id": request_id, "path": str(path), "error": str(e)},
-            )
-            continue
-
-        try:
-            if domain == "manufacturing":
-                if KitchenCapability.is_cooking_capability(raw):
-                    continue
-                fixed = UUIDValidator.validate_and_fix_okw_data(raw)
-                facility = ManufacturingFacility.from_dict(fixed)
-                facilities_by_id[facility.id] = facility
-            elif domain == "cooking":
-                if not KitchenCapability.is_cooking_capability(raw):
-                    continue
-                facility = KitchenCapability.from_dict(raw)
-                facilities_by_id[facility.id] = facility
-            else:
-                return []
-        except Exception as e:
-            logger.warning(
-                "Skipping invalid OKW JSON file for local dir load",
-                extra={"request_id": request_id, "path": str(path), "error": str(e)},
-            )
-
-    return list(facilities_by_id.values())
-
-
 def _extract_facility_process_names_for_prefilter(facility: Any) -> set[str]:
     """Best-effort process extraction for cheap candidate prefiltering."""
     if hasattr(facility, "to_dict"):
@@ -2455,107 +2371,28 @@ async def _get_filtered_facilities(
                     },
                 )
             else:
+                # No inline facilities: resolve the pool from the effective OKW
+                # source (env universe; a classic MatchRequest carries no per-request
+                # source override). union → storage ∪ MoM, storage → blob only, mom →
+                # MoM only; MATCHING_LOCAL_OKW_JSON_DIR handled inside the resolver.
+                # One shared resolver keeps this identical to the CLI.
+                from src.config.storage_config import resolve_effective_source
+
+                effective_source = resolve_effective_source()
+                facilities = await resolve_match_facilities(
+                    effective_source=effective_source,
+                    domain=domain,
+                    request_id=request_id,
+                )
                 logger.info(
-                    "Facility candidates: no inline okw_facilities; checking OKW_SOURCE then MATCHING_LOCAL_OKW_JSON_DIR then remote storage",
+                    "Facility candidates resolved via shared resolver",
                     extra={
                         "request_id": request_id,
                         "domain": domain,
-                        "cwd": str(Path.cwd()),
+                        "effective_source": effective_source,
+                        "facility_count": len(facilities),
                     },
                 )
-                from src.config.storage_config import get_mom_config, get_okw_source
-
-                # OKW_SOURCE=mom is an explicit request for MoM SPARQL data and must
-                # win over MATCHING_LOCAL_OKW_JSON_DIR (a local-storage dev convenience)
-                # so the CLI (--okw-source mom) and API behave identically regardless
-                # of that env var. See docs/runbooks/mom-integration-e2e-validation.md.
-                if get_okw_source() == "mom" and okh_manifest is not None:
-                    from src.core.services.mom_bridge import (
-                        fetch_mom_facilities_for_manifest,
-                    )
-
-                    mom_cfg = get_mom_config()
-                    logger.info(
-                        "Loading OKW facilities from MoM SPARQL endpoint",
-                        extra={
-                            "request_id": request_id,
-                            "domain": domain,
-                            "endpoint": mom_cfg["endpoint"],
-                        },
-                    )
-                    facilities = await fetch_mom_facilities_for_manifest(
-                        okh_manifest, endpoint=mom_cfg["endpoint"]
-                    )
-                    logger.info(
-                        "Facility candidates loaded from MoM SPARQL",
-                        extra={
-                            "request_id": request_id,
-                            "domain": domain,
-                            "endpoint": mom_cfg["endpoint"],
-                            "facility_count": len(facilities),
-                        },
-                    )
-                else:
-                    local_dir = _resolve_matching_local_okw_json_dir()
-                    if local_dir:
-                        facilities = _load_facilities_from_local_okw_json_dir(
-                            local_dir, domain, request_id
-                        )
-                        logger.info(
-                            "Using MATCHING_LOCAL_OKW_JSON_DIR (remote OKW listing skipped)",
-                            extra={
-                                "request_id": request_id,
-                                "domain": domain,
-                                "directory": local_dir,
-                                "facility_count": len(facilities),
-                            },
-                        )
-                    else:
-                        # Get all facilities using OKWService with proper pagination.
-                        # list() skips kitchen files — returns ManufacturingFacility only.
-                        from src.config.storage_config import get_default_storage_config
-
-                        try:
-                            cfg = get_default_storage_config()
-                            logger.info(
-                                "Loading OKW facilities from blob storage",
-                                extra={
-                                    "request_id": request_id,
-                                    "domain": domain,
-                                    "provider": cfg.provider,
-                                    "bucket": cfg.bucket_name,
-                                },
-                            )
-                        except Exception:
-                            pass
-
-                        okw_service = await OKWService.get_instance()
-
-                        all_facilities = []
-                        page = 1
-                        page_size = 1000
-
-                        while True:
-                            facilities_batch, _ = await okw_service.list(
-                                page=page, page_size=page_size
-                            )
-                            all_facilities.extend(facilities_batch)
-
-                            if len(facilities_batch) < page_size:
-                                break
-
-                            page += 1
-
-                        facilities = all_facilities
-                        logger.info(
-                            "Facility candidates loaded from remote OKW storage listing "
-                            "(MATCHING_LOCAL_OKW_JSON_DIR was unset or invalid)",
-                            extra={
-                                "request_id": request_id,
-                                "domain": domain,
-                                "facility_count": len(facilities),
-                            },
-                        )
 
         elif domain == "cooking":
             expected_type = KitchenCapability
@@ -2603,9 +2440,9 @@ async def _get_filtered_facilities(
                         "cwd": str(Path.cwd()),
                     },
                 )
-                local_dir = _resolve_matching_local_okw_json_dir()
+                local_dir = resolve_matching_local_okw_json_dir()
                 if local_dir:
-                    facilities = _load_facilities_from_local_okw_json_dir(
+                    facilities = load_facilities_from_local_okw_json_dir(
                         local_dir, domain, request_id
                     )
                     logger.info(

--- a/src/core/services/okw_service.py
+++ b/src/core/services/okw_service.py
@@ -1,4 +1,6 @@
 import json
+import os
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from uuid import UUID
 
@@ -46,11 +48,19 @@ def _canonical_processes(raw: List[str]) -> List[str]:
     return processes
 
 
-def _local_facility_to_space(f: ManufacturingFacility) -> Optional[Dict[str, Any]]:
-    """Project a local facility to the unified network-space shape, or ``None``
-    when it has no plottable coordinates."""
+def _local_facility_to_space(
+    f: ManufacturingFacility, *, require_coords: bool = True
+) -> Optional[Dict[str, Any]]:
+    """Project a local facility to the unified network-space shape.
+
+    Returns ``None`` when the facility has no plottable coordinates *and*
+    ``require_coords`` is True (the browse/map surface needs a point). For
+    matching, callers pass ``require_coords=False`` so a capability-valid
+    facility is not dropped from the candidate pool for lacking geography;
+    ``lat``/``lon`` are then ``None``.
+    """
     coords = f.location.coordinates() if f.location else None
-    if coords is None:
+    if coords is None and require_coords:
         return None
     loc = f.location
     addr = getattr(loc, "address", None)
@@ -58,8 +68,8 @@ def _local_facility_to_space(f: ManufacturingFacility) -> Optional[Dict[str, Any
     return {
         "id": str(f.id),
         "name": f.name,
-        "lat": coords.latitude,
-        "lon": coords.longitude,
+        "lat": coords.latitude if coords else None,
+        "lon": coords.longitude if coords else None,
         "city": getattr(addr, "city", None) or getattr(loc, "city", None),
         "region": getattr(addr, "region", None) or getattr(loc, "region", None),
         "country": getattr(addr, "country", None) or getattr(loc, "country", None),
@@ -160,6 +170,92 @@ def filter_network_spaces(
     # Definite matches first, ambiguous last (stable within each group).
     kept.sort(key=lambda s: s.get("ambiguous", False))
     return kept
+
+
+# --- Local OKW JSON dir (dev convenience; storage-only, never unioned) ---------
+
+
+def resolve_matching_local_okw_json_dir() -> Optional[str]:
+    """Resolve the optional local OKW directory from env or imported settings.
+
+    Expands ``~`` and resolves relative paths against the process working
+    directory. Logs a warning when set but not pointing at a directory so
+    misconfiguration is visible. Returns ``None`` when unset/invalid.
+    """
+    from src.config import settings as _settings
+
+    val = getattr(_settings, "MATCHING_LOCAL_OKW_JSON_DIR", None)
+    raw = str(val).strip() if val else ""
+    if not raw:
+        raw = (os.getenv("MATCHING_LOCAL_OKW_JSON_DIR") or "").strip()
+    if not raw:
+        return None
+
+    path = Path(raw).expanduser()
+    if not path.is_absolute():
+        path = Path.cwd() / path
+    try:
+        resolved = path.resolve()
+    except OSError as e:
+        logger.warning(
+            "MATCHING_LOCAL_OKW_JSON_DIR could not be resolved; using remote OKW listing",
+            extra={"raw": raw, "error": str(e)},
+        )
+        return None
+
+    if not resolved.is_dir():
+        logger.warning(
+            "MATCHING_LOCAL_OKW_JSON_DIR is not a directory; using remote OKW listing",
+            extra={"path": str(resolved), "raw": raw},
+        )
+        return None
+    logger.info(
+        "MATCHING_LOCAL_OKW_JSON_DIR resolved successfully",
+        extra={"directory": str(resolved), "raw_input": raw},
+    )
+    return str(resolved)
+
+
+def load_facilities_from_local_okw_json_dir(
+    directory: str,
+    domain: str,
+    request_id: str = "",
+) -> List[Any]:
+    """Load OKW-shaped JSON files from disk (local/dev when remote listing hangs)."""
+    root = Path(directory)
+    if not root.is_dir():
+        return []
+
+    facilities_by_id: Dict[UUID, Any] = {}
+    for path in sorted(root.rglob("*.json")):
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as e:
+            logger.warning(
+                "Skipping unreadable OKW JSON file",
+                extra={"request_id": request_id, "path": str(path), "error": str(e)},
+            )
+            continue
+        try:
+            if domain == "manufacturing":
+                if KitchenCapability.is_cooking_capability(raw):
+                    continue
+                fixed = UUIDValidator.validate_and_fix_okw_data(raw)
+                facility = ManufacturingFacility.from_dict(fixed)
+                facilities_by_id[facility.id] = facility
+            elif domain == "cooking":
+                if not KitchenCapability.is_cooking_capability(raw):
+                    continue
+                facility = KitchenCapability.from_dict(raw)
+                facilities_by_id[facility.id] = facility
+            else:
+                return []
+        except Exception as e:
+            logger.warning(
+                "Skipping invalid OKW JSON file for local dir load",
+                extra={"request_id": request_id, "path": str(path), "error": str(e)},
+            )
+    return list(facilities_by_id.values())
 
 
 class OKWService(BaseService["OKWService"]):
@@ -514,11 +610,15 @@ class OKWService(BaseService["OKWService"]):
         }
 
     async def _load_network_candidates(
-        self, *, include_mom: bool, force_refresh: bool
+        self, *, include_mom: bool, force_refresh: bool, require_coords: bool = True
     ) -> Tuple[List[Dict[str, Any]], int, bool]:
         """Load local ∪ MoM as unified space dicts, each carrying its ``_facility``
         (the matchable object) under a private key. Shared by the browse surface
         and the network-match candidate pool so filtering stays identical.
+
+        ``require_coords`` gates whether local facilities without plottable
+        coordinates are dropped — True for the map/browse surface, False for
+        matching (where geography is not required to be a valid candidate).
         """
         candidates: List[Dict[str, Any]] = []
         dropped_no_coords = 0
@@ -529,7 +629,7 @@ class OKWService(BaseService["OKWService"]):
             if not facilities:
                 break
             for f in facilities:
-                space = _local_facility_to_space(f)
+                space = _local_facility_to_space(f, require_coords=require_coords)
                 if space is None:
                     dropped_no_coords += 1
                     continue
@@ -556,6 +656,7 @@ class OKWService(BaseService["OKWService"]):
         *,
         include_mom: bool = True,
         force_refresh: bool = False,
+        require_coords: bool = True,
         country: Optional[str] = None,
         city: Optional[str] = None,
         process: Optional[str] = None,
@@ -567,9 +668,14 @@ class OKWService(BaseService["OKWService"]):
         """Return the filtered network as matchable facilities (local full objects
         ∪ MoM process stubs), for matching a design against the same filtered set
         the browse surface shows. Uses the identical filter as ``get_network_spaces``.
+
+        ``require_coords`` defaults True (browse parity); the match resolver passes
+        False so coordinate-less facilities remain matchable candidates.
         """
         candidates, _, _ = await self._load_network_candidates(
-            include_mom=include_mom, force_refresh=force_refresh
+            include_mom=include_mom,
+            force_refresh=force_refresh,
+            require_coords=require_coords,
         )
         filtered = filter_network_spaces(
             candidates,
@@ -952,3 +1058,68 @@ class OKWService(BaseService["OKWService"]):
         except Exception as e:
             logger.error(f"Failed to register domains for fallback mode: {e}")
             # Don't raise the exception - let the service continue without domains
+
+
+async def resolve_match_facilities(
+    *,
+    effective_source: str,
+    domain: str = "manufacturing",
+    request_id: str = "",
+    force_refresh: bool = False,
+    country: Optional[str] = None,
+    city: Optional[str] = None,
+    process: Optional[str] = None,
+    status: Optional[str] = None,
+    region: Optional[str] = None,
+    access_type: Optional[str] = None,
+) -> List[ManufacturingFacility]:
+    """Resolve the manufacturing match candidate pool for an effective source.
+
+    The one facility-pool resolver shared by the API match route and the CLI
+    (structural parity, not copy-paste). ``effective_source`` is the already
+    env+request-reconciled value (see
+    :func:`src.config.storage_config.resolve_effective_source`):
+
+    - ``"mom"``    → Maps of Making only. An explicit request for MoM data, so it
+      wins over ``MATCHING_LOCAL_OKW_JSON_DIR`` (a local-storage dev convenience),
+      keeping API and CLI identical.
+    - ``"storage"`` → blob storage only (``include_mom=False``); honours
+      ``MATCHING_LOCAL_OKW_JSON_DIR`` when set.
+    - ``"union"``  → storage ∪ MoM; ``MATCHING_LOCAL_OKW_JSON_DIR`` forces
+      storage-only (a local dir is never unioned with MoM).
+
+    The service instance is only loaded for the branches that read from storage,
+    so the local-dir path touches no remote storage. Facilities are matched
+    regardless of geography (``require_coords=False``).
+    """
+    if effective_source == "mom":
+        svc = await OKWService.get_instance()
+        return await svc.get_network_match_facilities(
+            include_mom=True,
+            source="mom",
+            force_refresh=force_refresh,
+            require_coords=False,
+            country=country,
+            city=city,
+            process=process,
+            status=status,
+            region=region,
+            access_type=access_type,
+        )
+
+    local_dir = resolve_matching_local_okw_json_dir()
+    if local_dir:
+        return load_facilities_from_local_okw_json_dir(local_dir, domain, request_id)
+
+    svc = await OKWService.get_instance()
+    return await svc.get_network_match_facilities(
+        include_mom=(effective_source == "union"),
+        force_refresh=force_refresh,
+        require_coords=False,
+        country=country,
+        city=city,
+        process=process,
+        status=status,
+        region=region,
+        access_type=access_type,
+    )

--- a/tests/unit/test_config_schema.py
+++ b/tests/unit/test_config_schema.py
@@ -92,8 +92,9 @@ class TestEnvironmentNormalization:
 
 
 class TestOkwSourceResolution:
-    def test_unset_defaults_to_storage(self, clean_env):
-        assert get_settings().okw_source_resolved == "storage"
+    def test_unset_defaults_to_union(self, clean_env):
+        # #240: unset resolves to union (storage ∪ MoM), not storage.
+        assert get_settings().okw_source_resolved == "union"
 
     def test_explicit_storage(self, clean_env):
         clean_env.setenv("OKW_SOURCE", "storage")
@@ -103,9 +104,17 @@ class TestOkwSourceResolution:
         clean_env.setenv("OKW_SOURCE", "mom")
         assert get_settings().okw_source_resolved == "mom"
 
-    def test_unknown_falls_back_to_storage(self, clean_env):
+    def test_explicit_union(self, clean_env):
+        clean_env.setenv("OKW_SOURCE", "union")
+        assert get_settings().okw_source_resolved == "union"
+
+    def test_unknown_falls_back_to_union(self, clean_env):
         clean_env.setenv("OKW_SOURCE", "nonsense")
-        assert get_settings().okw_source_resolved == "storage"
+        assert get_settings().okw_source_resolved == "union"
+
+    def test_empty_string_resolves_to_union(self, clean_env):
+        clean_env.setenv("OKW_SOURCE", "")
+        assert get_settings().okw_source_resolved == "union"
 
     def test_tristate_distinguishes_unset_from_storage(self, clean_env):
         # Raw field preserves the None-vs-"storage" distinction for #240.

--- a/tests/unit/test_geographic_facility_filtering.py
+++ b/tests/unit/test_geographic_facility_filtering.py
@@ -104,16 +104,17 @@ def test_empty_location_field_excluded(matches_filters):
 
 
 def _patch_for_filtered_facilities(monkeypatch, facilities):
-    """Patch OKWService and local-dir resolver so _get_filtered_facilities uses only `facilities`."""
-    from src.core.services import okw_service as okw_mod
+    """Make the shared resolver return exactly `facilities`.
+
+    These tests exercise the *post-load* okw_filters geo step, not the source
+    resolution, so we stub the resolver rather than the storage/network path.
+    """
     import src.core.api.routes.match as match_mod
 
-    mock_service = AsyncMock()
-    mock_service.list = AsyncMock(return_value=(facilities, len(facilities)))
-    monkeypatch.setattr(
-        okw_mod.OKWService, "get_instance", AsyncMock(return_value=mock_service)
-    )
-    monkeypatch.setattr(match_mod, "_resolve_matching_local_okw_json_dir", lambda: None)
+    async def _fake_resolver(**kwargs):
+        return list(facilities)
+
+    monkeypatch.setattr(match_mod, "resolve_match_facilities", _fake_resolver)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_mom_okw_source_routing.py
+++ b/tests/unit/test_mom_okw_source_routing.py
@@ -1,9 +1,13 @@
-"""Regression: match API must route to MoM SPARQL when OKW_SOURCE=mom (no inline OKWs,
-no MATCHING_LOCAL_OKW_JSON_DIR) and must not touch blob storage in that case."""
+"""OKW_SOURCE=mom routing under the unified resolver (#240).
+
+Since the union-default change, all sources route through
+``OKWService.get_network_match_facilities`` (the network surface), not the
+per-manifest ``fetch_mom_facilities_for_manifest`` path. ``OKW_SOURCE=mom`` still
+means "MoM only" and still wins over ``MATCHING_LOCAL_OKW_JSON_DIR``.
+"""
 
 from __future__ import annotations
 
-import os
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -15,160 +19,84 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 
-@pytest.mark.asyncio
-async def test_get_filtered_facilities_uses_mom_when_okw_source_mom(monkeypatch):
-    from src.core.api.models.match.request import MatchRequest
-    from src.core.api.routes import match as match_mod
-    from src.core.models.okh import License, OKHManifest
-    from src.core.models.okw import FacilityStatus, Location, ManufacturingFacility
+def _mock_network(monkeypatch, return_value):
+    """Patch OKWService.get_instance so get_network_match_facilities is captured."""
     from src.core.services import okw_service as okw_mod
 
-    monkeypatch.setenv("OKW_SOURCE", "mom")
-    monkeypatch.setattr(match_mod, "_resolve_matching_local_okw_json_dir", lambda: None)
+    svc = AsyncMock()
+    svc.get_network_match_facilities = AsyncMock(return_value=return_value)
+    monkeypatch.setattr(okw_mod.OKWService, "get_instance", AsyncMock(return_value=svc))
+    return svc
 
-    monkeypatch.setattr(
-        okw_mod.OKWService,
-        "get_instance",
-        AsyncMock(
-            side_effect=AssertionError("OKWService must not load when OKW_SOURCE=mom")
-        ),
-    )
 
-    mom_facility = ManufacturingFacility(
+@pytest.mark.asyncio
+async def test_mom_routes_through_network_path_only(monkeypatch):
+    from src.core.services.okw_service import resolve_match_facilities
+    from src.core.models.okw import FacilityStatus, Location, ManufacturingFacility
+
+    mom_fac = ManufacturingFacility(
         name="Fab Lab Berlin",
         location=Location(gps_coordinates="52.52, 13.4"),
         facility_status=FacilityStatus.ACTIVE,
         manufacturing_processes=["laser_cutting"],
     )
+    svc = _mock_network(monkeypatch, [mom_fac])
 
-    mock_fetch = AsyncMock(return_value=[mom_facility])
+    # The requirement-aware per-manifest MoM fetch must NOT be used any more.
+    fetch = AsyncMock()
     monkeypatch.setattr(
-        "src.core.services.mom_bridge.fetch_mom_facilities_for_manifest", mock_fetch
+        "src.core.services.mom_bridge.fetch_mom_facilities_for_manifest", fetch
     )
 
-    manifest = OKHManifest(
-        title="Test Manifest",
-        version="1.0.0",
-        license=License(hardware="CERN-OHL-S-2.0"),
-        licensor="Test Licensor",
-        documentation_language="en",
-        function="Test function",
-        manufacturing_processes=["laser_cutting"],
-    )
-    req = MatchRequest.model_construct(okw_facilities=None)
+    result = await resolve_match_facilities(effective_source="mom")
 
-    facilities = await match_mod._get_filtered_facilities(
-        storage_service=None,
-        request=req,
-        request_id="unit-test",
-        domain="manufacturing",
-        okh_manifest=manifest,
-    )
-
-    assert facilities == [mom_facility]
-    mock_fetch.assert_awaited_once()
-    assert mock_fetch.call_args.args[0] is manifest
+    assert result == [mom_fac]
+    fetch.assert_not_awaited()
+    svc.get_network_match_facilities.assert_awaited_once()
+    kwargs = svc.get_network_match_facilities.await_args.kwargs
+    assert kwargs["include_mom"] is True
+    assert kwargs["source"] == "mom"
+    assert kwargs["require_coords"] is False
 
 
 @pytest.mark.asyncio
-async def test_get_filtered_facilities_mom_wins_over_local_json_dir(
-    tmp_path, monkeypatch
-):
-    """Regression: OKW_SOURCE=mom must win over MATCHING_LOCAL_OKW_JSON_DIR.
-
-    Previously the API checked MATCHING_LOCAL_OKW_JSON_DIR before OKW_SOURCE,
-    so a dev-convenience env var silently overrode an explicit mom request —
-    a divergence from the CLI, where --okw-source mom always reaches MoM.
-    See docs/runbooks/mom-integration-e2e-validation.md (Troubleshooting).
-    """
+async def test_mom_wins_over_local_json_dir(tmp_path, monkeypatch):
+    """OKW_SOURCE=mom is explicit; it must beat MATCHING_LOCAL_OKW_JSON_DIR."""
     import json
 
-    from src.core.api.models.match.request import MatchRequest
-    from src.core.api.routes import match as match_mod
-    from src.core.models.okh import License, OKHManifest
-    from src.core.models.okw import FacilityStatus, Location, ManufacturingFacility
     from src.core.services import okw_service as okw_mod
+    from src.core.services.okw_service import resolve_match_facilities
+    from src.core.models.okw import FacilityStatus, Location, ManufacturingFacility
 
-    monkeypatch.setenv("OKW_SOURCE", "mom")
-
-    local_facility = {
-        "name": "Local JSON Facility",
-        "location": {"gps_coordinates": "0.0, 0.0"},
-        "facility_status": "Active",
-        "manufacturing_processes": ["laser_cutting"],
-    }
-    (tmp_path / "facility.json").write_text(json.dumps(local_facility))
+    (tmp_path / "facility.json").write_text(
+        json.dumps(
+            {
+                "name": "Local JSON Facility",
+                "location": {"gps_coordinates": "0.0, 0.0"},
+                "facility_status": "Active",
+                "manufacturing_processes": ["laser_cutting"],
+            }
+        )
+    )
     monkeypatch.setattr(
         "src.config.settings.MATCHING_LOCAL_OKW_JSON_DIR", str(tmp_path)
     )
 
+    # If the local-dir loader were reached, this would fire the assertion.
     monkeypatch.setattr(
-        okw_mod.OKWService,
-        "get_instance",
-        AsyncMock(
-            side_effect=AssertionError("OKWService must not load when OKW_SOURCE=mom")
+        okw_mod,
+        "load_facilities_from_local_okw_json_dir",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("local dir must not be read when OKW_SOURCE=mom")
         ),
     )
 
-    mom_facility = ManufacturingFacility(
+    mom_fac = ManufacturingFacility(
         name="Fab Lab Berlin",
         location=Location(gps_coordinates="52.52, 13.4"),
         facility_status=FacilityStatus.ACTIVE,
-        manufacturing_processes=["laser_cutting"],
     )
-    mock_fetch = AsyncMock(return_value=[mom_facility])
-    monkeypatch.setattr(
-        "src.core.services.mom_bridge.fetch_mom_facilities_for_manifest", mock_fetch
-    )
+    _mock_network(monkeypatch, [mom_fac])
 
-    manifest = OKHManifest(
-        title="Test Manifest",
-        version="1.0.0",
-        license=License(hardware="CERN-OHL-S-2.0"),
-        licensor="Test Licensor",
-        documentation_language="en",
-        function="Test function",
-        manufacturing_processes=["laser_cutting"],
-    )
-    req = MatchRequest.model_construct(okw_facilities=None)
-
-    facilities = await match_mod._get_filtered_facilities(
-        storage_service=None,
-        request=req,
-        request_id="unit-test",
-        domain="manufacturing",
-        okh_manifest=manifest,
-    )
-
-    assert facilities == [mom_facility]
-    mock_fetch.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_get_filtered_facilities_ignores_mom_without_okh_manifest(monkeypatch):
-    """get_okw_source()=='mom' is only honored when an OKH manifest is available
-    to derive required processes from; otherwise falls through to blob storage."""
-    from src.core.api.models.match.request import MatchRequest
-    from src.core.api.routes import match as match_mod
-    from src.core.services import okw_service as okw_mod
-
-    monkeypatch.setenv("OKW_SOURCE", "mom")
-    monkeypatch.setattr(match_mod, "_resolve_matching_local_okw_json_dir", lambda: None)
-
-    mock_get_instance = AsyncMock()
-    mock_okw_service = AsyncMock()
-    mock_okw_service.list.return_value = ([], 0)
-    mock_get_instance.return_value = mock_okw_service
-    monkeypatch.setattr(okw_mod.OKWService, "get_instance", mock_get_instance)
-
-    req = MatchRequest.model_construct(okw_facilities=None)
-
-    await match_mod._get_filtered_facilities(
-        storage_service=None,
-        request=req,
-        request_id="unit-test",
-        domain="manufacturing",
-        okh_manifest=None,
-    )
-
-    mock_get_instance.assert_awaited()
+    result = await resolve_match_facilities(effective_source="mom")
+    assert result == [mom_fac]

--- a/tests/unit/test_okw_id_subset_filtering.py
+++ b/tests/unit/test_okw_id_subset_filtering.py
@@ -30,16 +30,17 @@ def _make_facility(facility_id: str):
 
 
 def _patch_for_filtered_facilities(monkeypatch, facilities):
-    """Patch OKWService + local-dir resolver so the loader returns only `facilities`."""
-    from src.core.services import okw_service as okw_mod
+    """Make the shared resolver return exactly `facilities`.
+
+    These tests exercise the post-load --okw-id subset restriction, not source
+    resolution, so we stub the resolver rather than the storage/network path.
+    """
     import src.core.api.routes.match as match_mod
 
-    mock_service = AsyncMock()
-    mock_service.list = AsyncMock(return_value=(facilities, len(facilities)))
-    monkeypatch.setattr(
-        okw_mod.OKWService, "get_instance", AsyncMock(return_value=mock_service)
-    )
-    monkeypatch.setattr(match_mod, "_resolve_matching_local_okw_json_dir", lambda: None)
+    async def _fake_resolver(**kwargs):
+        return list(facilities)
+
+    monkeypatch.setattr(match_mod, "resolve_match_facilities", _fake_resolver)
 
 
 def _request(**overrides):

--- a/tests/unit/test_okw_source_union_resolver.py
+++ b/tests/unit/test_okw_source_union_resolver.py
@@ -1,0 +1,199 @@
+"""#240 — OKW_SOURCE union default + shared facility-pool resolver.
+
+Covers the tri-state (union|storage|mom), env-restricts-request-narrows
+precedence, MATCHING_LOCAL_OKW_JSON_DIR (storage-only, never unioned),
+MoM-down graceful degradation, coordinate-less retention for matching, and
+API↔CLI parity on the single shared resolver.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    for key in ("OKW_SOURCE", "MATCHING_LOCAL_OKW_JSON_DIR"):
+        monkeypatch.delenv(key, raising=False)
+    return monkeypatch
+
+
+# ---------------------------------------------------------------------------
+# Precedence: env sets the universe; request narrows within it, never broadens.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "env, request_source, expected",
+    [
+        (None, None, "union"),  # unset → union
+        (None, "storage", "storage"),  # union narrows to storage
+        (None, "mom", "mom"),  # union narrows to mom
+        ("storage", None, "storage"),
+        ("storage", "mom", "storage"),  # cannot broaden storage → mom
+        ("storage", "union", "storage"),  # cannot broaden back to union
+        ("mom", None, "mom"),
+        ("mom", "storage", "mom"),  # mom is absolute
+        ("union", "storage", "storage"),
+        ("union", None, "union"),
+    ],
+)
+def test_resolve_effective_source(clean_env, env, request_source, expected):
+    from src.config.storage_config import resolve_effective_source
+
+    if env is not None:
+        clean_env.setenv("OKW_SOURCE", env)
+    assert resolve_effective_source(request_source) == expected
+
+
+# ---------------------------------------------------------------------------
+# Resolver routing: each source maps to the right network-path call.
+# ---------------------------------------------------------------------------
+
+
+def _mock_network(monkeypatch, return_value=None):
+    from src.core.services import okw_service as okw_mod
+
+    svc = AsyncMock()
+    svc.get_network_match_facilities = AsyncMock(return_value=return_value or [])
+    monkeypatch.setattr(okw_mod.OKWService, "get_instance", AsyncMock(return_value=svc))
+    # Ensure no stray local dir interferes.
+    monkeypatch.setattr(okw_mod, "resolve_matching_local_okw_json_dir", lambda: None)
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_union_includes_mom(clean_env, monkeypatch):
+    from src.core.services.okw_service import resolve_match_facilities
+
+    svc = _mock_network(monkeypatch)
+    await resolve_match_facilities(effective_source="union")
+    kwargs = svc.get_network_match_facilities.await_args.kwargs
+    assert kwargs["include_mom"] is True
+    assert kwargs.get("source") is None
+    assert kwargs["require_coords"] is False
+
+
+@pytest.mark.asyncio
+async def test_storage_excludes_mom(clean_env, monkeypatch):
+    from src.core.services.okw_service import resolve_match_facilities
+
+    svc = _mock_network(monkeypatch)
+    await resolve_match_facilities(effective_source="storage")
+    kwargs = svc.get_network_match_facilities.await_args.kwargs
+    assert kwargs["include_mom"] is False
+
+
+# ---------------------------------------------------------------------------
+# MATCHING_LOCAL_OKW_JSON_DIR: storage-only, never unioned.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_local_dir_is_storage_only_never_unioned(clean_env, monkeypatch):
+    from src.core.services import okw_service as okw_mod
+    from src.core.services.okw_service import resolve_match_facilities
+
+    sentinel = ["local-only"]
+    monkeypatch.setattr(
+        okw_mod, "resolve_matching_local_okw_json_dir", lambda: "/some/dir"
+    )
+    monkeypatch.setattr(
+        okw_mod,
+        "load_facilities_from_local_okw_json_dir",
+        lambda *a, **k: list(sentinel),
+    )
+    # If the network path were taken, this would fail the test.
+    monkeypatch.setattr(
+        okw_mod.OKWService,
+        "get_instance",
+        AsyncMock(
+            side_effect=AssertionError("must not touch storage/MoM for local dir")
+        ),
+    )
+
+    # Even with the union default, a local dir is never unioned with MoM.
+    result = await resolve_match_facilities(effective_source="union")
+    assert result == sentinel
+
+
+# ---------------------------------------------------------------------------
+# Coordinate-less facilities: dropped for browse, retained for matching.
+# ---------------------------------------------------------------------------
+
+
+def _facility_without_coords():
+    from src.core.models.okw import FacilityStatus, Location, ManufacturingFacility
+
+    return ManufacturingFacility(
+        name="No-Coords Fab",
+        location=Location(city="Nowhere"),  # no gps_coordinates
+        facility_status=FacilityStatus.ACTIVE,
+        manufacturing_processes=["cnc_milling"],
+    )
+
+
+def test_coordless_dropped_when_require_coords_true():
+    from src.core.services.okw_service import _local_facility_to_space
+
+    assert _local_facility_to_space(_facility_without_coords()) is None
+
+
+def test_coordless_retained_when_require_coords_false():
+    from src.core.services.okw_service import _local_facility_to_space
+
+    space = _local_facility_to_space(_facility_without_coords(), require_coords=False)
+    assert space is not None
+    assert space["lat"] is None and space["lon"] is None
+    assert space["source"] == "local"
+
+
+# ---------------------------------------------------------------------------
+# MoM-down graceful degradation: union still returns storage facilities.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_union_degrades_to_storage_when_mom_unavailable(clean_env, monkeypatch):
+    from src.core.services import okw_service as okw_mod
+
+    local = _facility_without_coords()
+
+    async def _one_page(self, *, page, page_size):
+        return ([local], 1) if page == 1 else ([], 0)
+
+    monkeypatch.setattr(okw_mod.OKWService, "list", _one_page)
+    # MoM cache reports unavailable (network down) → no MoM candidates added.
+    from src.core.services import mom_bridge
+
+    monkeypatch.setattr(
+        mom_bridge.mom_spaces_cache,
+        "get",
+        AsyncMock(return_value=([], False)),
+    )
+
+    svc = await okw_mod.OKWService.get_instance()
+    facilities = await svc.get_network_match_facilities(
+        include_mom=True, require_coords=False
+    )
+    assert facilities == [local]
+
+
+# ---------------------------------------------------------------------------
+# API ↔ CLI parity: both use the one shared resolver object.
+# ---------------------------------------------------------------------------
+
+
+def test_api_and_service_share_one_resolver():
+    import src.core.api.routes.match as match_mod
+    from src.core.services import okw_service as okw_mod
+
+    assert match_mod.resolve_match_facilities is okw_mod.resolve_match_facilities

--- a/uv.lock
+++ b/uv.lock
@@ -3185,7 +3185,7 @@ wheels = [
 
 [[package]]
 name = "supply-graph-ai"
-version = "0.8.7"
+version = "0.8.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Closes #240.

## What & why

An unset `OKW_SOURCE` used to resolve to **storage only**, so a match with no configured source silently ignored the Maps of Making (MoM) network. This flips the default to **`union` (storage ∪ MoM)** and consolidates facility loading behind one resolver shared by the API and CLI.

- **Tri-state** `OKW_SOURCE`: unset → `union`, `storage` → blob only, `mom` → MoM only. `okw_source_resolved` now distinguishes unset from an explicit `storage`.
- **Precedence** (`resolve_effective_source`): the environment sets the candidate universe; a per-request override may **narrow** within it but never **broaden** it (`storage`/`mom` are absolute).
- **`MATCHING_LOCAL_OKW_JSON_DIR`** stays storage-only, never unioned.

## One shared resolver (structural parity)

`OKWService.resolve_match_facilities` now backs **both** the API `_get_filtered_facilities` and the CLI fallback — not copy-paste. The ~110-line storage/MoM/local-dir branch in the match route collapses to a single call (net **−~180 lines** in the route). The local-dir helpers moved to the service layer so both callers share them.

### Design decisions made explicit
- **MoM unified on the network path** (`get_network_match_facilities`), per the decision recorded during planning — the requirement-aware per-manifest `fetch_mom_facilities_for_manifest` is no longer used for routing. Union **degrades gracefully** to storage when MoM is unavailable.
- **Coordinate-less facilities are retained for matching** (`require_coords=False`). The coordinate drop was correct for the map/browse surface but wrong for matching — a capability-valid facility shouldn't fall out of the pool for lacking geography. Parameterized so browse keeps its behavior.

## CLI
`--okw-source` omitted → union; an explicit source (or `OKW_SOURCE` env) takes the local fallback so the client-side override is honoured against the server's env. `--access-type`/`--facility-status`/`--location` are applied client-side after resolution (the API's classic path applies none).

## Tests
New `test_okw_source_union_resolver.py`: tri-state, full precedence matrix, local-dir storage-only, MoM-down degradation, coordinate retention, and API↔CLI parity (same resolver object). Existing MoM-routing / geo-filter / okw-id tests updated to the new contract.

## Verification
- `make ready` — **all 9 gates pass** (626 tests, +18).
- Live CLI match driven both ways: union default → 3 matches; `--okw-source storage` → 2 matches; no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)