### PR TITLE
Pin deploys to image digests and assert build identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,12 @@ jobs:
     name: Publish multi-arch to Docker Hub
     runs-on: ubuntu-latest
     needs: [validate, test, docker-smoke]
+    # Deploys pin this digest rather than the tag. Republishing a release tag
+    # leaves the tag string unchanged, so Container Apps sees an identical
+    # revision spec, creates no new revision, and keeps serving the old image
+    # while the deploy reports success.
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     if: >-
       github.event_name == 'push' ||
       (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
@@ -167,6 +173,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push multi-arch manifest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -178,6 +185,7 @@ jobs:
             ${{ env.IMAGE }}:latest
           build-args: |
             APP_VERSION=${{ needs.validate.outputs.version }}
+            GIT_SHA=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -241,7 +249,7 @@ jobs:
         # (locally it would be read from a developer's .env — a prod footgun).
         run: |
           uv run python deploy/scripts/deploy_azure.py \
-            --image ${{ env.IMAGE }}:${{ needs.validate.outputs.version }} \
+            --image ${{ env.IMAGE }}@${{ needs.publish.outputs.digest }} \
             --subscription-id ${{ secrets.AZURE_SUBSCRIPTION_ID }} \
             --environment production
 
@@ -249,6 +257,12 @@ jobs:
         env:
           API_HOST: openhardwaremanager.blackdune-e38fce01.westus3.azurecontainerapps.io
           EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
+          # Identity, not just liveness. `version` cannot tell two builds of the
+          # same release apart, so a deploy that fails to roll over passes a
+          # version check while serving old code — which is exactly what happened
+          # on 2026-07-26. The build SHA is baked into the image, so this asserts
+          # the running container IS the image just published.
+          EXPECTED_BUILD: ${{ github.sha }}
         # Lifespan startup (storage + MATCHING_EAGER_INIT up to 120s) can exceed
         # the old 20×5s window; use liveness (no storage fingerprint) and tolerate
         # empty/non-JSON gateway responses during revision rollout.
@@ -263,26 +277,41 @@ jobs:
 
           host = os.environ["API_HOST"]
           expected = os.environ["EXPECTED_VERSION"]
-          url = f"https://{host}/health/liveness"
+          expected_build = os.environ["EXPECTED_BUILD"]
+          # /health carries the build SHA; liveness does not.
+          url = f"https://{host}/health"
           actual = None
+          actual_build = None
 
           for attempt in range(1, 37):
               try:
                   with urllib.request.urlopen(url, timeout=10) as resp:
                       body = json.load(resp)
                   actual = body.get("version")
-                  if actual == expected:
-                      print(f"deployed version={actual} (expected {expected})", flush=True)
+                  actual_build = body.get("build")
+                  if actual == expected and actual_build == expected_build:
+                      print(
+                          f"deployed version={actual} build={actual_build}",
+                          flush=True,
+                      )
                       sys.exit(0)
                   print(
-                      f"attempt {attempt}/36: version={actual!r} (waiting for {expected!r})",
+                      f"attempt {attempt}/36: version={actual!r} build={actual_build!r} "
+                      f"(waiting for {expected!r} / {expected_build[:8]!r})",
                       flush=True,
                   )
               except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, KeyError) as exc:
                   print(f"attempt {attempt}/36: not ready ({type(exc).__name__})", flush=True)
               time.sleep(10)
 
-          print(f"deployed version={actual!r} (expected {expected!r})")
+          print(f"deployed version={actual!r} build={actual_build!r}")
+          print(f"expected version={expected!r} build={expected_build!r}")
+          if actual == expected and actual_build != expected_build:
+              print(
+                  "::error::The app reports the right version but the wrong build — "
+                  "the container app did not roll over to the new image. If the image "
+                  "reference is unchanged, Container Apps creates no new revision.",
+              )
           sys.exit(1)
           PY
 
