### PR TITLE
docs(config): fix stale OKW_SOURCE comment (unset → union)

### DIFF
--- a/config/environments/development.toml
+++ b/config/environments/development.toml
@@ -7,5 +7,5 @@
 storage_provider = "local"
 
 # Optional overrides (unset here; resolved by code defaults):
-#   okw_source    = "storage"   # "storage" | "mom"; unset -> storage (Slice 1)
+#   okw_source    = "storage"   # "storage" | "mom"; unset -> union (storage ∪ MoM)
 #   cors_origins  = "*"         # unset in development -> allow-all ("*")


### PR DESCRIPTION
`config/environments/development.toml` still described the pre-#240 behavior — `unset -> storage (Slice 1)`. Since v0.8.8, an unset `OKW_SOURCE` resolves to **union (storage ∪ MoM)**. Comment-only change to the commented-out example line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)