### PR TITLE
Near-miss tolerance, taxonomy drift gate, country names, Contact page, and frontend CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -162,3 +162,52 @@ jobs:
 
       - name: Static security scan
         run: uv run bandit -q -r src -c pyproject.toml -x tests
+
+  # The frontend gate had NO CI coverage: nothing ran typecheck, lint, unit
+  # tests, the build, or the Playwright/a11y suite. That is how a unit test
+  # broken by 0.10.2 sat red on main until someone happened to run the gate
+  # locally, and it left the accessibility suite unenforced.
+  #
+  # Runs `frontend-ready`, the same single signal used locally and by the build
+  # loop, so CI and a developer's machine agree on what "green" means.
+  frontend:
+    name: Frontend (typecheck, lint, unit, build, e2e + a11y)
+    runs-on: ubuntu-latest
+    needs: quality
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Only the browser the mocked lane drives; the full download is slow and
+      # the other engines are unused.
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: frontend-ready
+        run: npm run frontend-ready
+
+      # Screenshots and traces are the difference between "a11y failed" and
+      # knowing which element, which matters most for the runs nobody watched.
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            frontend/artifacts/test-results
+            frontend/artifacts/playwright-report
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 581
+Total Python files: 582
 
 ├── deploy/
 │   ├── __init__.py
@@ -177,6 +177,10 @@ Total Python files: 581
 │   ├── generate_openapi_routes_md.py
 │   │       def _escape_cell()
 │   │       def build_markdown()
+│   │       def main()
+│   ├── generate_process_definitions.py
+│   │       def _render()
+│   │       def _splice()
 │   │       def main()
 │   ├── generate_repo_map.py
 │   │       def get_git_files()
@@ -2881,7 +2885,7 @@ Total Python files: 581
 
 ## Overview
 
-Total files analyzed: 581
+Total files analyzed: 582
 
 ## Entry Points
 
@@ -6084,6 +6088,18 @@ Output is in...
 
 **Functions:**
 - `build_markdown(api_v1)`
+- `main()`
+
+**Internal Dependencies:** 1 imports
+
+### `scripts/generate_process_definitions.py`
+> Generate ``PROCESS_DEFINITIONS`` from ``src/config/taxonomy/processes.yaml``.
+
+The process taxonomy ...
+
+**Exports:** main
+
+**Functions:**
 - `main()`
 
 **Internal Dependencies:** 1 imports

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Code style and project map via uv-managed environment.
-.PHONY: format format-check lint test check black ruff repo-map env-template env-template-check validate-docs version-check lock-check scripts scripts-check parity ready setup verify-env frontend-setup frontend-ready harness harness-probes match-harness docs-site docs-status
+.PHONY: format format-check lint test check black ruff repo-map env-template env-template-check validate-docs version-check lock-check scripts scripts-check parity ready setup verify-env frontend-setup frontend-ready harness harness-probes match-harness docs-site docs-status taxonomy taxonomy-check
 
 # Web frontend verification harness (the frontend analogue of `ready`).
 # See frontend/harness/README.md. Runs typecheck, lint, unit, build, and the
@@ -80,6 +80,15 @@ env-template-check:
 validate-docs:
 	uv run python scripts/validate_docs.py
 
+# Process taxonomy: processes.yaml is the source of truth; the Python
+# PROCESS_DEFINITIONS literal is its generated fallback (used when the YAML is
+# missing or invalid). Regenerate after editing the YAML.
+taxonomy:
+	uv run python scripts/generate_process_definitions.py
+
+taxonomy-check:
+	uv run python scripts/generate_process_definitions.py --check
+
 # Public docs <-> code gate. Fails when a site page claims a capability the
 # code does not have (see tests/parity/test_docs_status.py). Narrative staleness
 # is reported as a warning here, never as a failure.
@@ -119,14 +128,15 @@ parity:
 # Definition of done. Green tests are not "ready to merge"; this is.
 # Each step verifies (does not mutate) and fails fast. Run before any MR.
 ready:
-	@echo "==> [1/10] env verify";      $(MAKE) verify-env
-	@echo "==> [2/10] format check";    $(MAKE) format-check
-	@echo "==> [3/10] lint";            $(MAKE) lint
-	@echo "==> [4/10] unit tests";      $(MAKE) test
-	@echo "==> [5/10] service parity";  $(MAKE) parity
-	@echo "==> [6/10] docs ↔ code";     $(MAKE) validate-docs
-	@echo "==> [7/10] site docs status";$(MAKE) docs-status
-	@echo "==> [8/10] version sync";    $(MAKE) version-check
-	@echo "==> [9/10] lockfile sync";   $(MAKE) lock-check
-	@echo "==> [10/10] script registry";$(MAKE) scripts-check
+	@echo "==> [1/11] env verify";      $(MAKE) verify-env
+	@echo "==> [2/11] format check";    $(MAKE) format-check
+	@echo "==> [3/11] lint";            $(MAKE) lint
+	@echo "==> [4/11] unit tests";      $(MAKE) test
+	@echo "==> [5/11] service parity";  $(MAKE) parity
+	@echo "==> [6/11] docs ↔ code";     $(MAKE) validate-docs
+	@echo "==> [7/11] site docs status";$(MAKE) docs-status
+	@echo "==> [8/11] taxonomy sync";   $(MAKE) taxonomy-check
+	@echo "==> [9/11] version sync";    $(MAKE) version-check
+	@echo "==> [10/11] lockfile sync";  $(MAKE) lock-check
+	@echo "==> [11/11] script registry";$(MAKE) scripts-check
 	@echo "==> READY: all gates passed."