@@ -334,6 +363,9 @@ jobs:
     name: Publish frontend multi-arch to Docker Hub
     runs-on: ubuntu-latest
     needs: [validate, test, docker-smoke]
+    # See the note on `publish.outputs.digest` — deploys pin the digest.
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     if: >-
       github.event_name == 'push' ||
       (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
@@ -366,6 +398,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push multi-arch frontend manifest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: frontend
@@ -375,6 +408,8 @@ jobs:
             ${{ env.FRONTEND_IMAGE }}:${{ needs.validate.outputs.version }}
             ${{ env.FRONTEND_IMAGE }}:${{ needs.validate.outputs.major_minor }}
             ${{ env.FRONTEND_IMAGE }}:latest
+          build-args: |
+            GIT_SHA=${{ github.sha }}
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,mode=max,scope=frontend
 
@@ -425,7 +460,7 @@ jobs:
       - name: Deploy frontend
         run: |
           uv run python deploy/scripts/deploy_azure_frontend.py \
-            --image ${{ env.FRONTEND_IMAGE }}:${{ needs.validate.outputs.version }} \
+            --image ${{ env.FRONTEND_IMAGE }}@${{ needs['publish-frontend'].outputs.digest }} \
             --subscription-id ${{ secrets.AZURE_SUBSCRIPTION_ID }} \
             --environment production
 
@@ -440,6 +475,25 @@ jobs:
           done
           echo "frontend /healthz -> $code"
           test "$code" = "200"
+
+          # Liveness is not identity: the OLD revision also answers /healthz with
+          # 200, so polling it proves nothing about which image is serving. The
+          # build SHA is baked into the image at build time, so wait for the
+          # container to actually report the build we just published.
+          expected="${{ github.sha }}"
+          build=""
+          for i in $(seq 1 36); do
+            build=$(curl -s --max-time 20 "https://$host/build-info.json" \
+              | python3 -c "import sys,json;print(json.load(sys.stdin).get('build',''))" 2>/dev/null || true)
+            [ "$build" = "$expected" ] && break
+            echo "attempt $i/36: build=${build:-unknown} (waiting for ${expected:0:8})"
+            sleep 10
+          done
+          if [ "$build" != "$expected" ]; then
+            echo "::error::frontend reports build '${build:-unknown}', expected '${expected}' — the container app did not roll over to the new image."
+            exit 1
+          fi
+          echo "frontend build -> ${build:0:8} (matches)"
           # The /v1 reverse-proxy reaches the backend API (same-origin).
           curl -sf --max-time 20 "https://$host/v1/openapi.json" >/dev/null
           echo "frontend proxy -> backend /v1 OK"

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,13 @@ RUN uv sync --frozen --no-dev --no-editable
 FROM python:3.12-slim AS runtime
 
 ARG APP_VERSION=0.8.0
+# The commit this image was built from. A version alone cannot identify a build:
+# two images published under the same release tag report the same version, so a
+# deploy that silently fails to roll over looks healthy. /health reports this so
+# a deploy can assert it is running the image it just pushed.
+ARG GIT_SHA=unknown
 LABEL org.opencontainers.image.version="${APP_VERSION}" \
+      org.opencontainers.image.revision="${GIT_SHA}" \
       org.opencontainers.image.title="Open Hardware Manager (OHM)" \
       org.opencontainers.image.source="https://github.com/helpfulengineering/supply-graph-ai/supply-graph-ai"
 
@@ -47,7 +53,8 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PATH="/opt/venv/bin:$PATH" \
     PYTHONPATH="/app" \
-    APP_VERSION="${APP_VERSION}"
+    APP_VERSION="${APP_VERSION}" \
+    GIT_SHA="${GIT_SHA}"
 
 # curl: container healthcheck.
 # git:  the generation pipeline's clone path (`clone=true`) shells out to

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -26,6 +26,15 @@ COPY --from=build /app/dist /usr/share/nginx/html
 # empty docs section, which the post-deploy smoke check is there to catch.
 COPY docs-dist /usr/share/nginx/html/docs
 
+# Build identity, baked in so a deploy can prove which image is actually
+# serving. A version string cannot do this: republishing a release tag yields a
+# new image reporting the same version, so a deploy that silently fails to roll
+# over still passes a version check. Static file rather than a runtime env var —
+# it has to describe the IMAGE, not the container's environment.
+ARG GIT_SHA=unknown
+LABEL org.opencontainers.image.revision="${GIT_SHA}"
+RUN printf '{"build":"%s"}\n' "${GIT_SHA}" > /usr/share/nginx/html/build-info.json
+
 # Host-specific config — injected at deploy time from the centralized config
 # surface (config/environments/<env>.toml [frontend]); NOT baked into the image.
 # API_UPSTREAM_URL has no default on purpose: an unset value fails nginx startup

--- a/src/core/main.py
+++ b/src/core/main.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import os
 from contextlib import asynccontextmanager
 
 import uvicorn
@@ -257,6 +258,12 @@ async def health_check():
         "status": "ok",
         "domains": list(DomainRegistry.get_registered_domains()),
         "version": get_version(),
+        # The commit this image was built from, baked in at build time.
+        # `version` cannot identify a build: republishing a release tag produces
+        # a new image reporting the SAME version, so a deploy that fails to roll
+        # over passes a version check while serving the old code. This is what
+        # the deploy gate asserts against.
+        "build": os.getenv("GIT_SHA", "unknown"),
     }
     try:
         storage_service = await StorageService.get_instance()


