### PR TITLE
fix(cd): install deps for deploy-azure job + make deploy environment explicit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,6 +201,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        # deploy_azure.py imports src.config (pydantic-settings, python-dotenv,
+        # …), so the deploy step needs the project's runtime deps installed.
+        run: uv sync
+
       - name: Azure login (OIDC)
         uses: azure/login@v2
         with:
@@ -209,10 +217,13 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy
+        # --environment is explicit: the deploy target must never be inferred
+        # (locally it would be read from a developer's .env — a prod footgun).
         run: |
-          python3 deploy/scripts/deploy_azure.py \
+          uv run python deploy/scripts/deploy_azure.py \
             --image ${{ env.IMAGE }}:${{ needs.validate.outputs.version }} \
-            --subscription-id ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+            --subscription-id ${{ secrets.AZURE_SUBSCRIPTION_ID }} \
+            --environment production
 
       - name: Verify deployment
         run: |

--- a/deploy/scripts/deploy_azure.py
+++ b/deploy/scripts/deploy_azure.py
@@ -64,8 +64,14 @@ def main():
     )
     parser.add_argument(
         "--environment",
-        default=os.getenv("ENVIRONMENT", "production"),
-        help="Target environment; selects config/environments/<env>.toml (default: production)",
+        default="production",
+        help=(
+            "Target environment; selects config/environments/<env>.toml "
+            "(default: production). Deliberately NOT read from the ENVIRONMENT "
+            "env var: importing src.config loads .env, so inferring the deploy "
+            "target from it would let a developer's local .env redirect a prod "
+            "deploy. Pass --environment explicitly for anything but production."
+        ),
     )
     parser.add_argument(
         "--cors-origins",


### PR DESCRIPTION
## What happened

The `v0.8.8` release published fine (Docker Hub image + GitHub Release), but the **deploy-azure** job failed:

```
ModuleNotFoundError: No module named 'dotenv'
  from src.config.schema import deploy_env_vars → src/config/__init__.py → settings.py → from dotenv import load_dotenv
```

The job ran `python3 deploy/scripts/deploy_azure.py` on the bare runner with **no project dependencies installed**. This was latent — v0.8.7 never reached the Deploy step (it failed earlier at `azure/login`, before the service principal had an RBAC role), so this was the first time the step actually executed.

*(0.8.8 was deployed manually in the meantime; prod is live and healthy on 0.8.8.)*

## Fix

- **Install deps in the job**: add `astral-sh/setup-uv` + `uv sync`, and run the script via `uv run python`.
- **Make the deploy target explicit**: pass `--environment production` in the workflow, and change the script default from `os.getenv("ENVIRONMENT", "production")` to a literal `"production"`. Importing `src.config` calls `load_dotenv()`, so the old default let a local `.env` (`ENVIRONMENT=development`) silently redirect the deploy to dev config — a prod footgun (which is exactly how a manual run misfired during recovery). The deploy target should never be inferred from ambient env.

## Verification
- `deploy_azure.py --help` parses; `release.yml` is valid YAML.
- The real proof is the next tagged release exercising `deploy-azure` green; manual local runs of the script (with `--environment production`) already succeed against the live app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)