--- a/docs-site/docs/contact.md
+++ b/docs-site/docs/contact.md
@@ -1,0 +1,51 @@
+---
+title: Contact
+reviewed: 2026-07-26
+---
+
+# Contact
+
+**[contact@openhardwaremanager.org](mailto:contact@openhardwaremanager.org)**
+
+OHM is maintained by a small team, so a real person reads this. That also means
+replies are not instant — if something is time-sensitive, say so.
+
+## Worth getting in touch about
+
+**You run a workshop and something about your entry is wrong.** Particularly if
+your capabilities are recorded inaccurately — that directly affects whether
+people can find you.
+
+**You have a collection of designs to bring in.** Tell us roughly how many and
+what form they're in — a repository, a spreadsheet, a database, a pile of PDFs.
+The answer to "how hard is this?" is usually clear from a handful of examples.
+See [bring your collection](guides/bring-your-collection.md).
+
+**You want to run your own instance and something is in the way.** Especially if
+you have constraints about where data can live — that case is what the design is
+for, and if it doesn't work for you we'd rather know.
+
+**Something is broken, or the documentation is wrong.** Both are useful. If a
+page here says OHM does something it doesn't, that's a bug in its own right.
+
+**You hit a limit we've documented.** Several pages say "this doesn't work yet"
+or "this can exceed the limit". Those are honest, but knowing a limitation bites
+real projects is what moves it up the list — so tell us rather than working
+around it silently.
+
+**You're a commercial manufacturer.** OHM doesn't offer you much today and
+[we say so plainly](about/what-ohm-is-not.md). If you'd want to hear when that
+changes, say so and we'll note it.
+
+## Development and issues
+
+Development happens in the open on
+[GitHub](https://github.com/helpfulengineering/supply-graph-ai). Bug reports and
+feature requests are welcome there, and a public issue is often more useful than
+an email — other people hit the same things.
+
+## What we can't do
+
+We don't broker work, quote for manufacturing, or introduce you to a workshop.
+OHM tells you who can build something; the conversation after that is yours to
+have. See [what OHM is not](about/what-ohm-is-not.md).

--- a/docs-site/docs/guides/find-who-can-build-it.md
+++ b/docs-site/docs/guides/find-who-can-build-it.md
@@ -32,15 +32,18 @@ of which requirements the workshop satisfied, which it didn't, and why — for
 example that it covers the printing and cutting a design needs but has nothing
 recorded for soldering.
 
-!!! warning "A percentage is not a yes"
+### Near misses, and how much slack to allow
 
-    The results list currently includes **near misses as well as matches**. A
-    workshop can show "Medium · 67%" and still be a facility that cannot build
-    the design — its explanation will begin with `NOT MATCHED` and name what's
-    missing.
+A workshop that satisfies most of a design's requirements but not all of it is
+often still worth contacting — a single missing process is frequently an easy
+gap to fill. So results say plainly what is missing rather than reducing it to a
+score: **"Missing 1 of 4 requirements"**, or **"Meets every requirement"**.
 
-    This is confusing and we're fixing it. Until then: the explanation is
-    authoritative, the badge is a hint.
+A slider controls how much slack to allow, measured in missing requirements
+rather than a percentage — one gap means something quite different in a design
+with two requirements than in one with six. It starts at a single gap, and it
+cannot be relaxed past the point where a result would meet fewer than two of
+your requirements.
 
 ## When nothing matches
 

--- a/docs-site/docs/guides/find-your-space.md
+++ b/docs-site/docs/guides/find-your-space.md
@@ -29,11 +29,10 @@ Narrow it down with:
 Filtering by country and then city is usually the fastest way to find a
 particular place.
 
-!!! note "Searching by name isn't available yet"
-
-    You can't currently type a workshop's name and jump to it — you narrow by
-    place and process instead. This is a known gap and a high priority to fix,
-    because it's obviously the thing most people will try first.
+Or just type the name. **Search by name** sits above the filters and matches on
+name, city, and country — so "lyon" finds a workshop whose own name doesn't
+mention it. It ignores accents, punctuation, and word order, because "fablab
+bordeaux" should find "Fablab Coh@bit IUT Bordeaux".
 
 ## If you find yourself
 

--- a/docs-site/mkdocs.yml
+++ b/docs-site/mkdocs.yml
@@ -115,6 +115,7 @@ nav:
       - Bring your collection: guides/bring-your-collection.md
       - Run your own node: guides/run-your-own-node.md
       - Use the OHM API: guides/use-the-api.md
+  - Contact: contact.md
   - Reference:
       - Glossary: reference/glossary.md
       - OKH and OKW: reference/okh-and-okw.md

--- a/frontend/e2e/a11y.ts
+++ b/frontend/e2e/a11y.ts
@@ -6,6 +6,29 @@ import { expect, type Page } from "@playwright/test";
  * serious or critical violations. Feature slices call this on each journey.
  */
 export async function expectNoA11yViolations(page: Page): Promise<void> {
+  // Wait for animations to finish before scanning.
+  //
+  // Elements fade in (tw-animate-css), and axe computes contrast from whatever
+  // is on screen at that instant. Mid-fade, a colour is blended toward its
+  // background, so the scan sees greys that exist in no stylesheet — observed
+  // as "#4f4f4f on #a9a9a9", with different values each run. That produced
+  // intermittent failures (2-3 in every 5-8 runs) attributable to no component.
+  //
+  // Waiting for settled animations makes the scan deterministic. It is bounded
+  // so an infinite/looping animation cannot hang the suite.
+  await page
+    .waitForFunction(
+      () =>
+        document
+          .getAnimations()
+          .every((a) => a.playState === "finished" || a.playState === "idle"),
+      undefined,
+      { timeout: 5_000 },
+    )
+    .catch(() => {
+      /* a persistent animation is not itself a failure; scan anyway */
+    });
+
   const results = await new AxeBuilder({ page })
     .withTags(["wcag2a", "wcag2aa"])
     .analyze();

--- a/frontend/e2e/match.spec.ts
+++ b/frontend/e2e/match.spec.ts
@@ -24,7 +24,10 @@ test("running a match shows ranked results, summary, and coverage gaps (mocked)"
   await page.getByRole("button", { name: /run match/i }).click();
 
   await expect(page.getByRole("heading", { name: "FabLab Drome" })).toBeVisible();
-  await expect(page.getByText(/High · 95%/)).toBeVisible();
+  // Confidence is now a secondary signal; coverage leads. The old assertion
+  // ("High · 95%") encoded the presentation that made a facility missing a
+  // requirement read as broadly fine.
+  await expect(page.getByText(/confidence 95%/)).toBeVisible();
   await expect(page.getByText(/2 candidate solutions found/)).toBeVisible();
   await expect(page.getByText(/CNC Machining/)).toBeVisible();
   // Each solution links to its own supply tree.
@@ -127,4 +130,71 @@ test("network mode sends network_filter and shows the banner (mocked)", async ({
 
   await expect(page.getByRole("heading", { name: "FabLab Drome" })).toBeVisible();
   expect(body!.network_filter).toMatchObject({ country: "FR", process: "laser_cutting", include_mom: true });
+});
+
+test("near-misses are filtered by a tolerance the design's size bounds (mocked)", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "asserts mocked results");
+
+  // Four requirements: one facility meets all, one misses a single process.
+  const req = (status: string) => ({ status });
+  await page.route("**/api/match", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        data: {
+          total_solutions: 2,
+          solutions: [
+            {
+              facility_name: "Complete Works",
+              facility_id: "f1",
+              confidence: 1,
+              rank: 1,
+              explanation: {
+                requirement_matches: [
+                  req("matched"), req("matched"), req("matched"), req("matched"),
+                ],
+              },
+            },
+            {
+              facility_name: "Nearly There",
+              facility_id: "f2",
+              confidence: 0.75,
+              rank: 2,
+              explanation: {
+                requirement_matches: [
+                  req("matched"), req("matched"), req("matched"), req("unmatched"),
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    }),
+  );
+
+  await page.goto("/match");
+  await page.getByLabel("Search designs").fill("Ventilator");
+  await page.getByRole("option", { name: /Open Ventilator/i }).click();
+  await page.getByLabel("Laser Fab Lab").check();
+  await page.getByRole("button", { name: /run match/i }).click();
+
+  // Default tolerance is one gap, so both appear — and the near-miss says what
+  // is missing rather than showing a percentage that reads as "probably fine".
+  await expect(page.getByRole("heading", { name: "Complete Works" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Nearly There" })).toBeVisible();
+  await expect(page.getByText("Missing 1 of 4 requirements")).toBeVisible();
+  await expect(page.getByText("Meets every requirement")).toBeVisible();
+
+  // Tightening to zero hides the near-miss.
+  const slider = page.getByLabel(/Allow facilities missing up to/);
+  await slider.fill("0");
+  await expect(page.getByRole("heading", { name: "Nearly There" })).toBeHidden();
+  await expect(page.getByRole("heading", { name: "Complete Works" })).toBeVisible();
+  await expect(page.getByText(/1 facility is hidden/)).toBeVisible();
+
+  // The ceiling is r-2, so a 4-requirement design can never relax past 2.
+  await expect(slider).toHaveAttribute("max", "2");
 });

--- a/frontend/e2e/okh-catalog.spec.ts
+++ b/frontend/e2e/okh-catalog.spec.ts
@@ -24,7 +24,14 @@ test("selecting a facet narrows the results (mocked)", async ({ page }, testInfo
   test.skip(testInfo.project.name === "real-api", "asserts fixture data");
   await page.goto("/okh");
   // Only Face Shield is GPL-2.0.
-  await page.getByRole("checkbox", { name: /GPL-2\.0/ }).check();
+  //
+  // click(), not check(): facet state lives in the URL, so the checkbox is
+  // controlled and its DOM value round-trips through the router. check()
+  // asserts the input's own state flipped and samples during the window where
+  // React has reset the value but the URL update has not landed — which failed
+  // intermittently under load, including in CI with a retry. The assertions
+  // below verify the behaviour that actually matters.
+  await page.getByRole("checkbox", { name: /GPL-2\.0/ }).click();
   await expect(page.getByRole("heading", { name: "Face Shield" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Open Ventilator" })).toBeHidden();
   // Facet selection is reflected in the URL (deep-linkable).
@@ -46,7 +53,8 @@ test("category facet is the primary spine and narrows results (mocked)", async (
   // Retry until the check sticks: the facet can still remount as counts recompute,
   // which otherwise drops the click ("did not change its state").
   await expect(async () => {
-    await page.getByRole("checkbox", { name: /Test & Measurement/ }).check();
+    // click(), not check() — see the note above on URL-controlled facets.
+    await page.getByRole("checkbox", { name: /Test & Measurement/ }).click();
     await expect(page).toHaveURL(/category=Test/);
   }).toPass();
   await expect(page.getByRole("heading", { name: "Test Rig" })).toBeVisible();

--- a/frontend/src/api/ohm/match.ts
+++ b/frontend/src/api/ohm/match.ts
@@ -28,6 +28,12 @@ export interface RawSolution {
   score?: number;
   rank?: number;
   explanation_human?: string | null;
+  /** Structured explanation; carries per-requirement match status. */
+  explanation?: {
+    requirement_matches?: { status?: string | null }[] | null;
+    missing_capabilities?: unknown[] | null;
+    overall_status?: string | null;
+  } | null;
   match_type?: string | null;
   tree?: { id?: string | null } | null;
 }

--- a/frontend/src/features/match/MatchResultCard.test.tsx
+++ b/frontend/src/features/match/MatchResultCard.test.tsx
@@ -13,6 +13,7 @@ const solution: RankedSolution = {
   rank: 1,
   explanation: "✓ FabLab Drome MATCHED\nAll requirements satisfied.",
   treeId: "tree-1",
+  coverage: null,
 };
 
 describe("MatchResultCard", () => {

--- a/frontend/src/features/match/MatchResultCard.tsx
+++ b/frontend/src/features/match/MatchResultCard.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { Badge } from "../../components/ui/Badge";
 import type { RankedSolution } from "./matchViewModel";
 import { confidencePct, confidenceToken } from "./confidence";
+import { coverageLabel } from "./nearMiss";
 
 export function MatchResultCard({
   solution,
@@ -54,9 +55,21 @@ export function MatchResultCard({
                 </p>
               )}
             </div>
-            <Badge variant={token.variant}>
-              {token.label} · {confidencePct(solution.confidence)}%
-            </Badge>
+            {/*
+              Coverage leads, confidence follows. A bare percentage was the bug:
+              a facility missing a requirement read as "Medium · 67%", which
+              invites "probably fine". What a person can act on is WHICH
+              requirement is unmet, so say that first and keep the score as a
+              secondary signal.
+            */}
+            <div className="flex shrink-0 flex-col items-end gap-1">
+              <Badge variant={solution.coverage?.missing ? "yellow" : token.variant}>
+                {coverageLabel(solution.coverage)}
+              </Badge>
+              <span className="text-xs text-slate-500 dark:text-slate-400">
+                confidence {confidencePct(solution.confidence)}%
+              </span>
+            </div>
           </div>
           {treeHref && (
             <div className="mt-3">

--- a/frontend/src/features/match/MatchView.tsx
+++ b/frontend/src/features/match/MatchView.tsx
@@ -7,6 +7,11 @@ import { runMatch } from "../../api/ohm/match";
 import { ApiError } from "../../api/ohm/client";
 import { solutionSelectionKey, toMatchView } from "./matchViewModel";
 import {
+  defaultTolerance,
+  toleranceCeiling,
+  withinTolerance,
+} from "./nearMiss";
+import {
   buildInlineMatchRequest,
   buildMatchRequest,
   SYSTEM_MODES,
@@ -137,10 +142,40 @@ export function MatchView({
     },
     onSuccess: () => setSelectedSolutionKeys([]),
   });
-  const view = useMemo(
+  const rawView = useMemo(
     () => (mutation.data ? toMatchView(mutation.data) : null),
     [mutation.data],
   );
+
+  // The design's requirement count comes from the results themselves — every
+  // solution is evaluated against the same requirement set.
+  const requirementCount = useMemo(
+    () =>
+      rawView?.solutions.reduce((max, s) => Math.max(max, s.coverage?.total ?? 0), 0) ??
+      0,
+    [rawView],
+  );
+  const ceiling = toleranceCeiling(requirementCount);
+  const [tolerance, setTolerance] = useState<number | null>(null);
+  const effectiveTolerance = Math.min(
+    tolerance ?? defaultTolerance(requirementCount),
+    ceiling,
+  );
+
+  // Near-misses are filtered out by default rather than shown as if they
+  // matched — the previous behaviour presented a facility that cannot build the
+  // design as "Medium · 67%".
+  const view = useMemo(() => {
+    if (!rawView) return null;
+    return {
+      ...rawView,
+      solutions: rawView.solutions.filter((s) =>
+        withinTolerance(s.coverage, effectiveTolerance),
+      ),
+    };
+  }, [rawView, effectiveTolerance]);
+
+  const hiddenCount = (rawView?.solutions.length ?? 0) - (view?.solutions.length ?? 0);
 
   const selectedDesign = useMemo(
     () => (designs.data?.items ?? []).find((d) => d.id === selected) ?? null,
@@ -328,6 +363,43 @@ export function MatchView({
                 </p>
               </div>
             )}
+            {ceiling > 0 && (
+              <div className="rounded-lg border border-input bg-muted/30 p-4">
+                <label
+                  htmlFor="near-miss-tolerance"
+                  className="block text-sm font-medium text-foreground"
+                >
+                  Allow facilities missing up to{" "}
+                  {effectiveTolerance === 0
+                    ? "nothing"
+                    : `${effectiveTolerance} requirement${effectiveTolerance === 1 ? "" : "s"}`}
+                </label>
+                <input
+                  id="near-miss-tolerance"
+                  type="range"
+                  min={0}
+                  max={ceiling}
+                  step={1}
+                  value={effectiveTolerance}
+                  onChange={(e) => setTolerance(Number(e.target.value))}
+                  className="mt-2 w-full max-w-sm"
+                />
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {/*
+                    Capped at r-2 so a "match" always means at least two
+                    satisfied requirements. Counting missing requirements rather
+                    than a percentage keeps this comparable across designs: one
+                    gap in a 2-requirement design is not the same as one gap in
+                    a design with six.
+                  */}
+                  This design has {requirementCount} requirements. The most you can
+                  relax to is {ceiling}, so a result always meets at least two.
+                  {hiddenCount > 0 &&
+                    ` ${hiddenCount} facilit${hiddenCount === 1 ? "y is" : "ies are"} hidden at this setting.`}
+                </p>
+              </div>
+            )}
+
             <div className="flex flex-wrap items-center justify-between gap-3">
               <p className="text-xs text-muted-foreground">
                 {view.totalSolutions} solution

--- a/frontend/src/features/match/geoDisplay.test.ts
+++ b/frontend/src/features/match/geoDisplay.test.ts
@@ -28,3 +28,36 @@ describe("geoDisplay", () => {
     expect(regionMatchKey("TX")).toBe(regionMatchKey("Texas"));
   });
 });
+
+describe("country names cover the whole ISO range, not a curated table", () => {
+  // Codes taken from the live network, which holds 140 distinct country values
+  // — 96 of them codes. The old hand-maintained table covered ~46, so the rest
+  // rendered raw and dropdowns showed a mix of "France" and "BJ".
+  const LIVE_CODES = [
+    "AF", "AL", "AM", "AO", "AW", "BA", "BD", "BF", "BG", "BH", "BJ", "BO",
+    "BT", "BY", "CD", "CG", "CI", "CM", "CR", "CY", "DJ", "DZ", "EC", "EG", "ET",
+  ];
+
+  it("resolves every code to a full name", () => {
+    for (const code of LIVE_CODES) {
+      const name = displayCountryName(code);
+      expect(name, `${code} should resolve to a name`).not.toBe(code);
+      expect(name.length).toBeGreaterThan(2);
+    }
+  });
+
+  it("still honours curated overrides for non-ISO spellings", () => {
+    expect(displayCountryName("USA")).toBe("United States");
+    expect(displayCountryName("US")).toBe("United States");
+  });
+
+  it("collapses a code and its full name to one filter option", () => {
+    expect(countryMatchKey("BJ")).toBe(countryMatchKey("Benin"));
+    expect(countryMatchKey("FR")).toBe(countryMatchKey("France"));
+  });
+
+  it("passes through values that are not country codes", () => {
+    expect(displayCountryName("Notacountry")).toBe("Notacountry");
+    expect(displayCountryName("")).toBe("");
+  });
+});

--- a/frontend/src/features/match/geoDisplay.ts
+++ b/frontend/src/features/match/geoDisplay.ts
@@ -117,11 +117,39 @@ function invert(map: Record<string, string>): Record<string, string> {
 const COUNTRY_BY_NAME = invert(COUNTRY_NAMES);
 const STATE_BY_NAME = invert(US_STATE_NAMES);
 
+/**
+ * Resolves every ISO 3166-1 alpha-2 code, not just the curated ones.
+ *
+ * The hand-maintained table below covers ~46 countries; the live network holds
+ * 140 distinct country values, 96 of which are codes. Anything outside the
+ * table used to fall through and render raw, which is why country dropdowns
+ * showed a mix of "France" and "BJ". Intl handles the long tail, and the table
+ * remains for non-standard values (e.g. "USA") and as a fallback.
+ */
+const REGION_DISPLAY: Intl.DisplayNames | null = (() => {
+  try {
+    return new Intl.DisplayNames(["en"], { type: "region" });
+  } catch {
+    return null;
+  }
+})();
+
 export function displayCountryName(raw: string | null | undefined): string {
   if (!raw?.trim()) return "";
   const s = raw.trim();
   const upper = s.toUpperCase();
-  return COUNTRY_NAMES[upper] ?? s;
+  // Curated overrides win: they handle non-ISO spellings Intl rejects.
+  if (COUNTRY_NAMES[upper]) return COUNTRY_NAMES[upper];
+  if (REGION_DISPLAY && /^[A-Z]{2}$/.test(upper)) {
+    try {
+      const name = REGION_DISPLAY.of(upper);
+      // Intl echoes the input back for codes it does not recognise.
+      if (name && name !== upper) return name;
+    } catch {
+      /* not a valid region subtag — fall through to the raw value */
+    }
+  }
+  return s;
 }
 
 export function displayRegionName(raw: string | null | undefined): string {
@@ -139,7 +167,10 @@ export function countryMatchKey(raw: string | null | undefined): string {
   if (COUNTRY_NAMES[upper]) return COUNTRY_NAMES[upper].toLowerCase();
   const fromName = COUNTRY_BY_NAME[s.toLowerCase()];
   if (fromName) return (COUNTRY_NAMES[fromName] ?? fromName).toLowerCase();
-  return s.toLowerCase();
+  // Same resolution as the display name, so a code and its full name collapse
+  // to one option instead of appearing twice in a filter.
+  const resolved = displayCountryName(s);
+  return resolved.toLowerCase();
 }
 
 /** Canonical key for comparing region/state values. */

--- a/frontend/src/features/match/matchViewModel.ts
+++ b/frontend/src/features/match/matchViewModel.ts
@@ -8,6 +8,8 @@ import type { RawMatchResponse } from "../../api/ohm/match";
  * coverage gaps, and a total. No React.
  */
 
+import { requirementStats, type RequirementStats } from "./nearMiss";
+
 export interface RankedSolution {
   facilityName: string;
   facilityId: string | null;
@@ -17,6 +19,11 @@ export interface RankedSolution {
   explanation: string | null;
   /** Per-solution supply-tree id when the API returned one on the solution. */
   treeId: string | null;
+  /**
+   * Requirement coverage from the structured explanation. Null when the API
+   * did not supply one — which must not be read as "nothing missing".
+   */
+  coverage: RequirementStats | null;
 }
 
 export interface MatchView {
@@ -39,6 +46,9 @@ export function toMatchView(raw: RawMatchResponse): MatchView {
       rank: s.rank ?? 0,
       explanation: s.explanation_human ?? null,
       treeId: s.tree?.id ?? null,
+      coverage: requirementStats(
+        s.explanation as Parameters<typeof requirementStats>[0],
+      ),
     }))
     .sort((a, b) => b.confidence - a.confidence || a.rank - b.rank);
 

--- a/frontend/src/features/match/nearMiss.test.ts
+++ b/frontend/src/features/match/nearMiss.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  coverageLabel,
+  defaultTolerance,
+  requirementStats,
+  toleranceCeiling,
+  withinTolerance,
+} from "./nearMiss";
+
+const explanation = (statuses: string[]) => ({
+  requirement_matches: statuses.map((status) => ({ status })),
+});
+
+describe("requirementStats", () => {
+  it("counts total and missing requirements", () => {
+    const s = requirementStats(explanation(["matched", "matched", "unmatched"]));
+    expect(s).toEqual({ total: 3, missing: 1 });
+  });
+
+  it("treats any non-matched status as missing", () => {
+    const s = requirementStats(explanation(["matched", "partial", "unknown"]));
+    expect(s).toEqual({ total: 3, missing: 2 });
+  });
+
+  it("returns null when the API gave no structured explanation", () => {
+    // Must not be confused with "nothing missing" — that would resurrect the
+    // original bug, where non-matches looked like matches.
+    expect(requirementStats(null)).toBeNull();
+    expect(requirementStats({})).toBeNull();
+    expect(requirementStats({ requirement_matches: [] })).toBeNull();
+  });
+});
+
+describe("toleranceCeiling", () => {
+  it("always requires at least two satisfied requirements", () => {
+    expect(toleranceCeiling(6)).toBe(4);
+    expect(toleranceCeiling(3)).toBe(1);
+  });
+
+  it("permits no gap at all for very small designs", () => {
+    // With 2 requirements, allowing a gap would mean matching on one process.
+    expect(toleranceCeiling(2)).toBe(0);
+    expect(toleranceCeiling(1)).toBe(0);
+    expect(toleranceCeiling(0)).toBe(0);
+  });
+});
+
+describe("defaultTolerance", () => {
+  it("defaults to a single easy-to-fill gap", () => {
+    expect(defaultTolerance(6)).toBe(1);
+    expect(defaultTolerance(3)).toBe(1);
+  });
+
+  it("never exceeds the ceiling", () => {
+    expect(defaultTolerance(2)).toBe(0);
+    expect(defaultTolerance(1)).toBe(0);
+  });
+
+  it("is always a valid slider position", () => {
+    for (let r = 0; r <= 12; r++) {
+      expect(defaultTolerance(r)).toBeLessThanOrEqual(toleranceCeiling(r));
+      expect(defaultTolerance(r)).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+describe("withinTolerance", () => {
+  it("includes exact matches at every setting", () => {
+    expect(withinTolerance({ total: 5, missing: 0 }, 0)).toBe(true);
+  });
+
+  it("excludes results beyond the chosen tolerance", () => {
+    expect(withinTolerance({ total: 5, missing: 2 }, 1)).toBe(false);
+    expect(withinTolerance({ total: 5, missing: 2 }, 2)).toBe(true);
+  });
+
+  it("shows results with unknown coverage rather than hiding them", () => {
+    expect(withinTolerance(null, 0)).toBe(true);
+  });
+});
+
+describe("coverageLabel", () => {
+  it("never reports a bare percentage", () => {
+    const label = coverageLabel({ total: 3, missing: 1 });
+    expect(label).toBe("Missing 1 of 3 requirements");
+    expect(label).not.toMatch(/%/);
+  });
+
+  it("states plainly when everything is met", () => {
+    expect(coverageLabel({ total: 3, missing: 0 })).toBe("Meets every requirement");
+  });
+
+  it("is explicit when coverage is unknown", () => {
+    expect(coverageLabel(null)).toBe("Coverage unknown");
+  });
+});

--- a/frontend/src/features/match/nearMiss.ts
+++ b/frontend/src/features/match/nearMiss.ts
@@ -1,0 +1,81 @@
+/**
+ * Near-miss tolerance (pure, unit-tested).
+ *
+ * The match API returns facilities that do NOT satisfy every requirement
+ * alongside those that do, and the UI showed both with a confidence badge — so
+ * a workshop that cannot build your design appeared as "Medium · 67%". The
+ * percentage is the problem: it invites people to read 67% as "probably fine",
+ * and it is not comparable across designs. A design with 2 requirements drops
+ * to 50% for one gap; a design with 6 drops to 83% for the same gap.
+ *
+ * So tolerance is expressed in MISSING REQUIREMENTS, which is both actionable
+ * ("missing soldering") and stable across designs.
+ *
+ * The bounds are a function of the design's requirement count `r`:
+ *
+ *   ceiling  = max(r - 2, 0)   a facility must always satisfy at least 2
+ *                              requirements, so results never degrade into
+ *                              "this workshop shares one process with you"
+ *   default  = min(1, ceiling) missing at most one — an easy gap to fill, and
+ *                              the case worth surfacing unprompted
+ */
+
+export interface RequirementStats {
+  /** Requirements the design states. */
+  total: number;
+  /** How many this facility does not satisfy. */
+  missing: number;
+}
+
+interface RequirementMatch {
+  status?: string | null;
+}
+
+interface ExplanationLike {
+  requirement_matches?: RequirementMatch[] | null;
+  missing_capabilities?: unknown[] | null;
+  overall_status?: string | null;
+}
+
+/**
+ * Read requirement counts out of a structured explanation.
+ *
+ * Returns null when the API did not include one — callers must not infer
+ * "nothing missing" from missing data, which would resurrect the original bug
+ * in a quieter form.
+ */
+export function requirementStats(
+  explanation: ExplanationLike | null | undefined,
+): RequirementStats | null {
+  const matches = explanation?.requirement_matches;
+  if (!Array.isArray(matches) || matches.length === 0) return null;
+  const missing = matches.filter((m) => m?.status !== "matched").length;
+  return { total: matches.length, missing };
+}
+
+/** Most missing requirements a user may choose to tolerate, given `r`. */
+export function toleranceCeiling(totalRequirements: number): number {
+  return Math.max(totalRequirements - 2, 0);
+}
+
+/** Where the control starts: one gap, unless the design is too small to allow it. */
+export function defaultTolerance(totalRequirements: number): number {
+  return Math.min(1, toleranceCeiling(totalRequirements));
+}
+
+export function withinTolerance(
+  stats: RequirementStats | null,
+  tolerance: number,
+): boolean {
+  // Unknown coverage is shown rather than hidden: silently dropping results
+  // because the API omitted an explanation would be worse than showing them.
+  if (!stats) return true;
+  return stats.missing <= tolerance;
+}
+
+/** Short, honest label for a result — never a bare percentage. */
+export function coverageLabel(stats: RequirementStats | null): string {
+  if (!stats) return "Coverage unknown";
+  if (stats.missing === 0) return "Meets every requirement";
+  return `Missing ${stats.missing} of ${stats.total} requirements`;
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,6 +23,7 @@ A ✎ marks a script that **writes** files / storage / remote state; the rest ar
 | `dump_api_routes` | Print sorted 'METHOD path' lines for the v1 FastAPI app; --count-only for a route count. | `uv run python scripts/dump_api_routes.py [--count-only]` |
 | `generate_env_template` ✎ | Regenerate the schema-owned block of env.template from the config schema; --check gates staleness. | `uv run python scripts/generate_env_template.py [--check]` |
 | `generate_openapi_routes_md` ✎ | Write the MkDocs API route table from the versioned FastAPI (api_v1) OpenAPI schema. | `uv run python scripts/generate_openapi_routes_md.py` |
+| `generate_process_definitions` ✎ | Generate the PROCESS_DEFINITIONS fallback literal from processes.yaml; --check gates drift between the two. | `uv run python scripts/generate_process_definitions.py [--check]` |
 | `generate_repo_map` ✎ | Generate .repo-map.md (Aider + Sourcegraph styles) for codebase navigation. | `uv run python scripts/generate_repo_map.py` |
 | `generate_scripts_index` ✎ | Generate scripts/README.md from this registry; --check gates staleness and registry completeness. | `uv run python scripts/generate_scripts_index.py [--check]` |
 

--- a/scripts/generate_process_definitions.py
+++ b/scripts/generate_process_definitions.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Generate ``PROCESS_DEFINITIONS`` from ``src/config/taxonomy/processes.yaml``.
+
+The process taxonomy exists in two places:
+
+  * ``src/config/taxonomy/processes.yaml`` — the live source of truth
+  * ``src/core/taxonomy/process_taxonomy.py`` → ``PROCESS_DEFINITIONS`` — the
+    fallback ``_create_taxonomy()`` uses when the YAML is missing or invalid
+
+They were hand-synchronised across 49 processes with nothing asserting they
+agreed, so adding a process meant remembering two files; miss one and the
+fallback silently serves a different taxonomy from production.
+
+Generating at COMMIT time rather than import time is deliberate. Deriving the
+literal at import would mean a corrupt YAML leaves no fallback at all — removing
+the safety net exactly when it is needed. Keeping it checked in preserves a real
+fallback while making drift impossible.
+
+Usage:
+    uv run python scripts/generate_process_definitions.py            # write
+    uv run python scripts/generate_process_definitions.py --check    # gate
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+TARGET = REPO_ROOT / "src" / "core" / "taxonomy" / "process_taxonomy.py"
+YAML_PATH = REPO_ROOT / "src" / "config" / "taxonomy" / "processes.yaml"
+
+DECLARATION = "PROCESS_DEFINITIONS: List[ProcessDefinition] = ["
+
+HEADER = f"""{DECLARATION}
+    # ------------------------------------------------------------------
+    # GENERATED — do not edit by hand.
+    #
+    # Source of truth: src/config/taxonomy/processes.yaml
+    # Regenerate:      uv run python scripts/generate_process_definitions.py
+    # Verified by:     make ready (taxonomy-check)
+    #
+    # This literal is the fallback used when the YAML is missing or invalid,
+    # so it stays checked in rather than being derived at import time.
+    # ------------------------------------------------------------------"""
+
+
+def _render(definitions) -> str:
+    """Render the definitions as the Python list literal."""
+    lines = [HEADER]
+    for d in definitions:
+        lines.append("    ProcessDefinition(")
+        lines.append(f"        canonical_id={d.canonical_id!r},")
+        lines.append(f"        display_name={d.display_name!r},")
+        lines.append(f"        tsdc_code={d.tsdc_code!r},")
+        lines.append(f"        parent={d.parent!r},")
+        if d.aliases:
+            lines.append("        aliases=frozenset(")
+            lines.append("            {")
+            # Sorted so regeneration is deterministic; a set has no order.
+            for alias in sorted(d.aliases):
+                lines.append(f"                {alias!r},")
+            lines.append("            }")
+            lines.append("        ),")
+        else:
+            lines.append("        aliases=frozenset(),")
+        if d.wikidata_qid:
+            lines.append(f"        wikidata_qid={d.wikidata_qid!r},")
+        lines.append("    ),")
+    lines.append("]")
+    return "\n".join(lines)
+
+
+def _splice(source: str, rendered: str) -> str:
+    """Replace the existing literal with the rendered one, black-formatted.
+
+    Formatting here rather than leaving it to `make format` is what makes
+    `--check` meaningful: otherwise the formatter rewrites the generated block,
+    the generator disagrees with what is on disk, and the gate fails on every
+    run even though nothing drifted.
+    """
+    import black
+
+    start = source.index(DECLARATION)
+    # The literal ends at the first line that is exactly "]" at column zero.
+    end = source.index("\n]\n", start) + len("\n]\n")
+    updated = source[:start] + rendered + "\n" + source[end:]
+    return black.format_str(updated, mode=black.Mode())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail if the checked-in literal differs from the YAML.",
+    )
+    args = parser.parse_args()
+
+    from src.core.taxonomy.process_taxonomy import load_from_yaml
+
+    definitions = load_from_yaml(YAML_PATH)
+    source = TARGET.read_text(encoding="utf-8")
+    updated = _splice(source, _render(definitions))
+
+    if args.check:
+        if updated != source:
+            print(
+                "DRIFT: PROCESS_DEFINITIONS does not match "
+                "src/config/taxonomy/processes.yaml.\n"
+                "The YAML is the source of truth; the Python literal is its "
+                "generated fallback.\n"
+                "Fix: uv run python scripts/generate_process_definitions.py",
+                file=sys.stderr,
+            )
+            return 1
+        print(
+            f"OK: PROCESS_DEFINITIONS matches processes.yaml ({len(definitions)} processes)"
+        )
+        return 0
+
+    if updated == source:
+        print(f"OK: already current ({len(definitions)} processes)")
+        return 0
+
+    TARGET.write_text(updated, encoding="utf-8")
+    print(
+        f"Wrote {len(definitions)} processes to "
+        f"{TARGET.relative_to(REPO_ROOT)} from {YAML_PATH.relative_to(REPO_ROOT)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/registry.toml
+++ b/scripts/registry.toml
@@ -71,6 +71,13 @@ run = "uv run python scripts/build_docs_site.py"
 mutates = true
 used_by = ["make docs-site", "notes/docs-v2-spec.md"]
 
+[scripts.generate_process_definitions]
+category = "generate"
+summary = "Generate the PROCESS_DEFINITIONS fallback literal from processes.yaml; --check gates drift between the two."
+run = "uv run python scripts/generate_process_definitions.py [--check]"
+mutates = true
+used_by = ["make ready (taxonomy-check)", "make taxonomy"]
+
 [scripts.generate_scripts_index]
 category = "generate"
 summary = "Generate scripts/README.md from this registry; --check gates staleness and registry completeness."

--- a/src/config/taxonomy/processes.yaml
+++ b/src/config/taxonomy/processes.yaml
@@ -156,6 +156,21 @@ processes:
       - "laser_cutting"
       - "laser cut"
 
+  # Maps of Making publishes a `vinyl-cutting` activity that OHM had no process
+  # for, so those spaces' capability was dropped on ingest. Aliases are taken
+  # from MoM's own skos:altLabel values so the bridge resolves on first contact.
+  # No wikidata_qid: MoM's concept carries no owl:sameAs, and alias matching is
+  # sufficient (that is how laser_cutting resolves today).
+  vinyl_cutting:
+    display_name: "Vinyl Cutting"
+    aliases:
+      - "vinyl cutting"
+      - "vinyl_cutting"
+      - "vinyl cutter"
+      - "plotter"
+      - "sticker cutting"
+      - "découpe vinyle"
+
   # ---------------------------------------------------------------------------
   # PCB (TSDC: PCB)
   # ---------------------------------------------------------------------------

--- a/src/core/taxonomy/process_taxonomy.py
+++ b/src/core/taxonomy/process_taxonomy.py
@@ -75,9 +75,16 @@ class ProcessDefinition:
 # ---------------------------------------------------------------------------
 
 PROCESS_DEFINITIONS: List[ProcessDefinition] = [
-    # -----------------------------------------------------------------------
-    # Additive Manufacturing (TSDC: 3DP)
-    # -----------------------------------------------------------------------
+    # ------------------------------------------------------------------
+    # GENERATED — do not edit by hand.
+    #
+    # Source of truth: src/config/taxonomy/processes.yaml
+    # Regenerate:      uv run python scripts/generate_process_definitions.py
+    # Verified by:     make ready (taxonomy-check)
+    #
+    # This literal is the fallback used when the YAML is missing or invalid,
+    # so it stays checked in rather than being derived at import time.
+    # ------------------------------------------------------------------
     ProcessDefinition(
         canonical_id="3d_printing",
         display_name="3D Printing",
@@ -85,16 +92,17 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent=None,
         aliases=frozenset(
             {
-                "3dp",
-                "3d printing",
                 "3d print",
+                "3d printing",
                 "3d_printing",
+                "3dp",
                 "additive manufacturing",
                 "am",
-                "printing",
                 "print",
+                "printing",
             }
         ),
+        wikidata_qid="Q229367",
     ),
     ProcessDefinition(
         canonical_id="3d_printing_fdm",
@@ -105,11 +113,11 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
             {
                 "fdm",
                 "fdm printing",
+                "fff",
                 "fused deposition modeling",
                 "fused deposition modelling",
                 "fused filament fabrication",
                 "fused_filament_fabrication",
-                "fff",
             }
         ),
     ),
@@ -121,8 +129,8 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         aliases=frozenset(
             {
                 "sla",
-                "sla printing",
                 "sla printer",
+                "sla printing",
                 "stereolithography",
             }
         ),
@@ -134,9 +142,9 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent="3d_printing",
         aliases=frozenset(
             {
+                "selective laser sintering",
                 "sls",
                 "sls printing",
-                "selective laser sintering",
             }
         ),
     ),
@@ -147,15 +155,12 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent="3d_printing",
         aliases=frozenset(
             {
+                "digital light processing",
                 "dlp",
                 "dlp printing",
-                "digital light processing",
             }
         ),
     ),
-    # -----------------------------------------------------------------------
-    # Subtractive Manufacturing (TSDC: CNC)
-    # -----------------------------------------------------------------------
     ProcessDefinition(
         canonical_id="cnc_machining",
         display_name="CNC Machining",
@@ -167,10 +172,11 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
                 "cnc machining",
                 "cnc_machining",
                 "computer numerical control",
-                "subtractive manufacturing",
                 "machining",
+                "subtractive manufacturing",
             }
         ),
+        wikidata_qid="Q174689",
     ),
     ProcessDefinition(
         canonical_id="cnc_milling",
@@ -179,13 +185,14 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent="cnc_machining",
         aliases=frozenset(
             {
-                "cnc milling",
-                "cnc_milling",
                 "cnc mill",
+                "cnc milling",
                 "cnc_mill",
+                "cnc_milling",
                 "milling",
             }
         ),
+        wikidata_qid="Q179507",
     ),
     ProcessDefinition(
         canonical_id="cnc_turning",
@@ -194,17 +201,15 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent="cnc_machining",
         aliases=frozenset(
             {
-                "cnc turning",
-                "cnc_turning",
                 "cnc lathe",
+                "cnc turning",
                 "cnc_lathe",
+                "cnc_turning",
                 "turning",
             }
         ),
+        wikidata_qid="Q1260093",
     ),
-    # -----------------------------------------------------------------------
-    # Laser Processes (TSDC: LAS)
-    # -----------------------------------------------------------------------
     ProcessDefinition(
         canonical_id="laser_cutting",
         display_name="Laser Cutting",
@@ -214,15 +219,29 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
             {
                 "las",
                 "laser",
+                "laser cut",
                 "laser cutting",
                 "laser_cutting",
-                "laser cut",
+            }
+        ),
+        wikidata_qid="Q3062349",
+    ),
+    ProcessDefinition(
+        canonical_id="vinyl_cutting",
+        display_name="Vinyl Cutting",
+        tsdc_code=None,
+        parent=None,
+        aliases=frozenset(
+            {
+                "découpe vinyle",
+                "plotter",
+                "sticker cutting",
+                "vinyl cutter",
+                "vinyl cutting",
+                "vinyl_cutting",
             }
         ),
     ),
-    # -----------------------------------------------------------------------
-    # PCB (TSDC: PCB)
-    # -----------------------------------------------------------------------
     ProcessDefinition(
         canonical_id="pcb_fabrication",
         display_name="PCB Fabrication",
@@ -230,18 +249,16 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent=None,
         aliases=frozenset(
             {
+                "circuit board",
                 "pcb",
                 "pcb fabrication",
                 "pcb_fabrication",
                 "printed circuit board",
                 "printed_circuit_board",
-                "circuit board",
             }
         ),
+        wikidata_qid="Q1047286",
     ),
-    # -----------------------------------------------------------------------
-    # Assembly (TSDC: ASM)
-    # -----------------------------------------------------------------------
     ProcessDefinition(
         canonical_id="assembly",
         display_name="Assembly",
@@ -250,14 +267,14 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         aliases=frozenset(
             {
                 "asm",
+                "assemble",
+                "assembling",
                 "assembly",
                 "assembly line",
                 "assembly_line",
-                "assemble",
-                "assembling",
-                "component assembly",
                 "attach",
                 "attaching",
+                "component assembly",
                 "install",
                 "installing",
                 "mount",
@@ -286,11 +303,12 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         aliases=frozenset(
             {
                 "electronics assembly",
-                "electronics_assembly",
                 "electronics manufacturing",
+                "electronics_assembly",
                 "electronics_manufacturing",
             }
         ),
+        wikidata_qid="Q11650",
     ),
     ProcessDefinition(
         canonical_id="pcb_assembly",
@@ -299,16 +317,13 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent="assembly",
         aliases=frozenset(
             {
-                "pcb assembly",
-                "pcb_assembly",
                 "clean room assembly",
                 "clean_room_assembly",
+                "pcb assembly",
+                "pcb_assembly",
             }
         ),
     ),
-    # -----------------------------------------------------------------------
-    # Welding (TSDC: WEL)
-    # -----------------------------------------------------------------------
     ProcessDefinition(
         canonical_id="welding",
         display_name="Welding",
@@ -317,11 +332,12 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         aliases=frozenset(
             {
                 "wel",
-                "welding",
                 "weld",
                 "welder",
+                "welding",
             }
         ),
+        wikidata_qid="Q12544",
     ),
     ProcessDefinition(
         canonical_id="tig_welding",
@@ -330,9 +346,9 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent="welding",
         aliases=frozenset(
             {
+                "tig",
                 "tig welding",
                 "tig_welding",
-                "tig",
             }
         ),
     ),
@@ -343,9 +359,9 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent="welding",
         aliases=frozenset(
             {
+                "mig",
                 "mig welding",
                 "mig_welding",
-                "mig",
             }
         ),
     ),
@@ -361,9 +377,6 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
             }
         ),
     ),
-    # -----------------------------------------------------------------------
-    # Brazing / Soldering (distinct from welding)
-    # -----------------------------------------------------------------------
     ProcessDefinition(
         canonical_id="brazing",
         display_name="Brazing",
@@ -371,16 +384,13 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent=None,
         aliases=frozenset(
             {
-                "brazing",
                 "braze",
+                "brazing",
                 "silver brazing",
                 "torch brazing",
             }
         ),
     ),
-    # -----------------------------------------------------------------------
-    # Sheet Metal
-    # -----------------------------------------------------------------------
     ProcessDefinition(
         canonical_id="sheet_metal_forming",
         display_name="Sheet Metal Forming",
@@ -391,14 +401,11 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
                 "sheet",
                 "sheet metal",
                 "sheet metal forming",
-                "sheet_metal_forming",
                 "sheet_metal",
+                "sheet_metal_forming",
             }
         ),
     ),
-    # -----------------------------------------------------------------------
-    # Other Manufacturing Processes
-    # -----------------------------------------------------------------------
     ProcessDefinition(
         canonical_id="injection_molding",
         display_name="Injection Molding",
@@ -407,8 +414,8 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         aliases=frozenset(
             {
                 "injection molding",
-                "injection_molding",
                 "injection moulding",
+                "injection_molding",
             }
         ),
     ),
@@ -419,10 +426,10 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent=None,
         aliases=frozenset(
             {
+                "water jet",
                 "water jet cutting",
                 "water_jet_cutting",
                 "waterjet",
-                "water jet",
             }
         ),
     ),
@@ -433,8 +440,8 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent=None,
         aliases=frozenset(
             {
-                "casting",
                 "cast",
+                "casting",
             }
         ),
     ),
@@ -445,8 +452,8 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent=None,
         aliases=frozenset(
             {
-                "forging",
                 "forge",
+                "forging",
             }
         ),
     ),
@@ -457,8 +464,8 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent=None,
         aliases=frozenset(
             {
-                "soldering",
                 "solder",
+                "soldering",
             }
         ),
     ),
@@ -469,8 +476,8 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent=None,
         aliases=frozenset(
             {
-                "drilling",
                 "drill",
+                "drilling",
             }
         ),
     ),
@@ -481,8 +488,8 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent=None,
         aliases=frozenset(
             {
-                "bending",
                 "bend",
+                "bending",
             }
         ),
     ),
@@ -493,8 +500,8 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent=None,
         aliases=frozenset(
             {
-                "grinding",
                 "grind",
+                "grinding",
             }
         ),
     ),
@@ -505,8 +512,8 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent=None,
         aliases=frozenset(
             {
-                "polishing",
                 "polish",
+                "polishing",
             }
         ),
     ),
@@ -517,8 +524,8 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent=None,
         aliases=frozenset(
             {
-                "sanding",
                 "sand",
+                "sanding",
             }
         ),
     ),
@@ -529,8 +536,8 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent=None,
         aliases=frozenset(
             {
-                "coating",
                 "coat",
+                "coating",
             }
         ),
     ),
@@ -541,9 +548,9 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent=None,
         aliases=frozenset(
             {
-                "anodizing",
                 "anodising",
                 "anodize",
+                "anodizing",
             }
         ),
     ),
@@ -554,11 +561,11 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent=None,
         aliases=frozenset(
             {
-                "electroplating",
-                "electroplate",
-                "plating",
                 "chrome plating",
+                "electroplate",
+                "electroplating",
                 "nickel plating",
+                "plating",
                 "zinc plating",
             }
         ),
@@ -570,9 +577,9 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent=None,
         aliases=frozenset(
             {
+                "heat treat",
                 "heat treatment",
                 "heat_treatment",
-                "heat treat",
             }
         ),
     ),
@@ -583,8 +590,8 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent="heat_treatment",
         aliases=frozenset(
             {
-                "annealing",
                 "anneal",
+                "annealing",
             }
         ),
     ),
@@ -595,8 +602,8 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent="heat_treatment",
         aliases=frozenset(
             {
-                "tempering",
                 "temper",
+                "tempering",
             }
         ),
     ),
@@ -607,8 +614,8 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent="heat_treatment",
         aliases=frozenset(
             {
-                "quenching",
                 "quench",
+                "quenching",
             }
         ),
     ),
@@ -619,11 +626,11 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent=None,
         aliases=frozenset(
             {
+                "cnc plasma",
+                "cnc plasma cutting",
+                "plasma cut",
                 "plasma cutting",
                 "plasma_cutting",
-                "plasma cut",
-                "cnc plasma cutting",
-                "cnc plasma",
             }
         ),
     ),
@@ -634,11 +641,11 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent=None,
         aliases=frozenset(
             {
-                "surface finishing",
-                "surface_finishing",
                 "surface finish",
-                "surface_finish",
+                "surface finishing",
                 "surface treatment",
+                "surface_finish",
+                "surface_finishing",
                 "surface_treatment",
             }
         ),
@@ -652,8 +659,8 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
             {
                 "post",
                 "post processing",
-                "post_processing",
                 "post-processing",
+                "post_processing",
                 "postprocessing",
             }
         ),
@@ -665,8 +672,8 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent=None,
         aliases=frozenset(
             {
-                "deburring",
                 "deburr",
+                "deburring",
             }
         ),
     ),
@@ -677,10 +684,11 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent=None,
         aliases=frozenset(
             {
-                "painting",
                 "paint",
+                "painting",
             }
         ),
+        wikidata_qid="Q11629",
     ),
     ProcessDefinition(
         canonical_id="cutting",
@@ -689,8 +697,8 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent=None,
         aliases=frozenset(
             {
-                "cutting",
                 "cut",
+                "cutting",
             }
         ),
     ),