### PR DESCRIPTION
## What the failing docs gate actually found

Deploys have been **silently no-opping**. 0.10.3 was published, deployed, and reported success — while the containers kept serving the *previous* image.

None of this is live, despite two green deploy jobs:

- the documentation site
- `git` in the backend image (`clone=true` still returns "Failed to clone repository")
- the 7× generation speedup

## Cause: a mutable tag

Deploys pinned `--image repo:${version}`. Republishing 0.10.3 overwrote that tag with a new digest, then the deploy set the image to **the same string already running**.

Container Apps creates a revision only when the revision spec *changes*. Unchanged image reference → no new revision → no rollout. The `az` command succeeded because it genuinely had nothing to do.

| Evidence | |
|---|---|
| New image was pushed | `0.10.3` re-pushed 22:54:53Z, digest `sha256:43b326f08a0a5` |
| Old one still serving | `/docs/definitely-not-a-page/` → 200 with the SPA title |
| Backend also stale | `clone=true` → "Failed to clone repository" (git absent) |

## Why nothing caught it

**Every check tested liveness, not identity.**

The backend compared `/health` `version` against the release version — but the stale image reports the **same** version, because both were built from the same release. The frontend polled `/healthz`, which the old revision answers happily.

The only signal came from the docs check added a day earlier, and only because it asserts **content** rather than status.

## The fix

**1. Deploy by digest.** `publish` and `publish-frontend` expose `steps.build.outputs.digest`; both deploys pin `repo@sha256:...`. The spec changes whenever the content changes, so a rollout is guaranteed — and deploys become immutable and reproducible.

**2. Assert build identity.** Images bake in `GIT_SHA` at build time:

- backend reports it at `/health` as `build`
- frontend serves `/build-info.json`

Both deploy jobs now poll until the running container reports **the build just published**, and fail with an explicit diagnosis if it never does. A version string can never do this job — two builds of one release share it.

## Verification

Built both images with a known SHA and ran them:

```
backend  /health          -> version: 0.10.3   build: deadbeef1234
frontend /build-info.json -> {"build":"abc123def456"}
frontend (CI extraction)  -> abc123def456
backend  git --version    -> git version 2.47.3
```

That last line also confirms the earlier runtime-image fix builds correctly.

`make ready` 10/10.

## After merging

The next deploy will genuinely roll over. Expect it to actually take effect this time — and if it doesn't, the deploy will now say so instead of reporting success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)