### PR TITLE
Release 0.10.2: process inference, remote file types, country names

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 569
+Total Python files: 576
 
 ├── deploy/
 │   ├── __init__.py
@@ -718,6 +718,7 @@ Total Python files: 569
 │       │   ├── okh_file_urls.py
 │       │   │       def build_okh_file_proxy_url()
 │       │   │       def api_base_from_request()
+│       │   │       def _host_display_label()
 │       │   │       def enrich_file_ref()
 │       │   │       def enrich_manifest_file_urls()
 │       │   └── routes/
@@ -1133,6 +1134,9 @@ Total Python files: 569
 │       │   │   ├── __init__.py
 │       │   │   ├── file_categorization_service.py
 │       │   │   │       class FileCategorizationService (__init__, _parse_llm_response, _extract_json_from_response...)
+│       │   │   ├── process_inference_service.py
+│       │   │   │       class ProcessInferenceResult
+│       │   │   │       class ProcessInferenceService (__init__, infer_from_paths, infer_from_text...)
 │       │   │   ├── prompts/
 │       │   │   │   ├── __init__.py
 │       │   │   │   └── file_categorization_prompts.py
@@ -1690,6 +1694,10 @@ Total Python files: 569
 │       │           def validate_definitions()
 │       │           def _create_taxonomy()
 │       ├── utils/
+│       │   ├── country_names.py
+│       │   │       def display_country_name()
+│       │   │       def country_match_key()
+│       │   │       def countries_match()
 │       │   ├── domain_detection.py
 │       │   │       def detect_domain()
 │       │   ├── file_path_display.py
@@ -1707,6 +1715,12 @@ Total Python files: 569
 │       │   ├── match_human_summary.py
 │       │   │       def _solution_label()
 │       │   │       def build_match_human_summary()
+│       │   ├── remote_file_hint.py
+│       │   │       def filename_from_content_disposition()
+│       │   │       def filename_from_url_path()
+│       │   │       def clear_remote_filename_cache()
+│       │   │       def _filename_from_response()
+│       │   │       def probe_remote_filename()
 │       │   ├── schema_generator.py
 │       │   │       def generate_json_schema()
 │       │   │       def _normalize_schema()
@@ -2130,6 +2144,13 @@ Total Python files: 569
     │   ├── test_network_okw_ids_mom.py
     │   │       def _load_json()
     │   │       def _patch_mom_cache()
+    │   ├── test_remote_api.py
+    │   │       def _api_base()
+    │   │       def _get()
+    │   │       def _post()
+    │   │       def test_remote_health_and_mom_pool()
+    │   │       def test_remote_harness_manifest_matches_3dp()
+    │   │       def test_remote_stored_okh_empty_processes_yield_zero()
     │   └── test_taxonomy_coverage.py
     │           def _mom_live_enabled()
     ├── parity/
@@ -2319,6 +2340,9 @@ Total Python files: 569
         │       class TestDeployEnvVars (test_production_applies_storage_target, test_development_is_local, test_missing_environment_returns_empty...)
         │       class TestFrontendDeployEnvVars (test_production_frontend_config, test_keys_are_uppercased_env_names, test_absent_table_returns_empty...)
         │       def clean_env()
+        ├── test_country_names.py
+        │       def test_display_country_name_codes()
+        │       def test_countries_match_code_and_name()
         ├── test_deploy_cors_default.py
         │       def _data()
         │       def test_cors_origins_defaults_to_wildcard_when_omitted()
@@ -2678,6 +2702,25 @@ Total Python files: 569
         │       def test_probe_okh_files_clean_when_urls_proxied()
         │       def test_check_file_url_relative_path()
         │       def test_write_probe_proposals_creates_markdown()
+        ├── test_process_inference_service.py
+        │       def _manifest()
+        │       def service()
+        │       def test_stl_paths_infer_3d_printing()
+        │       def test_3mf_and_gcode_infer_3d_printing()
+        │       def test_gerber_infers_pcb_fabrication()
+        │       def test_nc_infers_cnc_machining()
+        │       def test_unrelated_extensions_yield_empty()
+        │       def test_deduplicates_across_paths()
+        │       def test_apply_to_manifest_only_if_empty()
+        │       def test_apply_merges_when_not_only_if_empty()
+        │       def test_infer_from_okh_paths_and_design_files()
+        │       def test_title_3dp_prefix_infers_3d_printing()
+        │       def test_title_laser_cut_infers_laser_cutting()
+        │       def test_keywords_infer_pcb()
+        │       def test_unrelated_title_yields_empty()
+        │       def test_face_in_title_does_not_infer_surface_finishing()
+        │       def test_manifest_title_used_when_no_file_types()
+        │       def test_file_type_and_title_merge()
         ├── test_provenance_model.py
         │       def test_credit_requires_exactly_one_identifier()
         │       def test_provenance_sign_and_verify_round_trip()
@@ -2699,6 +2742,12 @@ Total Python files: 569
         │       def test_red_loop_clean_with_empty_tracker()
         │       def test_red_loop_reports_threshold_breaches()
         │       def test_load_metrics_in_process_returns_endpoints_shape()
+        ├── test_remote_file_hint.py
+        │       def setup_function()
+        │       def test_filename_from_content_disposition()
+        │       def test_filename_from_url_path_strips_query()
+        │       def test_probe_remote_filename_uses_redirect_location()
+        │       def test_enrich_resolves_thingiverse_download_to_stl()
         ├── test_repair_model.py
         │       class _C (__init__)
         │       class TestDeriveAction (_cs, test_none_state_returns_assess, test_unknown_condition_returns_assess...)
@@ -2781,7 +2830,7 @@ Total Python files: 569
 
 ## Overview
 
-Total files analyzed: 569
+Total files analyzed: 576
 
 ## Entry Points
 
@@ -2843,6 +2892,9 @@ Slices 2–4 add ca...
 **Internal Dependencies:** 2 imports
 
 ### `src/core/generation/services/__init__.py`
+> Generation-pipeline helpers (not BaseService facades).
+
+Modules: ``file_categorization_service``, ``...
 
 ### `src/core/generation/services/file_categorization_service.py`
 > File Categorization Service for LLM-based file categorization.
@@ -2856,6 +2908,21 @@ This service provides file categoriz...
   - Service for file categorization using LLM content analysis.
 
 This service coordi...
+
+### `src/core/generation/services/process_inference_service.py`
+> Infer OKH manufacturing_processes from file types and title/keywords.
+
+Lives in ``src/core/generatio...
+
+**Exports:** ProcessInferenceResult, ProcessInferenceService
+
+**Classes:**
+- `ProcessInferenceResult`
+- `ProcessInferenceService`
+  - Methods: infer_from_paths, infer_from_text, infer, infer_from_manifest, apply_to_manifest
+  - File-type + title/keyword → manufacturing process inference....
+
+**Internal Dependencies:** 1 imports
 
 ### `src/core/generation/services/prompts/__init__.py`
 
@@ -3394,6 +3461,20 @@ This module provides functionality for migrating files to organized direc...
 - `test_cache_service_tracks_hits_and_misses()`
 
 **Internal Dependencies:** 7 imports
+
+### `tests/unit/test_process_inference_service.py`
+> Unit tests for file-type → manufacturing process inference....
+
+**Exports:** service, test_stl_paths_infer_3d_printing, test_3mf_and_gcode_infer_3d_printing, test_gerber_infers_pcb_fabrication, test_nc_infers_cnc_machining
+
+**Functions:**
+- `service()`
+- `test_stl_paths_infer_3d_printing(service)`
+- `test_3mf_and_gcode_infer_3d_printing(service)`
+- `test_gerber_infers_pcb_fabrication(service)`
+- `test_nc_infers_cnc_machining(service)`
+
+**Internal Dependencies:** 11 imports
 
 ### `tests/unit/test_service_provenance_stamping.py`
 > OKH/OKW create persists provenance to its own plane (Slice 3).
@@ -4974,6 +5055,18 @@ This module provides centralized text processing f...
   - Methods: clean_text, extract_license_type, extract_version_from_text, extract_manufacturing_processes, classify_content_type
   - Centralized text processing utilities...
 
+### `src/core/utils/country_names.py`
+> Normalize ISO country codes to English display names for UI / filter matching....
+
+**Exports:** display_country_name, country_match_key, countries_match
+
+**Functions:**
+- `display_country_name(raw)`
+  - Return English country name; pass through unknown values unchanged....
+- `country_match_key(raw)`
+  - Canonical lowercase key so FR and France compare equal....
+- `countries_match(a, b)`
+
 ### `src/core/utils/domain_detection.py`
 > Domain detection utilities for OKH and OKW data.
 
@@ -5030,6 +5123,20 @@ Args:
   - Build deterministic multi-level human summaries for match responses.
 
 The output...
+
+### `src/core/utils/remote_file_hint.py`
+> Probe remote download URLs for a real filename (Content-Disposition / redirect)....
+
+**Exports:** filename_from_content_disposition, filename_from_url_path, clear_remote_filename_cache, probe_remote_filename
+
+**Functions:**
+- `filename_from_content_disposition(header)`
+- `filename_from_url_path(url)`
+- `clear_remote_filename_cache()`
+- `probe_remote_filename(url, timeout)`
+  - Return a filename hint for classification without downloading bodies.
+
+Prefer a ...
 
 ### `src/core/utils/schema_generator.py`
 > JSON Schema Generator for Dataclasses
@@ -6645,7 +6752,7 @@ Args:
 - `enrich_manifest_file_urls(manifest_dict, api_base, okh_id)`
   - Add enriched fields on each file ref for clients and probes....
 
-**Internal Dependencies:** 2 imports
+**Internal Dependencies:** 4 imports
 
 ### `src/core/api/routes/__init__.py`
 
@@ -9686,6 +9793,20 @@ title and primary faci...
 
 **Internal Dependencies:** 8 imports
 
