### PR TITLE
feat(cd): build + deploy the frontend on tagged releases (Slice 3b)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ concurrency:
 
 env:
   IMAGE: touchthesun/openhardwaremanager
+  FRONTEND_IMAGE: touchthesun/openhardwaremanager-frontend
   PYTHON_VERSION: "3.12"
   # Published images must be pullable on Apple Silicon and linux/amd64 CI/cloud.
   PLATFORMS: linux/amd64,linux/arm64
@@ -265,6 +266,108 @@ jobs:
               sys.exit("DEPLOY GATE FAILED: " + "; ".join(errors))
           print("deploy gate passed")
           PY
+
+  # Frontend (nginx SPA + /v1 reverse-proxy) — built multi-arch so the image runs
+  # on linux/amd64 hosts (a bare `docker build` on Apple Silicon is arm64-only and
+  # fails to activate on Azure Container Apps).
+  publish-frontend:
+    name: Publish frontend multi-arch to Docker Hub
+    runs-on: ubuntu-latest
+    needs: [validate]
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: image=moby/buildkit:latest
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push multi-arch frontend manifest
+        uses: docker/build-push-action@v6
+        with:
+          context: frontend
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: |
+            ${{ env.FRONTEND_IMAGE }}:${{ needs.validate.outputs.version }}
+            ${{ env.FRONTEND_IMAGE }}:${{ needs.validate.outputs.major_minor }}
+            ${{ env.FRONTEND_IMAGE }}:latest
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,mode=max,scope=frontend
+
+      - name: Publish summary
+        run: |
+          echo "Published multi-arch frontend (${{ env.PLATFORMS }}):"
+          echo "  ${{ env.FRONTEND_IMAGE }}:${{ needs.validate.outputs.version }}"
+          echo "  ${{ env.FRONTEND_IMAGE }}:${{ needs.validate.outputs.major_minor }}"
+          echo "  ${{ env.FRONTEND_IMAGE }}:latest"
+
+  # Deploys the frontend container app (openhardwaremanager-frontend). Mirrors
+  # deploy-azure: OIDC into the "production" GitHub Environment, then updates the
+  # image + applies API_UPSTREAM_URL / PORT from config/environments/production.toml
+  # [frontend] via deploy_azure_frontend.py. --environment is explicit (never
+  # inferred). The container app itself is provisioned once out-of-band.
+  deploy-frontend-azure:
+    name: Deploy frontend to Azure Container Apps
+    runs-on: ubuntu-latest
+    needs: [validate, publish-frontend]
+    if: github.event_name == 'push'
+    environment: production
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        # deploy_azure_frontend.py imports src.config (frontend_deploy_env_vars).
+        run: uv sync
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deploy frontend
+        run: |
+          uv run python deploy/scripts/deploy_azure_frontend.py \
+            --image ${{ env.FRONTEND_IMAGE }}:${{ needs.validate.outputs.version }} \
+            --subscription-id ${{ secrets.AZURE_SUBSCRIPTION_ID }} \
+            --environment production
+
+      - name: Verify frontend deployment
+        run: |
+          host=openhardwaremanager-frontend.blackdune-e38fce01.westus3.azurecontainerapps.io
+          code=000
+          for i in $(seq 1 30); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 "https://$host/healthz" || true)
+            [ "$code" = "200" ] && break
+            sleep 5
+          done
+          echo "frontend /healthz -> $code"
+          test "$code" = "200"
+          # The /v1 reverse-proxy reaches the backend API (same-origin).
+          curl -sf --max-time 20 "https://$host/v1/openapi.json" >/dev/null
+          echo "frontend proxy -> backend /v1 OK"
 
   # Git tags alone do not appear under GitHub → Releases. This job creates the
   # Release page entry (notes, source archives) after Docker publish succeeds.


### PR DESCRIPTION
Completes the frontend deployment story: tagged releases now build and deploy the frontend alongside the backend.

Two jobs added to `release.yml`, mirroring the backend's `publish` / `deploy-azure`:

- **`publish-frontend`** — buildx **multi-arch** (`linux/amd64,linux/arm64`) from `frontend/`, pushed to `touchthesun/openhardwaremanager-frontend` (`:<version>`, `:<major.minor>`, `:latest`). Multi-arch is the whole point: a bare `docker build` on Apple Silicon is arm64-only and `ActivationFailed`s on ACA — this makes automated releases immune to that (the manual bootstrap hit it once).
- **`deploy-frontend-azure`** — OIDC into the `production` environment, then `deploy_azure_frontend.py` updates the frontend container app image and applies `API_UPSTREAM_URL` / `PORT` from `config/environments/production.toml [frontend]` (`--environment production`, explicit). Verifies `/healthz` and that the `/v1` reverse-proxy reaches the backend.

Frontend jobs gate only on `validate`, independent of the backend lane, so a `v*.*.*` tag ships both services.

Valid YAML; jobs: validate, test, docker-smoke, publish, deploy-azure, **publish-frontend, deploy-frontend-azure**, github-release. Real end-to-end proof comes with the next tagged release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)