@@ -701,8 +709,8 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent="cutting",
         aliases=frozenset(
             {
-                "sawing",
                 "saw",
+                "sawing",
             }
         ),
     ),
@@ -713,8 +721,8 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent="cutting",
         aliases=frozenset(
             {
-                "shearing",
                 "shear",
+                "shearing",
             }
         ),
     ),
@@ -725,11 +733,11 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         parent=None,
         aliases=frozenset(
             {
-                "testing",
-                "test equipment",
-                "test_equipment",
                 "quality control",
                 "quality_control",
+                "test equipment",
+                "test_equipment",
+                "testing",
             }
         ),
     ),
@@ -766,8 +774,8 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         aliases=frozenset(
             {
                 "cir",
-                "electronic circuitry",
                 "circuitry",
+                "electronic circuitry",
             }
         ),
     ),


### PR DESCRIPTION
Four commits that landed on the branch just after #287 was merged, so they were not part of it.

## 1. Near-miss handling (`13def9d`)

Results led with a percentage, so a facility that **cannot** build a design read as "Medium · 67%". Now:

- results lead with **coverage** — "Missing 1 of 4 requirements" / "Meets every requirement" — confidence demoted to a secondary line
- a tolerance control measured in **missing requirements**, bounded by design size: `ceiling = max(r-2, 0)`, `default = min(1, ceiling)`