+### `tests/matching/test_remote_api.py`
+> Opt-in remote API probe — set OHM_API_BASE to a live OHM origin.
+
+Documents the gap between harness ...
+
+**Exports:** test_remote_health_and_mom_pool, test_remote_harness_manifest_matches_3dp, test_remote_stored_okh_empty_processes_yield_zero
+
+**Functions:**
+- `test_remote_health_and_mom_pool()`
+- `test_remote_harness_manifest_matches_3dp()`
+  - Inline 3DP okh_manifest against MoM must return solutions (id-alignment OK)....
+- `test_remote_stored_okh_empty_processes_yield_zero(capsys)`
+  - UI path: many stored OKHs have empty manufacturing_processes → 0 matches....
+
 ### `tests/matching/test_taxonomy_coverage.py`
 > Offline + live taxonomy coverage across processes.yaml....
 
@@ -9943,6 +10064,17 @@ Verifies that:
 - `test_manifest_round_trip_with_ids()`
 
 **Internal Dependencies:** 13 imports
+
+### `tests/unit/test_country_names.py`
+> Tests for country code ↔ name normalization....
+
+**Exports:** test_display_country_name_codes, test_countries_match_code_and_name
+
+**Functions:**
+- `test_display_country_name_codes()`
+- `test_countries_match_code_and_name()`
+
+**Internal Dependencies:** 3 imports
 
 ### `tests/unit/test_deploy_cors_default.py`
 > Regression: deployment configs must never silently omit CORS_ORIGINS.
@@ -10569,6 +10701,20 @@ Covers the enriched M...
 - `test_red_loop_clean_with_empty_tracker(monkeypatch)`
 - `test_red_loop_reports_threshold_breaches(monkeypatch)`
 - `test_load_metrics_in_process_returns_endpoints_shape()`
