### PR TITLE
chore(guard): block deploy_azure.py without --environment (captured lesson)

### DIFF
--- a/.claude/hooks/require-deploy-environment.sh
+++ b/.claude/hooks/require-deploy-environment.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) guard: refuse to run deploy_azure.py without an explicit
+# --environment. Importing src.config runs load_dotenv(), so the deploy target
+# would otherwise be inferred from a developer's local .env — which once applied
+# development.toml (STORAGE_PROVIDER=local) to the PRODUCTION container app.
+# The deploy target must always be explicit. See ~/.claude/lessons/ledger.md.
+set -euo pipefail
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | python3 -c \
+  "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" \
+  2>/dev/null || true)
+
+# Only guard actual invocations (python3/uv run … deploy_azure.py), not
+# cat/grep/reads of the file.
+if printf '%s' "$cmd" | grep -qE '(python[0-9]*|uv run)[^&|;]*deploy_azure\.py'; then
+  # Allow help/inspection.
+  if printf '%s' "$cmd" | grep -qE '(^|[[:space:]])(-h|--help)([[:space:]]|$)'; then
+    exit 0
+  fi
+  # Require an explicit deploy target.
+  if ! printf '%s' "$cmd" | grep -qE '(^|[[:space:]])--environment([[:space:]]|=)'; then
+    echo "Blocked: deploy_azure.py invoked without --environment. The deploy target must be explicit — importing src.config runs load_dotenv(), so a local .env (ENVIRONMENT=development) can silently redirect the deploy and mis-point prod. Re-run with an explicit target, e.g. --environment production." >&2
+    exit 2
+  fi
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/require-deploy-environment.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Turns the v0.8.8 deploy incident into a gate.

## Background
During the 0.8.8 deploy recovery, `deploy_azure.py` was run locally without `--environment`. Importing `src.config` calls `load_dotenv()`, so the script's `--environment` default (`os.getenv("ENVIRONMENT", "production")`) read the developer's local `.env` (`ENVIRONMENT=development`) and applied `development.toml` (`STORAGE_PROVIDER=local`) to the **production** container — briefly mis-pointing prod at empty storage.

## This PR
A project **PreToolUse(Bash) hook** (`.claude/hooks/require-deploy-environment.sh`, registered in `.claude/settings.json`) that blocks any `python … deploy_azure.py` / `uv run … deploy_azure.py` command lacking `--environment` (exit 2, with the reason fed back). Allows `--help` and non-invocations (`cat`/`grep`).

Verified against the exact incident command (blocked), the corrected form with `--environment production` (passes), `--help` and `cat` (pass).

Complements **#253** (which hardens the script default + makes the workflow pass `--environment production`): #253 fixes the script/CD; this stops the mistake the moment an agent tries to run the command, in any local session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)