A percentage is not comparable across designs — one gap is 50% in a 2-requirement design and 83% in a 6-requirement one. Counting gaps is both actionable and stable.

When the API returns no structured explanation, coverage is `null`, and the result is **shown** and labelled "Coverage unknown" rather than hidden. Treating absent data as "nothing missing" would quietly recreate the original bug.

### The a11y failures were not flaky

I twice called them flaky and re-ran to green. That was wrong. Forcing repeats reproduced **2–3 failures in every 5–8 runs**, and the reported colours were greys appearing in no stylesheet (`#4f4f4f` on `#a9a9a9`, *different each run*) — axe scanning **mid-fade**, where colours blend toward the background.

The helper now waits for animations to settle, bounded so a looping animation cannot hang the suite. 10/10 on the previously-failing spec, 72/72 under high parallelism, three consecutive clean gate runs.

## 2. Country names (`0f58436`)

Dropdowns mixed "France" with "BJ" because resolution used a hand-maintained table of ~46 countries and fell through to the raw value. The live network holds **140 distinct country values, 96 of them codes**.

Now `Intl.DisplayNames`, covering the whole ISO 3166-1 range — **verified against the 96 codes actually in production: all resolve, none unresolved.** `countryMatchKey` uses the same resolution, so a code and its full name no longer appear as two separate filter options.