+
+### `tests/unit/test_remote_file_hint.py`
+> Unit tests for remote file filename probing....
+
+**Exports:** setup_function, test_filename_from_content_disposition, test_filename_from_url_path_strips_query, test_probe_remote_filename_uses_redirect_location, test_enrich_resolves_thingiverse_download_to_stl
+
+**Functions:**
+- `setup_function()`
+- `test_filename_from_content_disposition()`
+- `test_filename_from_url_path_strips_query()`
+- `test_probe_remote_filename_uses_redirect_location()`
+- `test_enrich_resolves_thingiverse_download_to_stl()`
+
+**Internal Dependencies:** 5 imports
 
 ### `tests/unit/test_reverse_facility_matching.py`
 > Unit tests for reverse matching — designs a facility can produce (review #7).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2] - 2026-07-23
+
+### Added
+
+- **Process inference service:** modular file-type + title/keyword →
+  `manufacturing_processes` (`ProcessInferenceService`), wired into OKH
+  generation and `ohm okh infer-processes` backfill (dry-run / `--apply`).
+- **Remote file type resolution:** extensionless downloads (e.g. Thingiverse)
+  resolve via redirect/Content-Disposition so the UI shows STL Mesh etc.
+  instead of Unknown.
+
+### Changed
+
+- **Facility country display:** network spaces and UI normalize ISO codes to
+  full names (`FR` → `France`); filters treat code and name as equivalent.
+
+### Fixed
+
+- Sparse Match UI when stored OKHs had empty `manufacturing_processes` despite
+  design files / `3DP-…` titles — backfill path and generation safety net.
+
 ## [0.10.1] - 2026-07-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Open Hardware Manager (OHM) is a flexible, domain-agnostic framework designe
 
 OHM exposes a FastAPI-based HTTP API that can be run locally via Docker Compose, from a [published Docker image](https://hub.docker.com/r/touchthesun/openhardwaremanager), or deployed serverlessly using the configurations in `deploy/`.
 
-**Current release:** `0.10.1` — see [CHANGELOG.md](CHANGELOG.md) and [Release process](docs/RELEASE.md).
+**Current release:** `0.10.2` — see [CHANGELOG.md](CHANGELOG.md) and [Release process](docs/RELEASE.md).
 
 ## Quick Start for New Users
 
@@ -28,11 +28,11 @@ After installing, open a new terminal so the tools are on your PATH.
 **Local storage (no credentials needed):**
 
 ```bash
-docker pull touchthesun/openhardwaremanager:0.10.1
+docker pull touchthesun/openhardwaremanager:0.10.2
 docker run -p 8001:8001 \
   -e STORAGE_PROVIDER=local \
   -e LLM_ENABLED=false \
-  touchthesun/openhardwaremanager:0.10.1
+  touchthesun/openhardwaremanager:0.10.2
 ```
 
 **Remote storage (Azure Blob, AWS S3, or GCS):**
@@ -43,7 +43,7 @@ The published image does not include a `.env` file — you must pass your storag
 # Copy the template, fill in your provider and credentials, then:
 docker run -p 8001:8001 \
   --env-file .env \
-  touchthesun/openhardwaremanager:0.10.1
+  touchthesun/openhardwaremanager:0.10.2
 ```
 
 The minimum `.env` keys for Azure Blob are:

--- a/docs/architecture/generation.md
+++ b/docs/architecture/generation.md
@@ -663,6 +663,28 @@ The LLM layer is designed to support:
 ### Purpose
 The Generation Engine orchestrates all generation layers and manages the progressive enhancement process to create high-quality OKH manifests from project data.
 
+### Supporting services (`src/core/generation/services/`)
+
+These are **pipeline helpers**, not `BaseService` domain facades (those live
+under `src/core/services/`). They are shared by generation layers and, where
+useful, by OKH storage backfill:
+
+| Service | Role |
+|---------|------|
+| `FileCategorizationService` | Heuristic + optional LLM file → OKH documentation buckets |
+| `RepositoryMappingService` | Large-repo routing / destination paths |
+| `ProcessInferenceService` | File extension + title/keyword → `manufacturing_processes` |
+
+**Process inference** fills empty `manufacturing_processes` during generation
+(heuristic layer, plus an engine post-normalize safety net) and via
+`ohm okh infer-processes` / `OKHService.backfill_manufacturing_processes`.
+It resolves display names through the [canonical process taxonomy](process-taxonomy-adr.md)
+using **exact** alias/TSDC lookup for tokens (avoids substring false positives
+such as `face` ⊂ `surface_finish`). Extension → process mappings are defined
+in the service; taxonomy remains the SSOT for process IDs.
+
+See also: [matching harness — backfill](../testing/matching-harness.md#backfilling-empty-manufacturing_processes).
+
 ### Implementation Details
 
 ```python

--- a/docs/architecture/process-taxonomy-adr.md
+++ b/docs/architecture/process-taxonomy-adr.md
@@ -119,16 +119,22 @@ Key aspects:
 - All 6 consumer sites needed refactoring (completed)
 - The alias table must be maintained as new processes are discovered
 - Substring matching in `normalize()` could cause false positives for
-  very short inputs (mitigated by 3-character minimum)
+  very short inputs (mitigated by 3-character minimum). Free-text
+  **process inference** (`ProcessInferenceService`) therefore uses
+  exact alias/TSDC lookup only when scanning titles/keywords.
 - YAML file must remain in sync with any new built-in definitions
 
 ## Files
 
 - **Taxonomy module**: `src/core/taxonomy/__init__.py`, `src/core/taxonomy/process_taxonomy.py`
 - **YAML definitions**: `src/config/taxonomy/processes.yaml`
+- **Process inference (generation helper)**: `src/core/generation/services/process_inference_service.py`
+  — extension/title → display names via this taxonomy; see
+  [Generation architecture](generation.md#supporting-services-srccoregenerationservices)
 - **Tests**: `tests/core/taxonomy/test_process_taxonomy.py` (164 tests),
-  `tests/core/taxonomy/test_yaml_loading.py` (33 tests)
-- **CLI**: `src/cli/taxonomy.py`
+  `tests/core/taxonomy/test_yaml_loading.py` (33 tests),
+  `tests/unit/test_process_inference_service.py`
+- **CLI**: `src/cli/taxonomy.py`; backfill via `ohm okh infer-processes`
 - **API**: `src/core/api/routes/taxonomy.py`
 - **Refactored consumers**: `matching_service.py`, `okh_validator.py`,
   `okw_validator.py`, `engine.py`, `heuristic.py`, `base.py`,

--- a/docs/llm/generation.md
+++ b/docs/llm/generation.md
@@ -230,7 +230,11 @@ The LLM layer can generate all OKH manifest fields:
 ### Optional Fields
 - **description**: Detailed description (confidence: 0.8-1.0)
 - **keywords**: Relevant tags (confidence: 0.8-0.9)
-- **manufacturing_processes**: Manufacturing methods (confidence: 0.7-0.9)
+- **manufacturing_processes**: Manufacturing methods (confidence: 0.7-0.9).
+  When layers leave this empty, file-type inference
+  (`ProcessInferenceService`) seeds processes from extensions such as
+  `.stl`/`.3mf`/`.gcode` → 3D Printing and Gerbers → PCB Fabrication.
+  Backfill stored OKHs with `ohm okh infer-processes`.
 - **materials**: Material specifications (confidence: 0.7-0.8)
 - **manufacturing_specs**: Detailed specifications (confidence: 0.6-0.8)
 - **parts**: Component specifications (confidence: 0.6-0.8)

--- a/docs/testing/matching-harness.md
+++ b/docs/testing/matching-harness.md
@@ -73,8 +73,41 @@ network match with `facility_count > 0`, and prints full taxonomy coverage.
 
 Recommended before cutting a release that touches matching or MoM.
 
+## Opt-in remote deployed API
+
+Probe a running OHM (e.g. Azure Container Apps) without local MoM SPARQL:
+
+```bash
+OHM_API_BASE=https://openhardwaremanager.EXAMPLE.azurecontainerapps.io \
+  uv run pytest tests/matching/test_remote_api.py -s
+```
+
+This checks: MoM browse pool is healthy, harness `okh_manifest` still matches,
+and reports how many **stored** OKHs have empty `manufacturing_processes`
+(UI `okh_id` path → zero solutions when empty).
+
+## Backfilling empty manufacturing_processes
+
+Stored OKHs often have manufacturing files (`.stl`, `.3mf`, `.gcode`, Gerbers)
+but an empty `manufacturing_processes` list — Match then finds nothing. The
+modular `ProcessInferenceService` maps file extensions **and** title/keyword
+tokens (e.g. `3DP-…`, `laser-cut-…`) → taxonomy processes and is used in
+generation (heuristic + engine safety net) and for backfill:
+
+```bash
+# Dry-run (default): report what would change
+ohm okh infer-processes --all --limit 100
+
+# One manifest
+ohm okh infer-processes <manifest-id>
+
+# Persist updates
+ohm okh infer-processes --all --apply
+```
+
 ## Related
 
 - [WF-1: Single-level matching](workflows/wf01-single-level-matching.md)
 - [`scripts/matching_batch.py`](../../scripts/matching_batch.py) — storage-only batch eval (separate from this harness)
 - Probe `probe_match` — availability/503, not correctness
+- `src/core/generation/services/process_inference_service.py` — file-type → process inference

--- a/frontend/src/features/network/NetworkMap.tsx
+++ b/frontend/src/features/network/NetworkMap.tsx
@@ -7,6 +7,7 @@ import "leaflet.markercluster/dist/MarkerCluster.css";
 import "leaflet.markercluster/dist/MarkerCluster.Default.css";
 import type { NetworkSpace } from "../../api/ohm/network";
 import { SOURCE_STYLES } from "./networkSummary";
+import { displayCountryName } from "../match/geoDisplay";
 
 // Vector div-icons (a colored dot) avoid Leaflet's broken default-marker asset
 // paths under Vite, are colorable by source, and are still real L.Markers so
@@ -60,7 +61,11 @@ export function NetworkMap({ spaces }: { spaces: NetworkSpace[] }) {
               {s.city && (
                 <>
                   <br />
-                  <span>{[s.city, s.country].filter(Boolean).join(", ")}</span>
+                  <span>
+                    {[s.city, s.country ? displayCountryName(s.country) : null]
+                      .filter(Boolean)
+                      .join(", ")}
+                  </span>
                 </>
               )}
             </Popup>

--- a/frontend/src/features/network/NetworkSpaceCard.tsx
+++ b/frontend/src/features/network/NetworkSpaceCard.tsx
@@ -4,12 +4,19 @@ import { Badge } from "../../components/ui/Badge";
 import type { NetworkSpace } from "../../api/ohm/network";
 import { humanizeProcessId } from "./deriveFilterOptions";
 import { SOURCE_STYLES } from "./networkSummary";
+import { displayCountryName, displayRegionName } from "../match/geoDisplay";
 
 const CARD_CLASS =
   "group flex h-full flex-col gap-3 rounded-xl border border-slate-200 bg-white p-5 no-underline shadow-sm transition-shadow hover:shadow-md dark:border-slate-700 dark:bg-slate-900";
 
 export function NetworkSpaceCard({ space }: { space: NetworkSpace }) {
-  const location = [space.city, space.region, space.country].filter(Boolean).join(", ");
+  const location = [
+    space.city,
+    space.region ? displayRegionName(space.region) : null,
+    space.country ? displayCountryName(space.country) : null,
+  ]
+    .filter(Boolean)
+    .join(", ");
   const processes = (space.processes ?? []).map(humanizeProcessId);
 
   const body = (

--- a/frontend/src/features/network/deriveFilterOptions.ts
+++ b/frontend/src/features/network/deriveFilterOptions.ts
@@ -1,4 +1,5 @@
 import type { NetworkSpace } from "../../api/ohm/network";
+import { countryMatchKey, displayCountryName } from "../match/geoDisplay";
 
 /** "laser_cutting" -> "Laser Cutting" (canonical OHM process id → label). */
 export function humanizeProcessId(id: string): string {
@@ -23,6 +24,19 @@ function distinct(values: (string | null | undefined)[]): string[] {
   );
 }
 
+/** Dedupe country codes vs full names; return sorted full display names. */
+function distinctCountries(values: (string | null | undefined)[]): string[] {
+  const byKey = new Map<string, string>();
+  for (const raw of values) {
+    if (!raw?.trim()) continue;
+    const label = displayCountryName(raw.trim());
+    const key = countryMatchKey(raw);
+    if (!key) continue;
+    if (!byKey.has(key)) byKey.set(key, label);
+  }
+  return [...byKey.values()].sort((a, b) => a.localeCompare(b));
+}
+
 /**
  * Derive the filter dropdown options from a set of spaces (pure). Computed from
  * the unfiltered baseline so the options stay comprehensive and stable as the
@@ -31,7 +45,7 @@ function distinct(values: (string | null | undefined)[]): string[] {
 export function deriveFilterOptions(spaces: NetworkSpace[]): FilterOptions {
   const processIds = distinct(spaces.flatMap((s) => s.processes ?? []));
   return {
-    countries: distinct(spaces.map((s) => s.country)),
+    countries: distinctCountries(spaces.map((s) => s.country)),
     regions: distinct(spaces.map((s) => s.region)),
     statuses: distinct(spaces.map((s) => s.status)),
     accessTypes: distinct(spaces.map((s) => s.access_type)),

--- a/frontend/src/features/okw/OkwDetailView.tsx
+++ b/frontend/src/features/okw/OkwDetailView.tsx
@@ -23,12 +23,17 @@ import {
   isSyncedFacilityProvenance,
   SyncedFacilityBanner,
 } from "./SyncedFacilityBanner";
+import { displayCountryName, displayRegionName } from "../match/geoDisplay";
 
 function locationLabel(f: OkwFacility): string | null {
   const a = f.location?.address;
-  const parts = [a?.city ?? f.location?.city, a?.region, a?.country ?? f.location?.country].filter(
-    Boolean,
-  );
+  const country = a?.country ?? f.location?.country;
+  const region = a?.region;
+  const parts = [
+    a?.city ?? f.location?.city,
+    region ? displayRegionName(region) : null,
+    country ? displayCountryName(country) : null,
+  ].filter(Boolean);
   return parts.length ? parts.join(", ") : null;
 }
 

--- a/frontend/src/features/rfq/RfqView.tsx
+++ b/frontend/src/features/rfq/RfqView.tsx
@@ -8,6 +8,7 @@ import { LoadingSpinner } from "../../components/ui/LoadingSpinner";
 import { ErrorMessage } from "../../components/ui/ErrorMessage";
 import { EmptyState } from "../../components/ui/EmptyState";
 import type { RfqNavigationState, RFQDocument } from "../../types/rfq";
+import { displayCountryName } from "../match/geoDisplay";
 
 interface Props {
   navState: RfqNavigationState | null;
@@ -166,7 +167,9 @@ export function RfqView({ navState }: Props) {
                     {s.facility.location?.city && s.facility.location?.country
                       ? ", "
                       : ""}
-                    {s.facility.location?.country ?? ""}
+                    {s.facility.location?.country
+                      ? displayCountryName(s.facility.location.country)
+                      : ""}
                   </span>
                   <span className="ml-auto text-xs font-medium text-slate-500 dark:text-slate-400">
                     {Math.round(s.confidence * 100)}% match

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "supply-graph-ai"
-version = "0.10.1"
+version = "0.10.2"
 description = "Open Hardware Manager (OHM) - A flexible, domain-agnostic framework for matching requirements with capabilities"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/cli/okh.py
+++ b/src/cli/okh.py
@@ -3255,3 +3255,87 @@ async def set_compatible_manifests_cmd(
     if output:
         Path(output).write_text(json.dumps(data, indent=2))
         cli_ctx.log(f"Updated manifest written to {output}", "info")
+
+
+@okh_group.command("infer-processes")
+@click.argument("manifest_id", required=False, default=None)
+@click.option(
+    "--all",
+    "all_manifests",
+    is_flag=True,
+    default=False,
+    help="Scan stored OKHs (use with --limit)",
+)
+@click.option(
+    "--limit", default=100, show_default=True, help="Max manifests when --all"
+)
+@click.option(
+    "--apply",
+    is_flag=True,
+    default=False,
+    help="Persist updates (default is dry-run)",
+)
+@click.option(
+    "--merge",
+    is_flag=True,
+    default=False,
+    help="Merge into existing processes (default: only fill when empty)",
+)
+@click.option("--output", "-o", default=None, help="Write JSON report to a file")
+@async_command
+@click.pass_context
+async def infer_processes_cmd(
+    ctx, manifest_id, all_manifests, limit, apply, merge, output
+):
+    """Infer manufacturing_processes from design/manufacturing file types.
+
+    Uses the modular ProcessInferenceService (file extensions + title/keywords
+    → taxonomy processes).
+    Default is dry-run; pass --apply to write storage.
+
+    \b
+    Examples:
+      ohm okh infer-processes <manifest-id>
+      ohm okh infer-processes --all --limit 50
+      ohm okh infer-processes --all --apply
+    """
+    cli_ctx = ctx.obj
+
+    if not manifest_id and not all_manifests:
+        raise click.UsageError("Provide MANIFEST_ID or --all")
+    if manifest_id and all_manifests:
+        raise click.UsageError("Use either MANIFEST_ID or --all, not both")
+
+    ids = None
+    if manifest_id:
+        try:
+            ids = [UUID(manifest_id)]
+        except ValueError as exc:
+            raise click.ClickException(f"Invalid manifest id: {manifest_id}") from exc
+
+    okh_service = await OKHService.get_instance()
+    report = await okh_service.backfill_manufacturing_processes(
+        manifest_ids=ids,
+        only_if_empty=not merge,
+        dry_run=not apply,
+        limit=None if ids else limit,
+    )
+
+    mode = "DRY-RUN" if report["dry_run"] else "APPLIED"
+    cli_ctx.log(
+        f"[{mode}] scanned={report['scanned']} "
+        f"updated={report['updated_count']} "
+        f"skipped_nonempty={report['skipped_nonempty']} "
+        f"no_inference={report['no_inference']} "
+        f"missing={report['missing']}",
+        "success" if report["updated_count"] or report["dry_run"] else "info",
+    )
+    for entry in report.get("updated") or []:
+        cli_ctx.log(
+            f"  {entry['id']}: {entry['before']} → {entry['after']}",
+            "info",
+        )
+
+    if output:
+        Path(output).write_text(json.dumps(report, indent=2))
+        cli_ctx.log(f"Report written to {output}", "info")

--- a/src/core/api/okh_file_urls.py
+++ b/src/core/api/okh_file_urls.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 from uuid import UUID
 
 from src.core.taxonomy.file_type_taxonomy import file_type_taxonomy
-from src.core.utils.file_path_display import enrich_path_fields
+from src.core.utils.file_path_display import enrich_path_fields, file_directory
+from src.core.utils.remote_file_hint import probe_remote_filename
 
 OKH_FILE_FIELDS = (
     "design_files",
@@ -31,6 +32,21 @@ def api_base_from_request(request) -> str:
     return f"{scheme}://{host}/v1/api"
 
 
+def _host_display_label(path: str) -> str | None:
+    host = (urlparse(path).hostname or "").lower()
+    if not host:
+        return None
+    if host.endswith("thingiverse.com"):
+        return "Thingiverse"
+    if host.endswith("instructables.com"):
+        return "Instructables"
+    if host.endswith("github.com") or host.endswith("githubusercontent.com"):
+        return "GitHub"
+    if "gitlab" in host:
+        return "GitLab"
+    return "External link"
+
+
 def enrich_file_ref(
     item: dict[str, Any], api_base: str, okh_id: UUID
 ) -> dict[str, Any]:
@@ -42,15 +58,33 @@ def enrich_file_ref(
     elif path:
         next_item["url"] = build_okh_file_proxy_url(api_base, okh_id, path)
 
-    if path:
-        path_fields = enrich_path_fields(path)
-        next_item.update(path_fields)
-        classification = file_type_taxonomy.classify(path)
-        next_item["file_type"] = classification.file_type
-        next_item["file_type_display"] = classification.display_name
-        next_item["render_tier"] = classification.render_tier
-        next_item["mime_type"] = classification.mime_type
-        next_item["okh_role"] = classification.okh_role
+    if not path:
+        return next_item
+
+    next_item.update(enrich_path_fields(path))
+    classification = file_type_taxonomy.classify(path)
+
+    if classification.file_type == "unknown" and path.startswith(
+        ("http://", "https://")
+    ):
+        remote_name = probe_remote_filename(path)
+        if remote_name:
+            classification = file_type_taxonomy.classify(remote_name)
+            next_item["display_path"] = remote_name
+            next_item["directory"] = file_directory(remote_name)
+
+    next_item["file_type"] = classification.file_type
+    next_item["file_type_display"] = classification.display_name
+    next_item["render_tier"] = classification.render_tier
+    next_item["mime_type"] = classification.mime_type
+    next_item["okh_role"] = classification.okh_role
+
+    if classification.file_type == "unknown" and path.startswith(
+        ("http://", "https://")
+    ):
+        host_label = _host_display_label(path)
+        if host_label:
+            next_item["file_type_display"] = host_label
 
     return next_item
 

--- a/src/core/generation/engine.py
+++ b/src/core/generation/engine.py
@@ -271,6 +271,9 @@ class GenerationEngine:
 
             # Normalize fields before quality assessment (manufacturing_processes, etc.)
             generated_fields = self._normalize_generated_fields(generated_fields)
+            generated_fields = self._fill_processes_from_file_types(
+                project_data, generated_fields, confidence_scores
+            )
 
             # Validate and filter out obviously bad field values
             generated_fields = self._validate_field_values(generated_fields)
@@ -501,27 +504,34 @@ class GenerationEngine:
 
             # Apply layers based on configuration
             if self.config.progressive_enhancement:
-                generated_fields, confidence_scores, missing_fields = (
-                    await self._progressive_enhancement_async(
-                        project_data,
-                        generated_fields,
-                        confidence_scores,
-                        missing_fields,
-                    )
+                (
+                    generated_fields,
+                    confidence_scores,
+                    missing_fields,
+                ) = await self._progressive_enhancement_async(
+                    project_data,
+                    generated_fields,
+                    confidence_scores,
+                    missing_fields,
                 )
             else:
-                generated_fields, confidence_scores, missing_fields = (
-                    await self._apply_all_layers_async(
-                        project_data,
-                        generated_fields,
-                        confidence_scores,
-                        missing_fields,
-                    )
+                (
+                    generated_fields,
+                    confidence_scores,
+                    missing_fields,
+                ) = await self._apply_all_layers_async(
+                    project_data,
+                    generated_fields,
+                    confidence_scores,
+                    missing_fields,
                 )
 
             # Match sync generate_manifest: normalize and validate before BOM/post-steps.
             # Without this, async/batch runs kept bogus heuristic fragments (e.g. intended_use).
             generated_fields = self._normalize_generated_fields(generated_fields)
+            generated_fields = self._fill_processes_from_file_types(
+                project_data, generated_fields, confidence_scores
+            )
             generated_fields = self._validate_field_values(generated_fields)
             for key in list(confidence_scores.keys()):
                 if key not in generated_fields:
@@ -1072,6 +1082,61 @@ class GenerationEngine:
                 )
 
         return normalized
+
+    def _fill_processes_from_file_types(
+        self,
+        project_data: ProjectData,
+        generated_fields: Dict[str, FieldGeneration],
+        confidence_scores: Dict[str, float],
+    ) -> Dict[str, FieldGeneration]:
+        """
+        Seed manufacturing_processes from file types / title when missing or empty.
+
+        Runs after layer merge/normalize so inference still applies when
+        an upstream layer omitted or cleared the field (e.g. chunked LLM reduce).
+        """
+        existing = generated_fields.get("manufacturing_processes")
+        if existing is not None:
+            value = existing.value
+            if isinstance(value, list) and len(value) > 0:
+                return generated_fields
+
+        from .services.process_inference_service import ProcessInferenceService
+
+        paths = [f.path for f in (project_data.files or []) if f.path]
+        title = ""
+        keywords: List[str] = []
+        title_fg = generated_fields.get("title")
+        if title_fg and isinstance(title_fg.value, str):
+            title = title_fg.value
+        elif project_data.metadata:
+            title = str(
+                project_data.metadata.get("name")
+                or project_data.metadata.get("title")
+                or ""
+            )
+        kw_fg = generated_fields.get("keywords")
+        if kw_fg and isinstance(kw_fg.value, list):
+            keywords = [str(k) for k in kw_fg.value if k]
+
+        inferred = ProcessInferenceService().infer(
+            paths=paths, text=title, keywords=keywords
+        )
+        if not inferred.processes:
+            return generated_fields
+
+        generated_fields = generated_fields.copy()
+        generated_fields["manufacturing_processes"] = FieldGeneration(
+            value=list(inferred.processes),
+            confidence=inferred.confidence,
+            source_layer=GenerationLayer.HEURISTIC,
+            generation_method="file_type_process_inference",
+            raw_source=(
+                f"Inferred from file types/title ({len(inferred.evidence)} process id(s))"
+            ),
+        )
+        confidence_scores["manufacturing_processes"] = inferred.confidence
+        return generated_fields
 
     def _validate_field_values(
         self, generated_fields: Dict[str, FieldGeneration]
@@ -2249,7 +2314,6 @@ Review all components and return the JSON response."""
                 and file_info.file_type == "markdown"
                 and not any(cat in file_info.path for cat in parts_directories)
             ):
-
                 part_name = (
                     file_info.path.split("/")[-1]
                     .replace(".md", "")

--- a/src/core/generation/layers/heuristic.py
+++ b/src/core/generation/layers/heuristic.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from ...models.okh import DocumentationType
-from ...taxonomy import taxonomy
 from ..bom_candidate_discovery import path_matches_dedicated_bom_file
 from ..models import AnalysisDepth, GenerationLayer, LayerConfig, ProjectData
 from ..utils.file_categorization import (
@@ -257,6 +256,9 @@ class HeuristicMatcher(BaseGenerationLayer):
 
             # Extract version and documentation language
             await self._extract_metadata_fields(project_data, result)
+
+            # File-type → process inference when processes still empty
+            await self._infer_processes_from_file_types(project_data, result)
 
             result.add_log(
                 f"Heuristic layer processed {len(project_data.files)} files and {len(project_data.documentation)} documents"
@@ -944,41 +946,70 @@ class HeuristicMatcher(BaseGenerationLayer):
         return materials
 
     def _extract_processes_from_text(self, text: str) -> List[str]:
-        """Extract manufacturing processes from text using the canonical taxonomy."""
-        processes = []
-        text_lower = text.lower()
+        """Extract manufacturing processes from text via ProcessInferenceService."""
+        from ..services.process_inference_service import ProcessInferenceService
 
-        # Keywords to search for in text, mapped to taxonomy input
-        search_keywords = [
-            "3d print",
-            "3d printing",
-            "laser cut",
-            "laser cutting",
-            "cnc",
-            "machining",
-            "solder",
-            "soldering",
-            "assemble",
-            "assembly",
-            "welding",
-            "weld",
-            "drilling",
-            "bending",
-            "grinding",
-            "casting",
-            "forging",
-            "injection mold",
-        ]
+        return ProcessInferenceService().infer_from_text(text).processes
 
-        for keyword in search_keywords:
-            if keyword in text_lower:
-                canonical_id = taxonomy.normalize(keyword)
-                if canonical_id is not None:
-                    display_name = taxonomy.get_display_name(canonical_id)
-                    if display_name not in processes:
-                        processes.append(display_name)
+    async def _infer_processes_from_file_types(
+        self, project_data: ProjectData, result: LayerResult
+    ) -> None:
+        """Seed manufacturing_processes from file types / title when still empty."""
+        if result.has_field("manufacturing_processes"):
+            return
 
-        return processes
+        from ..services.process_inference_service import ProcessInferenceService
+
+        paths: List[str] = [f.path for f in project_data.files if f.path]
+        # Include paths already categorized into manufacturing/design file fields
+        for field_name in ("manufacturing_files", "design_files"):
+            if not result.has_field(field_name):
+                continue
+            field_gen = result.get_field(field_name)
+            if field_gen is None:
+                continue
+            value = field_gen.value
+            if not isinstance(value, list):
+                continue
+            for entry in value:
+                if isinstance(entry, dict):
+                    if entry.get("path"):
+                        paths.append(str(entry["path"]))
+                    if entry.get("title"):
+                        paths.append(str(entry["title"]))
+                elif isinstance(entry, str):
+                    paths.append(entry)
+
+        title = ""
+        keywords: List[str] = []
+        title_field = result.get_field("title") if result.has_field("title") else None
+        if title_field and isinstance(title_field.value, str):
+            title = title_field.value
+        elif project_data.metadata:
+            title = str(
+                project_data.metadata.get("name")
+                or project_data.metadata.get("title")
+                or ""
+            )
+        kw_field = (
+            result.get_field("keywords") if result.has_field("keywords") else None
+        )
+        if kw_field and isinstance(kw_field.value, list):
+            keywords = [str(k) for k in kw_field.value if k]
+
+        inferred = ProcessInferenceService().infer(
+            paths=paths, text=title, keywords=keywords
+        )
+        if not inferred.processes:
+            return
+
+        result.add_field(
+            "manufacturing_processes",
+            inferred.processes,
+            inferred.confidence,
+            "file_type_process_inference",
+            f"Inferred from file types/title ({len(inferred.evidence)} process id(s))",
+        )
 
     async def _extract_metadata_fields(
         self, project_data: ProjectData, result: LayerResult

--- a/src/core/generation/services/__init__.py
+++ b/src/core/generation/services/__init__.py
@@ -1,0 +1,5 @@
+"""Generation-pipeline helpers (not BaseService facades).
+
+Modules: ``file_categorization_service``, ``process_inference_service``,
+``repository_mapping_service``. Import from the concrete module.
+"""

--- a/src/core/generation/services/process_inference_service.py
+++ b/src/core/generation/services/process_inference_service.py
@@ -1,0 +1,309 @@
+"""
+Infer OKH manufacturing_processes from file types and title/keywords.
+
+Lives in ``src/core/generation/services/`` (pipeline helper, peer to
+``FileCategorizationService``). Callers: heuristic layer, GenerationEngine
+safety net, ``OKHService.backfill_manufacturing_processes`` /
+``ohm okh infer-processes``. Uses taxonomy for display names; extension map
+is local (conservative).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+from typing import Dict, Iterable, List, Optional, Sequence
+
+from src.core.taxonomy import taxonomy
+
+# Extension → canonical process id. Conservative maker/OH defaults.
+EXTENSION_TO_PROCESS: Dict[str, str] = {
+    ".stl": "3d_printing",
+    ".3mf": "3d_printing",
+    ".amf": "3d_printing",
+    ".obj": "3d_printing",
+    ".ply": "3d_printing",
+    ".gcode": "3d_printing",
+    ".bgcode": "3d_printing",
+    ".nc": "cnc_machining",
+    ".ngc": "cnc_machining",
+    ".tap": "cnc_machining",
+    ".cnc": "cnc_machining",
+    ".gbr": "pcb_fabrication",
+    ".ger": "pcb_fabrication",
+    ".drl": "pcb_fabrication",
+    ".xln": "pcb_fabrication",
+    ".kicad_pcb": "pcb_fabrication",
+}
+
+TEXT_PHRASES: tuple[str, ...] = (
+    "3d printing",
+    "3d printed",
+    "3d-printed",
+    "3d print",
+    "3d-print",
+    "additive manufacturing",
+    "laser cutting",
+    "laser cut",
+    "laser-cut",
+    "cnc machining",
+    "cnc milling",
+    "cnc turning",
+    "pcb fabrication",
+    "pcb assembly",
+    "injection mold",
+    "injection mould",
+)
+
+SHORT_TOKEN_TO_PROCESS: Dict[str, str] = {
+    "3dp": "3d_printing",
+    "fdm": "3d_printing",
+    "fff": "3d_printing",
+    "sla": "3d_printing",
+    "sls": "3d_printing",
+    "dlp": "3d_printing",
+    "cnc": "cnc_machining",
+    "pcb": "pcb_fabrication",
+}
+
+_TEXT_TOKEN_BLOCKLIST = frozenset(
+    {
+        "print",
+        "printing",
+        "am",
+        "mold",
+        "mill",
+        "test",
+        "testing",
+        "surface",
+        "finish",
+        "finishing",
+        "coat",
+        "coating",
+        "sand",
+        "sanding",
+        "polish",
+        "polishing",
+        "paint",
+        "painting",
+    }
+)
+
+DEFAULT_FILE_TYPE_CONFIDENCE = 0.85
+DEFAULT_TEXT_CONFIDENCE = 0.72
+
+_TOKEN_SPLIT = re.compile(r"[^a-zA-Z0-9]+")
+
+
+@dataclass
+class ProcessInferenceResult:
+    processes: List[str] = field(default_factory=list)
+    evidence: Dict[str, List[str]] = field(default_factory=dict)
+    confidence: float = 0.0
+    applied: bool = False
+
+
+class ProcessInferenceService:
+    """File-type + title/keyword → manufacturing process inference."""
+
+    def __init__(self) -> None:
+        self.extension_map = dict(EXTENSION_TO_PROCESS)
+        self.confidence = DEFAULT_FILE_TYPE_CONFIDENCE
+        self.text_confidence = DEFAULT_TEXT_CONFIDENCE
+
+    def infer_from_paths(self, paths: Iterable[str]) -> ProcessInferenceResult:
+        seen_ids: Dict[str, List[str]] = {}
+        for raw in paths:
+            if not raw or not isinstance(raw, str):
+                continue
+            ext = self._extension_of(raw)
+            process_id = self.extension_map.get(ext) if ext else None
+            if process_id is None:
+                continue
+            evidence_token = f"{ext} ← {raw}"
+            bucket = seen_ids.setdefault(process_id, [])
+            if evidence_token not in bucket:
+                bucket.append(evidence_token)
+        return self._result_from_ids(seen_ids, self.confidence)
+
+    def infer_from_text(
+        self,
+        text: str = "",
+        *,
+        keywords: Optional[Sequence[str]] = None,
+    ) -> ProcessInferenceResult:
+        parts = [text] if text and isinstance(text, str) else []
+        parts.extend(str(kw) for kw in (keywords or ()) if kw and isinstance(kw, str))
+        if not parts:
+            return ProcessInferenceResult()
+
+        combined = " ".join(parts)
+        combined_lower = combined.lower()
+        seen_ids: Dict[str, List[str]] = {}
+
+        for phrase in TEXT_PHRASES:
+            if phrase not in combined_lower:
+                continue
+            canonical = taxonomy.normalize(phrase)
+            if canonical is None:
+                continue
+            evidence = f"phrase:{phrase}"
+            bucket = seen_ids.setdefault(canonical, [])
+            if evidence not in bucket:
+                bucket.append(evidence)
+
+        for token in _TOKEN_SPLIT.split(combined):
+            if not token:
+                continue
+            key = token.lower()
+            if key in SHORT_TOKEN_TO_PROCESS:
+                process_id: Optional[str] = SHORT_TOKEN_TO_PROCESS[key]
+            elif key in _TEXT_TOKEN_BLOCKLIST or len(key) < 4:
+                continue
+            else:
+                process_id = self._exact_taxonomy_alias(key)
+            if process_id is None:
+                continue
+            evidence = f"token:{token}"
+            bucket = seen_ids.setdefault(process_id, [])
+            if evidence not in bucket:
+                bucket.append(evidence)
+
+        return self._result_from_ids(seen_ids, self.text_confidence)
+
+    def infer(
+        self,
+        *,
+        paths: Optional[Iterable[str]] = None,
+        text: str = "",
+        keywords: Optional[Sequence[str]] = None,
+    ) -> ProcessInferenceResult:
+        return self._merge_results(
+            self.infer_from_paths(paths or ()),
+            self.infer_from_text(text, keywords=keywords),
+        )
+
+    def infer_from_manifest(self, manifest: object) -> ProcessInferenceResult:
+        paths = self._paths_from_manifest(manifest)
+        title = getattr(manifest, "title", None) or ""
+        keywords = getattr(manifest, "keywords", None) or []
+        if isinstance(keywords, str):
+            keywords = [keywords]
+        return self.infer(paths=paths, text=str(title), keywords=list(keywords))
+
+    def apply_to_manifest(
+        self,
+        manifest: object,
+        *,
+        only_if_empty: bool = True,
+    ) -> ProcessInferenceResult:
+        existing = list(getattr(manifest, "manufacturing_processes", None) or [])
+        if only_if_empty and existing:
+            return ProcessInferenceResult(processes=[], applied=False)
+
+        inferred = self.infer_from_manifest(manifest)
+        if not inferred.processes:
+            return inferred
+
+        if only_if_empty:
+            manifest.manufacturing_processes = list(inferred.processes)
+        else:
+            manifest.manufacturing_processes = self.merge_processes(
+                existing, inferred.processes
+            )
+        inferred.applied = True
+        return inferred
+
+    def merge_processes(
+        self, existing: Sequence[str], inferred: Sequence[str]
+    ) -> List[str]:
+        out: List[str] = []
+        seen: set[str] = set()
+        for name in list(existing) + list(inferred):
+            if not name or not isinstance(name, str):
+                continue
+            canonical = taxonomy.normalize(name.strip())
+            if canonical is not None:
+                display, key = taxonomy.get_display_name(canonical), canonical
+            else:
+                display, key = name.strip(), name.strip().lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(display)
+        return out
+
+    def _merge_results(
+        self, *results: ProcessInferenceResult
+    ) -> ProcessInferenceResult:
+        seen_ids: Dict[str, List[str]] = {}
+        best_conf = 0.0
+        for result in results:
+            if not result.evidence:
+                continue
+            best_conf = max(best_conf, result.confidence)
+            for process_id, evidence_list in result.evidence.items():
+                bucket = seen_ids.setdefault(process_id, [])
+                for item in evidence_list:
+                    if item not in bucket:
+                        bucket.append(item)
+        if not seen_ids:
+            return ProcessInferenceResult()
+        return self._result_from_ids(seen_ids, best_conf)
+
+    def _result_from_ids(
+        self, seen_ids: Dict[str, List[str]], confidence: float
+    ) -> ProcessInferenceResult:
+        processes: List[str] = []
+        for process_id in seen_ids:
+            display = taxonomy.get_display_name(process_id)
+            if display and display not in processes:
+                processes.append(display)
+        return ProcessInferenceResult(
+            processes=processes,
+            evidence=dict(seen_ids),
+            confidence=confidence if processes else 0.0,
+        )
+
+    @staticmethod
+    def _exact_taxonomy_alias(token: str) -> Optional[str]:
+        key = taxonomy._normalize_key(token)
+        if not key:
+            return None
+        if key in taxonomy._definitions:
+            return key
+        if key in taxonomy._alias_map:
+            return taxonomy._alias_map[key]
+        return taxonomy._tsdc_map.get(token.strip().upper())
+
+    @staticmethod
+    def _extension_of(path: str) -> str:
+        cleaned = path.split("?", 1)[0].split("#", 1)[0]
+        name = PurePosixPath(cleaned.replace("\\", "/")).name
+        if not name or "." not in name:
+            return ""
+        lower = name.lower()
+        return lower[lower.rfind(".") :]
+
+    @staticmethod
+    def _paths_from_manifest(manifest: object) -> List[str]:
+        paths: List[str] = []
+        for attr in (
+            "manufacturing_files",
+            "design_files",
+            "making_instructions",
+            "technical_specifications",
+        ):
+            for ref in getattr(manifest, attr, None) or []:
+                path = getattr(ref, "path", None) or (
+                    ref.get("path") if isinstance(ref, dict) else None
+                )
+                title = getattr(ref, "title", None) or (
+                    ref.get("title") if isinstance(ref, dict) else None
+                )
+                if path:
+                    paths.append(str(path))
+                if title:
+                    paths.append(str(title))
+        return paths

--- a/src/core/services/okh_service.py
+++ b/src/core/services/okh_service.py
@@ -864,6 +864,86 @@ class OKHService(BaseService["OKHService"]):
         else:
             return {"error": f"Unknown LLM request type: {request_type}"}
 
+    async def backfill_manufacturing_processes(
+        self,
+        *,
+        manifest_ids: Optional[List[UUID]] = None,
+        only_if_empty: bool = True,
+        dry_run: bool = True,
+        limit: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """
+        Infer manufacturing_processes from file types / title on stored OKHs.
+
+        By default only fills empty process lists and does not write (dry_run=True).
+        Pass dry_run=False to persist updates via :meth:`update`.
+        """
+        from ..generation.services.process_inference_service import (
+            ProcessInferenceService,
+        )
+
+        await self.ensure_initialized()
+        service = ProcessInferenceService()
+
+        targets: List[OKHManifest] = []
+        if manifest_ids:
+            for mid in manifest_ids:
+                manifest = await self.get(mid)
+                if manifest is None:
+                    continue
+                targets.append(manifest)
+        else:
+            page_size = limit or 500
+            manifests, _total = await self.list(page=1, page_size=page_size)
+            targets = manifests[:limit] if limit is not None else list(manifests)
+
+        scanned = 0
+        updated: List[Dict[str, Any]] = []
+        skipped_nonempty = 0
+        no_inference = 0
+        missing = 0
+
+        if manifest_ids:
+            found_ids = {m.id for m in targets}
+            missing = len([mid for mid in manifest_ids if mid not in found_ids])
+
+        for manifest in targets:
+            scanned += 1
+            before = list(manifest.manufacturing_processes or [])
+            if only_if_empty and before:
+                skipped_nonempty += 1
+                continue
+
+            result = service.apply_to_manifest(manifest, only_if_empty=only_if_empty)
+            if not result.applied or not result.processes:
+                if not result.applied:
+                    no_inference += 1
+                continue
+
+            after = list(manifest.manufacturing_processes or [])
+            entry = {
+                "id": str(manifest.id),
+                "title": manifest.title,
+                "before": before,
+                "after": after,
+                "inferred": result.processes,
+                "evidence": result.evidence,
+            }
+            if not dry_run:
+                await self.update(manifest.id, manifest.to_dict())
+            updated.append(entry)
+
+        return {
+            "dry_run": dry_run,
+            "only_if_empty": only_if_empty,
+            "scanned": scanned,
+            "missing": missing,
+            "skipped_nonempty": skipped_nonempty,
+            "no_inference": no_inference,
+            "updated_count": len(updated),
+            "updated": updated,
+        }
+
     async def cleanup(self) -> None:
         """Cleanup OKH resources and best-effort close dependency helpers."""
         await super().cleanup()

--- a/src/core/services/okw_service.py
+++ b/src/core/services/okw_service.py
@@ -24,6 +24,7 @@ from ..storage.provenance_store import ProvenanceStore
 from ..storage.visibility_store import VisibilityStore
 from ..storage.smart_discovery import SmartFileDiscovery
 from ..taxonomy import taxonomy
+from ..utils.country_names import countries_match, display_country_name
 from ..utils.logging import get_logger
 from ..validation.error_codes import VALIDATION_ERROR_CODE, VALIDATION_WARNING_CODE
 from ..validation.uuid_validator import UUIDValidator
@@ -81,6 +82,7 @@ def _local_facility_to_space(
     loc = f.location
     addr = getattr(loc, "address", None)
     owner = getattr(f, "owner", None)
+    raw_country = getattr(addr, "country", None) or getattr(loc, "country", None)
     return {
         "id": str(f.id),
         "name": f.name,
@@ -88,7 +90,7 @@ def _local_facility_to_space(
         "lon": coords.longitude if coords else None,
         "city": getattr(addr, "city", None) or getattr(loc, "city", None),
         "region": getattr(addr, "region", None) or getattr(loc, "region", None),
-        "country": getattr(addr, "country", None) or getattr(loc, "country", None),
+        "country": display_country_name(raw_country) or raw_country,
         "source": "local",
         "status": _normalize_status(
             f.facility_status.value if getattr(f, "facility_status", None) else None
@@ -130,7 +132,7 @@ def _mom_space_to_space(s: Dict[str, Any]) -> Dict[str, Any]:
         "lon": s["lon"],
         "city": s.get("city"),
         "region": None,  # MoM has no sub-national region
-        "country": s.get("country"),
+        "country": display_country_name(s.get("country")) or s.get("country"),
         "source": "mom",
         "status": _normalize_status(s.get("status")),
         "processes": s.get("processes", []),
@@ -166,7 +168,7 @@ def filter_network_spaces(
     for sp in spaces:
         if source and sp.get("source") != source:
             continue
-        if country and _ci(sp.get("country")) != _ci(country):
+        if country and not countries_match(sp.get("country"), country):
             continue
         if city and (not sp.get("city") or _ci(city) not in _ci(sp["city"])):
             continue

--- a/src/core/utils/country_names.py
+++ b/src/core/utils/country_names.py
@@ -1,0 +1,84 @@
+"""Normalize ISO country codes to English display names for UI / filter matching."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+# Keep in sync with frontend/src/features/match/geoDisplay.ts COUNTRY_NAMES.
+COUNTRY_NAMES: dict[str, str] = {
+    "AD": "Andorra",
+    "AE": "United Arab Emirates",
+    "AR": "Argentina",
+    "AT": "Austria",
+    "AU": "Australia",
+    "BE": "Belgium",
+    "BR": "Brazil",
+    "CA": "Canada",
+    "CH": "Switzerland",
+    "CL": "Chile",
+    "CN": "China",
+    "CO": "Colombia",
+    "CZ": "Czechia",
+    "DE": "Germany",
+    "DK": "Denmark",
+    "ES": "Spain",
+    "FI": "Finland",
+    "FR": "France",
+    "GB": "United Kingdom",
+    "GR": "Greece",
+    "HK": "Hong Kong",
+    "HU": "Hungary",
+    "IE": "Ireland",
+    "IL": "Israel",
+    "IN": "India",
+    "IT": "Italy",
+    "JP": "Japan",
+    "KR": "South Korea",
+    "MX": "Mexico",
+    "NL": "Netherlands",
+    "NO": "Norway",
+    "NZ": "New Zealand",
+    "PL": "Poland",
+    "PT": "Portugal",
+    "RO": "Romania",
+    "RU": "Russia",
+    "SE": "Sweden",
+    "SG": "Singapore",
+    "TH": "Thailand",
+    "TR": "Turkey",
+    "TW": "Taiwan",
+    "UA": "Ukraine",
+    "US": "United States",
+    "USA": "United States",
+    "ZA": "South Africa",
+}
+
+_BY_NAME = {name.lower(): code for code, name in COUNTRY_NAMES.items()}
+
+
+def display_country_name(raw: Optional[str]) -> str:
+    """Return English country name; pass through unknown values unchanged."""
+    if not raw or not str(raw).strip():
+        return ""
+    s = str(raw).strip()
+    upper = s.upper()
+    return COUNTRY_NAMES.get(upper, s)
+
+
+def country_match_key(raw: Optional[str]) -> str:
+    """Canonical lowercase key so FR and France compare equal."""
+    if not raw or not str(raw).strip():
+        return ""
+    s = str(raw).strip()
+    upper = s.upper()
+    if upper in COUNTRY_NAMES:
+        return COUNTRY_NAMES[upper].lower()
+    code = _BY_NAME.get(s.lower())
+    if code:
+        return COUNTRY_NAMES[code].lower()
+    return s.lower()
+
+
+def countries_match(a: Optional[str], b: Optional[str]) -> bool:
+    ka, kb = country_match_key(a), country_match_key(b)
+    return bool(ka) and ka == kb

--- a/src/core/utils/remote_file_hint.py
+++ b/src/core/utils/remote_file_hint.py
@@ -1,0 +1,102 @@
+"""Probe remote download URLs for a real filename (Content-Disposition / redirect)."""
+
+from __future__ import annotations
+
+import logging
+import re
+from functools import lru_cache
+from typing import Optional
+from urllib.parse import unquote, urlparse
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Browser-like UA: some CDNs (Thingiverse/Cloudflare) block default httpx HEAD.
+_BROWSER_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Accept": "*/*",
+}
+
+_CD_FILENAME = re.compile(
+    r"""filename\*\s*=\s*(?:UTF-8''|utf-8'')([^;]+)|filename\s*=\s*"([^"]+)"|filename\s*=\s*([^;\s]+)""",
+    re.IGNORECASE,
+)
+
+
+def filename_from_content_disposition(header: str) -> Optional[str]:
+    if not header:
+        return None
+    match = _CD_FILENAME.search(header)
+    if not match:
+        return None
+    raw = next((g for g in match.groups() if g), None)
+    if not raw:
+        return None
+    name = unquote(raw.strip().strip("'"))
+    return name or None
+
+
+def filename_from_url_path(url: str) -> Optional[str]:
+    path = urlparse(url).path or ""
+    name = unquote(path.rstrip("/").split("/")[-1] if path else "")
+    if not name or "." not in name:
+        return None
+    # Ignore opaque download tokens like "download:7851122"
+    if ":" in name.split(".")[0]:
+        return None
+    return name
+
+
+def clear_remote_filename_cache() -> None:
+    probe_remote_filename.cache_clear()
+
+
+def _filename_from_response(response: httpx.Response) -> Optional[str]:
+    from_cd = filename_from_content_disposition(
+        response.headers.get("content-disposition", "")
+    )
+    if from_cd:
+        return from_cd
+    location = response.headers.get("location")
+    if location:
+        from_loc = filename_from_url_path(location)
+        if from_loc:
+            return from_loc
+    return filename_from_url_path(str(response.url))
+
+
+@lru_cache(maxsize=256)
+def probe_remote_filename(url: str, timeout: float = 4.0) -> Optional[str]:
+    """
+    Return a filename hint for classification without downloading bodies.
+
+    Prefer a single non-following GET so redirect ``Location`` headers (e.g.
+    Thingiverse → CDN ``.stl``) yield the name. Fail-soft on network errors.
+    """
+    if not url or not url.startswith(("http://", "https://")):
+        return None
+    headers = {**_BROWSER_HEADERS, "Referer": url}
+    try:
+        with httpx.Client(
+            follow_redirects=False, timeout=timeout, headers=headers
+        ) as client:
+            # GET not HEAD: several hosts 403 HEAD but 302 GET with Location.
+            response = client.get(url)
+            name = _filename_from_response(response)
+            if name:
+                return name
+
+        # Rare: no redirect filename — follow once and read CD / final URL.
+        with httpx.Client(
+            follow_redirects=True, timeout=timeout, headers=headers
+        ) as client:
+            response = client.get(url)
+            return _filename_from_response(response)
+    except Exception as exc:  # noqa: BLE001 — enrich path must never fail hard
+        logger.debug("remote filename probe failed for %s: %s", url, exc)
+        return None

--- a/tests/matching/test_remote_api.py
+++ b/tests/matching/test_remote_api.py
@@ -1,0 +1,153 @@
+"""Opt-in remote API probe — set OHM_API_BASE to a live OHM origin.
+
+Documents the gap between harness okh_manifest matches (works) and stored
+okh_id matches when manufacturing_processes is empty (fails).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any
+
+import pytest
+
+from tests.matching.fixtures import __file__ as _fixtures_sentinel  # noqa: F401
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
+
+
+def _api_base() -> str | None:
+    raw = os.environ.get("OHM_API_BASE", "").strip().rstrip("/")
+    return raw or None
+
+
+pytestmark = [
+    pytest.mark.allow_network,
+    pytest.mark.skipif(
+        not _api_base(),
+        reason="Set OHM_API_BASE=https://… to probe a live OHM API",
+    ),
+]
+
+
+def _get(path: str, timeout: float = 120) -> dict[str, Any]:
+    base = _api_base()
+    assert base
+    with urllib.request.urlopen(f"{base}{path}", timeout=timeout) as resp:
+        return json.load(resp)
+
+
+def _post(path: str, body: dict[str, Any], timeout: float = 180) -> dict[str, Any]:
+    base = _api_base()
+    assert base
+    req = urllib.request.Request(
+        f"{base}{path}",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.load(resp)
+
+
+def test_remote_health_and_mom_pool():
+    health = _get("/health")
+    assert health.get("status") == "ok"
+    spaces = _get("/v1/api/okw/spaces?include_mom=true")
+    assert spaces.get("mom_available") is True
+    assert (spaces.get("mom_count") or 0) > 0
+    print(
+        f"\nremote health version={health.get('version')} "
+        f"okh={health.get('storage', {}).get('okh_count')} "
+        f"okw={health.get('storage', {}).get('okw_count')} "
+        f"mom_spaces={spaces.get('mom_count')} local_spaces={spaces.get('local_count')}"
+    )
+
+
+def test_remote_harness_manifest_matches_3dp():
+    """Inline 3DP okh_manifest against MoM must return solutions (id-alignment OK)."""
+    with open(os.path.join(FIXTURES, "okh_3dp_only.json"), encoding="utf-8") as f:
+        okh = json.load(f)
+    spaces = _get("/v1/api/okw/spaces?include_mom=true")["spaces"]
+    iri = next(s["id"] for s in spaces if "3d_printing" in (s.get("processes") or []))
+    data = _post(
+        "/v1/api/match",
+        {
+            "okh_manifest": okh,
+            "network_filter": {"include_mom": True},
+            "okw_ids": [iri],
+            "max_results": 10,
+            "save_solution": False,
+            "min_confidence": 0.1,
+            "include_human_summary": False,
+        },
+    )["data"]
+    assert (data.get("total_solutions") or 0) >= 1
+    print(f"\nharness okh_manifest + MoM IRI → solutions={data.get('total_solutions')}")
+
+
+def test_remote_stored_okh_empty_processes_yield_zero(capsys):
+    """UI path: many stored OKHs have empty manufacturing_processes → 0 matches."""
+    listing = _get("/v1/api/okh?page=1&page_size=25")
+    items = listing.get("items") or []
+    assert items, "live OKH catalog empty"
+
+    empty = 0
+    sampled = 0
+    for it in items[:20]:
+        oid = it["id"]
+        try:
+            detail = _get(f"/v1/api/okh/{oid}")
+        except urllib.error.HTTPError:
+            continue
+        sampled += 1
+        procs = detail.get("manufacturing_processes") or []
+        if not procs:
+            empty += 1
+
+    print(
+        f"\nstored OKH sample: {sampled} details, "
+        f"{empty} with empty manufacturing_processes "
+        f"({100 * empty / max(sampled, 1):.0f}%)"
+    )
+    assert sampled > 0
+    # Soft informational assert: flag when the catalog is largely process-empty.
+    if empty == sampled:
+        print(
+            "DIAGNOSIS: all sampled stored OKHs lack manufacturing_processes. "
+            "Match UI uses okh_id → extractor finds no requirements → 0 solutions. "
+            "Harness okh_manifest with explicit ['3DP'] still matches MoM."
+        )
+
+    # Prove one empty OKH yields zero solutions against known-good MoM 3DP subset.
+    empty_id = next(
+        it["id"]
+        for it in items
+        if not (_get(f"/v1/api/okh/{it['id']}").get("manufacturing_processes") or [])
+    )
+    spaces = _get("/v1/api/okw/spaces?include_mom=true")["spaces"]
+    only3 = [s["id"] for s in spaces if "3d_printing" in (s.get("processes") or [])][
+        :20
+    ]
+    data = _post(
+        "/v1/api/match",
+        {
+            "okh_id": empty_id,
+            "network_filter": {"include_mom": True},
+            "okw_ids": only3,
+            "max_results": 10,
+            "save_solution": False,
+            "min_confidence": 0.1,
+            "quality_level": "professional",
+            "strict_mode": False,
+            "include_human_summary": False,
+        },
+    )["data"]
+    assert (data.get("total_solutions") or 0) == 0
+    print(
+        f"stored okh_id={empty_id} vs 20 MoM 3DP spaces → "
+        f"solutions={data.get('total_solutions')} (expected 0)"
+    )

--- a/tests/unit/test_country_names.py
+++ b/tests/unit/test_country_names.py
@@ -1,0 +1,20 @@
+"""Tests for country code ↔ name normalization."""
+
+from src.core.utils.country_names import (
+    countries_match,
+    country_match_key,
+    display_country_name,
+)
+
+
+def test_display_country_name_codes() -> None:
+    assert display_country_name("FR") == "France"
+    assert display_country_name("US") == "United States"
+    assert display_country_name("France") == "France"
+
+
+def test_countries_match_code_and_name() -> None:
+    assert countries_match("FR", "France")
+    assert countries_match("us", "United States")
+    assert not countries_match("FR", "DE")
+    assert country_match_key("FR") == country_match_key("France")

--- a/tests/unit/test_okw_spaces.py
+++ b/tests/unit/test_okw_spaces.py
@@ -222,6 +222,9 @@ def test_cross_source_filters_hard_exclude():
         s["id"] for s in filter_network_spaces(_spaces(), process="laser_cutting")
     ] == ["a"]
     assert [s["id"] for s in filter_network_spaces(_spaces(), country="kr")] == ["b"]
+    assert [
+        s["id"] for s in filter_network_spaces(_spaces(), country="South Korea")
+    ] == ["b"]
     assert [s["id"] for s in filter_network_spaces(_spaces(), city="seo")] == ["b"]
     assert [s["id"] for s in filter_network_spaces(_spaces(), source="mom")] == ["b"]
 

--- a/tests/unit/test_process_inference_service.py
+++ b/tests/unit/test_process_inference_service.py
@@ -1,0 +1,246 @@
+"""Unit tests for file-type → manufacturing process inference."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.core.generation.services.process_inference_service import (
+    ProcessInferenceService,
+)
+from src.core.models.okh import DocumentationType, DocumentRef, License, OKHManifest
+
+
+def _manifest(**kwargs) -> OKHManifest:
+    defaults = dict(
+        title="Test",
+        version="1.0.0",
+        license=License(hardware="MIT"),
+        licensor="Test",
+        documentation_language="en",
+        function="Test part",
+    )
+    defaults.update(kwargs)
+    return OKHManifest(**defaults)
+
+
+@pytest.fixture
+def service() -> ProcessInferenceService:
+    return ProcessInferenceService()
+
+
+def test_stl_paths_infer_3d_printing(service: ProcessInferenceService) -> None:
+    result = service.infer_from_paths(["models/bracket.stl", "README.md"])
+    assert "3D Printing" in result.processes
+    assert result.confidence >= 0.7
+    assert any("stl" in e.lower() for e in result.evidence.get("3d_printing", []))
+
+
+def test_3mf_and_gcode_infer_3d_printing(service: ProcessInferenceService) -> None:
+    result = service.infer_from_paths(["part.3mf", "toolpath.gcode"])
+    assert result.processes == ["3D Printing"]
+
+
+def test_gerber_infers_pcb_fabrication(service: ProcessInferenceService) -> None:
+    result = service.infer_from_paths(["board.gbr", "board.drl"])
+    assert "PCB Fabrication" in result.processes
+
+
+def test_nc_infers_cnc_machining(service: ProcessInferenceService) -> None:
+    result = service.infer_from_paths(["pocket.nc"])
+    assert "CNC Machining" in result.processes
+
+
+def test_unrelated_extensions_yield_empty(service: ProcessInferenceService) -> None:
+    result = service.infer_from_paths(["main.py", "README.md", "photo.png"])
+    assert result.processes == []
+
+
+def test_deduplicates_across_paths(service: ProcessInferenceService) -> None:
+    result = service.infer_from_paths(["a.stl", "b.STL", "c.3mf"])
+    assert result.processes.count("3D Printing") == 1
+
+
+def test_apply_to_manifest_only_if_empty(service: ProcessInferenceService) -> None:
+    manifest = _manifest(
+        manufacturing_files=[
+            DocumentRef(
+                title="bracket.stl",
+                path="files/bracket.stl",
+                type=DocumentationType.MANUFACTURING_FILES,
+            )
+        ],
+        manufacturing_processes=[],
+    )
+
+    applied = service.apply_to_manifest(manifest, only_if_empty=True)
+    assert "3D Printing" in applied.processes
+    assert "3D Printing" in manifest.manufacturing_processes
+
+    manifest.manufacturing_processes = ["Laser Cutting"]
+    skipped = service.apply_to_manifest(manifest, only_if_empty=True)
+    assert skipped.processes == []
+    assert manifest.manufacturing_processes == ["Laser Cutting"]
+
+
+def test_apply_merges_when_not_only_if_empty(service: ProcessInferenceService) -> None:
+    manifest = _manifest(
+        manufacturing_files=[
+            DocumentRef(
+                title="board.gbr",
+                path="gerbers/board.gbr",
+                type=DocumentationType.MANUFACTURING_FILES,
+            ),
+        ],
+        manufacturing_processes=["Assembly"],
+    )
+
+    result = service.apply_to_manifest(manifest, only_if_empty=False)
+    assert "Assembly" in manifest.manufacturing_processes
+    assert "PCB Fabrication" in manifest.manufacturing_processes
+    assert "PCB Fabrication" in result.processes
+
+
+def test_infer_from_okh_paths_and_design_files(
+    service: ProcessInferenceService,
+) -> None:
+    manifest = _manifest(
+        design_files=[
+            DocumentRef(
+                title="body.stl",
+                path="cad/body.stl",
+                type=DocumentationType.DESIGN_FILES,
+            )
+        ],
+        manufacturing_processes=[],
+    )
+    result = service.infer_from_manifest(manifest)
+    assert "3D Printing" in result.processes
+
+
+def test_title_3dp_prefix_infers_3d_printing(service: ProcessInferenceService) -> None:
+    result = service.infer_from_text("3DP-Micropipette")
+    assert "3D Printing" in result.processes
+    assert any("3dp" in e.lower() for e in result.evidence.get("3d_printing", []))
+
+
+def test_title_laser_cut_infers_laser_cutting(
+    service: ProcessInferenceService,
+) -> None:
+    result = service.infer_from_text("laser-cut-origami-ear-extender")
+    assert "Laser Cutting" in result.processes
+
+
+def test_keywords_infer_pcb(service: ProcessInferenceService) -> None:
+    result = service.infer_from_text("open hardware", keywords=["electronics", "pcb"])
+    assert "PCB Fabrication" in result.processes
+
+
+def test_unrelated_title_yields_empty(service: ProcessInferenceService) -> None:
+    result = service.infer_from_text("Portable Hand Washing Station")
+    assert result.processes == []
+
+
+def test_face_in_title_does_not_infer_surface_finishing(
+    service: ProcessInferenceService,
+) -> None:
+    """Regression: taxonomy substring match maps 'face' ⊂ 'surface_finish'."""
+    result = service.infer_from_text("Badger-Shield Open-Source Face Shield")
+    assert "Surface Finishing" not in result.processes
+    assert result.processes == []
+
+
+def test_manifest_title_used_when_no_file_types(
+    service: ProcessInferenceService,
+) -> None:
+    manifest = _manifest(
+        title="3DP-Micropipette",
+        keywords=["lab", "tool"],
+        manufacturing_processes=[],
+    )
+    result = service.infer_from_manifest(manifest)
+    assert "3D Printing" in result.processes
+
+
+def test_file_type_and_title_merge(service: ProcessInferenceService) -> None:
+    manifest = _manifest(
+        title="Laser-Cut Face Shield",
+        design_files=[
+            DocumentRef(
+                title="bracket.stl",
+                path="bracket.stl",
+                type=DocumentationType.DESIGN_FILES,
+            )
+        ],
+        manufacturing_processes=[],
+    )
+    result = service.infer_from_manifest(manifest)
+    assert "3D Printing" in result.processes
+    assert "Laser Cutting" in result.processes
+
+
+@pytest.mark.asyncio
+async def test_okh_service_backfill_dry_run() -> None:
+    from unittest.mock import AsyncMock
+
+    from src.core.services.okh_service import OKHService
+
+    manifest = _manifest(
+        manufacturing_files=[
+            DocumentRef(
+                title="part.stl",
+                path="part.stl",
+                type=DocumentationType.MANUFACTURING_FILES,
+            )
+        ],
+        manufacturing_processes=[],
+    )
+    svc = OKHService()
+    svc.ensure_initialized = AsyncMock()
+    svc.get = AsyncMock(return_value=manifest)
+    svc.update = AsyncMock()
+
+    report = await svc.backfill_manufacturing_processes(
+        manifest_ids=[manifest.id],
+        only_if_empty=True,
+        dry_run=True,
+    )
+    assert report["dry_run"] is True
+    assert report["updated_count"] == 1
+    assert "3D Printing" in report["updated"][0]["after"]
+    svc.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_heuristic_layer_infers_from_stl() -> None:
+    from src.core.generation.layers.heuristic import HeuristicMatcher
+    from src.core.generation.models import (
+        FileInfo,
+        LayerConfig,
+        PlatformType,
+        ProjectData,
+    )
+
+    config = LayerConfig(
+        use_llm=False,
+        file_categorization_config={"enable_llm_categorization": False},
+    )
+    matcher = HeuristicMatcher(config)
+    project = ProjectData(
+        platform=PlatformType.GITHUB,
+        url="https://example.com/repo",
+        metadata={},
+        files=[
+            FileInfo(
+                path="models/bracket.stl",
+                size=100,
+                content="",
+                file_type="stl",
+            )
+        ],
+        documentation=[],
+        raw_content={},
+    )
+    result = await matcher.process(project)
+    assert result.has_field("manufacturing_processes")
+    processes = result.get_field("manufacturing_processes").value
+    assert "3D Printing" in processes

--- a/tests/unit/test_remote_file_hint.py
+++ b/tests/unit/test_remote_file_hint.py
@@ -1,0 +1,82 @@
+"""Unit tests for remote file filename probing."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+from src.core.api.okh_file_urls import enrich_file_ref
+from src.core.utils.remote_file_hint import (
+    clear_remote_filename_cache,
+    filename_from_content_disposition,
+    filename_from_url_path,
+    probe_remote_filename,
+)
+
+
+def setup_function() -> None:
+    clear_remote_filename_cache()
+
+
+def test_filename_from_content_disposition() -> None:
+    assert (
+        filename_from_content_disposition(
+            'attachment; filename="3.5cm_BiasTape_minimalistic_Q2.stl"'
+        )
+        == "3.5cm_BiasTape_minimalistic_Q2.stl"
+    )
+    assert (
+        filename_from_content_disposition("attachment; filename*=UTF-8''part%20a.stl")
+        == "part a.stl"
+    )
+
+
+def test_filename_from_url_path_strips_query() -> None:
+    assert (
+        filename_from_url_path(
+            "https://cdn.thingiverse.com/assets/x/3.5cm_BiasTape.stl?ofn=abc"
+        )
+        == "3.5cm_BiasTape.stl"
+    )
+
+
+def test_probe_remote_filename_uses_redirect_location() -> None:
+    mock_resp = MagicMock()
+    mock_resp.headers = {
+        "location": "https://cdn.example.com/files/bracket.stl?x=1",
+    }
+    mock_resp.url = "https://www.thingiverse.com/download:1"
+    mock_resp.status_code = 302
+
+    with patch("src.core.utils.remote_file_hint.httpx.Client") as client_cls:
+        client = MagicMock()
+        client.__enter__.return_value = client
+        client.__exit__.return_value = False
+        client.get.return_value = mock_resp
+        client_cls.return_value = client
+
+        assert (
+            probe_remote_filename("https://www.thingiverse.com/download:1")
+            == "bracket.stl"
+        )
+
+
+def test_enrich_resolves_thingiverse_download_to_stl() -> None:
+    item = {
+        "title": "Design Files 1",
+        "path": "https://www.thingiverse.com/download:7851122",
+        "type": "design-files",
+        "metadata": {},
+    }
+    okh_id = UUID("4148beb6-0b55-4ba8-8dfd-9480f6523f26")
+
+    with patch(
+        "src.core.api.okh_file_urls.probe_remote_filename",
+        return_value="3.5cm_BiasTape_minimalistic_Q2.stl",
+    ):
+        enriched = enrich_file_ref(item, "http://localhost:8001/v1/api", okh_id)
+
+    assert enriched["file_type"] == "mesh_stl"
+    assert enriched["file_type_display"] == "STL Mesh"
+    assert enriched["display_path"] == "3.5cm_BiasTape_minimalistic_Q2.stl"
+    assert enriched["url"] == item["path"]

--- a/uv.lock
+++ b/uv.lock
@@ -3269,7 +3269,7 @@ wheels = [
 
 [[package]]
 name = "supply-graph-ai"
-version = "0.10.1"
+version = "0.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Add `ProcessInferenceService` to seed `manufacturing_processes` from design file types and titles/keywords (generation + `ohm okh infer-processes` backfill)
- Resolve remote design-file URLs (e.g. Thingiverse downloads) so Match UI shows real file types instead of Unknown
- Normalize facility country codes to full names in network UI, filters, and spaces projection

## Test plan
- [x] `make ready` passed locally
- [ ] CI green on this PR
- [ ] After merge: tag `v0.10.2` and confirm Release workflow publishes Docker / GitHub Release


Made with [Cursor](https://cursor.com)