### PR TITLE
Release 0.10.4: docs site live, digest deploys, clone-by-default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.4] - 2026-07-27
+
+### Added
+
+- **The documentation site is actually served**, at `/docs` on the app's own
+  origin, with a nav link and a route back to the app from every page. It had
+  been built and gated but never deployed: `/docs` returned HTTP 200 only
+  because the SPA catch-all answers every unknown path, so nothing looked wrong.
+- **Search the network by name.** The site's primary call to action is "find your
+  workshop", and among ~3,200 spaces there was no way to type a name. Matches on
+  name, city, and country, ignoring accents, punctuation, and word order.
+- **Near-miss tolerance on match results.** A slider measured in *missing
+  requirements* rather than a percentage, bounded by the design's size
+  (`max(r-2, 0)`, defaulting to one gap) — one gap means something different in
+  a design with two requirements than in one with six.
+- **Guided form for "New design".** It previously accepted only pasted JSON,
+  which asks the author to already know the OKH format. It now opens the same
+  tiered editor the URL import uses; pasting JSON remains one click away.
+- **Contact page**, at contact@openhardwaremanager.org.
+- **`vinyl_cutting`** process. Maps of Making publishes a `vinyl-cutting`
+  activity OHM had no process for, so those spaces' capability was dropped on
+  ingest.
+- **Taxonomy drift gate.** `PROCESS_DEFINITIONS` is generated from
+  `processes.yaml`, with `--check` as `make ready` step 8/11. The two were
+  hand-synchronised across 49 processes with nothing asserting they agreed.
+- **The frontend gate now runs in CI** — typecheck, lint, unit, build, and the
+  Playwright/a11y suite. It had no CI coverage at all.
+
+### Changed
+
+- **Cloning is the default extraction path** for generate-from-URL, with
+  automatic fallback to the platform API if a clone fails. A public clone needs
+  no credential, so self-hosted instances work out of the box and the hosted
+  instance no longer subsidises every user's extraction through one shared,
+  rate-limited token. Measured on `RespiraWorks/Ventilator`: API path 504 after
+  120s, repeatedly; clone path 200 in ~21s.
+- **Match results lead with coverage, not a score.** "Missing 1 of 4
+  requirements" or "Meets every requirement", with confidence demoted to a
+  secondary line.
+- **Deploys pin image digests** instead of a mutable tag, and assert build
+  identity afterwards — images now carry `GIT_SHA`, reported at `/health` as
+  `build` and served at `/build-info.json`.
+
+### Fixed
+
+- **Deploys were silently doing nothing.** Publishing 0.10.3 overwrote the
+  release tag with a new digest, then the deploy set the same image reference
+  already running — so Container Apps created no revision and the previous image
+  kept serving, while both deploy jobs reported success. Every check tested
+  liveness rather than identity, and the stale image reported the same version.
+- **Full country names everywhere.** Filters mixed "France" with "BJ": name
+  resolution used a hand-maintained table of ~46 countries against a network
+  holding 140 distinct values, 96 of them codes. Now resolved via
+  `Intl.DisplayNames` — verified against all 96 codes in production. A code and
+  its full name also no longer appear as two separate filter options.
+- **Generation timeouts no longer report themselves as user cancellations**,
+  which left no clue whether to retry, wait, or give up.
+- **Accessibility:** 19 serious contrast violations in the tiered editor, and a
+  pre-existing one in the design picker's selected row. The a11y helper also
+  scanned mid-animation, producing intermittent failures against colours that
+  exist in no stylesheet; it now waits for animations to settle.
+
 ## [0.10.3] - 2026-07-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Open Hardware Manager (OHM) is a flexible, domain-agnostic framework designe
 
 OHM exposes a FastAPI-based HTTP API that can be run locally via Docker Compose, from a [published Docker image](https://hub.docker.com/r/touchthesun/openhardwaremanager), or deployed serverlessly using the configurations in `deploy/`.
 
-**Current release:** `0.10.3` — see [CHANGELOG.md](CHANGELOG.md) and [Release process](docs/RELEASE.md).
+**Current release:** `0.10.4` — see [CHANGELOG.md](CHANGELOG.md) and [Release process](docs/RELEASE.md).
 
 ## Quick Start for New Users
 
@@ -28,11 +28,11 @@ After installing, open a new terminal so the tools are on your PATH.
 **Local storage (no credentials needed):**
 
 ```bash
-docker pull touchthesun/openhardwaremanager:0.10.3
+docker pull touchthesun/openhardwaremanager:0.10.4
 docker run -p 8001:8001 \
   -e STORAGE_PROVIDER=local \
   -e LLM_ENABLED=false \
-  touchthesun/openhardwaremanager:0.10.3
+  touchthesun/openhardwaremanager:0.10.4
 ```
 
 **Remote storage (Azure Blob, AWS S3, or GCS):**
@@ -43,7 +43,7 @@ The published image does not include a `.env` file — you must pass your storag
 # Copy the template, fill in your provider and credentials, then:
 docker run -p 8001:8001 \
   --env-file .env \
-  touchthesun/openhardwaremanager:0.10.3
+  touchthesun/openhardwaremanager:0.10.4
 ```
 
 The minimum `.env` keys for Azure Blob are:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "supply-graph-ai"
-version = "0.10.3"
+version = "0.10.4"
 description = "Open Hardware Manager (OHM) - A flexible, domain-agnostic framework for matching requirements with capabilities"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -3208,7 +3208,7 @@ wheels = [
 
 [[package]]
 name = "supply-graph-ai"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Version bump only — all the code is already on main. Bumps `pyproject.toml` and the two README claims via `scripts/bump_version.py`, relocks, and adds the CHANGELOG entry by hand (the registry deliberately excludes historical records).

## What ships in 0.10.4

**The documentation site is actually served**, at `/docs`. It had been built, gated, and written — but never deployed, and `/docs` returned HTTP 200 the whole time because the SPA catch-all answers every unknown path.

**Deploys pin image digests and assert build identity.** 0.10.3 published, deployed, and reported success while the containers kept serving the previous image: the deploy set an image reference identical to what was already running, so Container Apps created no revision. Every check tested liveness, and the stale image reported the same version number.

**generate-from-URL clones by default**, with automatic fallback to the API path. On `RespiraWorks/Ventilator`: API path 504 after 120s, repeatedly; clone path 200 in ~21s.

Plus: network name search, near-miss tolerance measured in missing requirements, a guided form for New design, the Contact page, full country names everywhere, the taxonomy drift gate, and the frontend gate finally running in CI.

## Verification

`make ready` 11/11, including the two new gates (`docs-status`, `taxonomy-check`). `frontend-ready` all stages.

## Deploy notes

This deploy is the first that will genuinely roll over — 0.10.3's did not. Two things confirm it rather than assume it:

- `/health` reports `build` (the commit SHA), and the deploy job polls until it matches what was just published
- the frontend deploy asserts the docs site serves real content, and that a missing docs page 404s rather than falling through to the app shell

If either is wrong, the deploy fails loudly instead of reporting success.

Worth checking by hand once it lands, since neither has run against production before: `/docs` from the nav, and `clone=true` generation on a substantial repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)