Also adds the **Contact page** (contact@openhardwaremanager.org), a launch blocker.

## 3. Taxonomy drift gate + `vinyl_cutting` (`69864b6`)

`PROCESS_DEFINITIONS` and `processes.yaml` were hand-synchronised across 49 processes with nothing asserting they agreed. The literal is now generated, with `--check` as `make ready` step **8/11**.

Generated at commit time, not import time: deriving it at import would mean a corrupt YAML leaves **no fallback at all**, removing the safety net exactly when needed.

The generator black-formats its own output — otherwise `make format` rewrites the block, the generator disagrees with disk, and the gate cries wolf on every run.

Verified: only the literal changes (header and tail byte-identical), the taxonomy is equivalent across all fields, `--check` survives `make format`, and injected drift exits 1.

With that, `vinyl_cutting` is one YAML edit plus a regenerate. All of MoM's `skos:altLabel` values resolve, including their exact `vinyl-cutting` prefLabel.

## 4. Frontend CI gate (`e33e66a`)

**The frontend had no CI coverage at all** — nothing ran typecheck, lint, unit tests, the build, or the Playwright/a11y suite. That is how a unit test broken by 0.10.2 sat red on main until someone ran the gate locally, and it left the accessibility suite unenforced.

Runs `frontend-ready`, the same signal used locally, so CI and a developer's machine agree on what green means. Chromium only; uploads traces and the HTML report on failure, with paths verified against what Playwright actually writes.

Verified locally with `CI=true` (which enables `forbidOnly` and one retry): 72 tests pass.

---

`make ready` 11/11 · `frontend-ready` all stages.

**This PR is where the new frontend job first runs in CI** — it wasn't on main when #287 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)