### PR TITLE
Designs page performance, usable city filter, and MoM doc accuracy

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 582
+Total Python files: 583
 
 ├── deploy/
 │   ├── __init__.py
@@ -1582,7 +1582,7 @@ Total Python files: 582
 │       │   │       class OkhLoshConversionError
 │       │   │       class OkhLoshConverter (okh_losh_to_okh, _pick_primary_image)
 │       │   ├── okh_service.py
-│       │   │       class OKHService (__init__, _provenance_store, _visibility_store)
+│       │   │       class OKHService (__init__, _provenance_store, _visibility_store...)
 │       │   ├── okw_service.py
 │       │   │       class OKWService (__init__, _provenance_store, _visibility_store...)
 │       │   │       def _normalize_status()
@@ -2560,6 +2560,16 @@ Total Python files: 582
         │       def test_rejected_keys_suppress_reharvest()
         ├── test_mom_okw_source_routing.py
         │       def _mock_network()
+        ├── test_okh_catalog_performance.py
+        │       class FakeStorageManager (__init__)
+        │       class FakeStorage (__init__)
+        │       class TestConcurrency
+        │       class TestCaching
+        │       class TestSemanticsPreserved
+        │       def manifest_dict()
+        │       def file_info()
+        │       def build_service()
+        │       def _isolate_cache()
         ├── test_okh_collection.py
         │       def _manifest()
         │       def test_export_returns_bytes()
@@ -2885,7 +2895,7 @@ Total Python files: 582
 
 ## Overview
 
-Total files analyzed: 582
+Total files analyzed: 583
 
 ## Entry Points
 
@@ -10529,6 +10539,29 @@ Tests current behavior of BaseMatchingLayer uti...
 Since the union-default change, all sourc...
 
 **Internal Dependencies:** 10 imports
+
+### `tests/unit/test_okh_catalog_performance.py`
+> The OKH catalogue is assembled concurrently and cached.
+
+Rendering the Designs page cost ~15s becaus...
+
+**Exports:** manifest_dict, FakeStorageManager, FakeStorage, file_info, build_service
+
+**Classes:**
+- `FakeStorageManager`
+  - Records concurrency and can simulate per-object latency....
+- `FakeStorage`
+- `TestConcurrency`
+- `TestCaching`
+- `TestSemanticsPreserved`
+
+**Functions:**
+- `manifest_dict(manifest_id, title)`
+  - The minimum shape OKHService.list accepts as a manifest....
+- `file_info(key, minutes_old)`
+- `build_service(objects, latency)`
+
+**Internal Dependencies:** 4 imports
 
 ### `tests/unit/test_okh_collection.py`
 > Unit tests for OKH bulk import/export/diff (issue #176)....

--- a/docs-site/docs/about/meet-people-where-they-are.md
+++ b/docs-site/docs/about/meet-people-where-they-are.md
@@ -38,9 +38,8 @@ in OHM without having done anything or agreed to anything with us.
 
 It's worth being precise about how that data works, because it's easy to assume
 the worst. In the case of Maps of Making, each space publishes a small file **on
-its own website**, and the map is assembled by finding those files. The
-information belongs to the space and is hosted by the space. The map — and OHM —
-are readers.
+its own endpoint**, which the map reads. The information belongs to the space
+and is hosted by the space. The map — and OHM — are readers.
 
 So this is not a case of workshops being scraped into someone else's database.
 It's a case of workshops publishing about themselves, and more than one thing

--- a/docs-site/docs/guides/find-your-space.md
+++ b/docs-site/docs/guides/find-your-space.md
@@ -53,7 +53,7 @@ You can add your workshop directly. See
 [list or enrich your facility](list-or-enrich-your-facility.md).
 
 Worth knowing first: if your space publishes its details through Maps of Making,
-that information lives **on your own website** and is read from there. Adding a
+that information lives **at your own endpoint** and is read from there. Adding a
 record in OHM is a separate thing from that, not a replacement for it, and it
 doesn't move anything away from you.
 

--- a/docs-site/docs/reference/standards-and-ecosystem.md
+++ b/docs-site/docs/reference/standards-and-ecosystem.md
@@ -33,9 +33,9 @@ OHM implements both. See [OKH and OKW](okh-and-okw.md).
 of most facilities visible in OHM.
 
 Its design is worth understanding, because it's unusually good: each space
-publishes a small file **on its own website**, and the map is assembled by finding
-those files. The data belongs to the space, hosted by the space. Maps of Making
-reads it. So does OHM.
+publishes **its own data at its own endpoint**, which the map reads. The data
+belongs to the space and is hosted by the space; Maps of Making reads it, and so
+does OHM.
 
 It's also worth being straight about the limitation, since it shapes what OHM can
 currently do. That vocabulary describes what a space is *about* — digital

--- a/frontend/src/features/match/FacilityFilter.test.tsx
+++ b/frontend/src/features/match/FacilityFilter.test.tsx
@@ -130,3 +130,45 @@ describe("FacilityFilter", () => {
     expect(onChange).toHaveBeenLastCalledWith([]);
   });
 });
+
+describe("city options", () => {
+  const messy: FacilityOption[] = [
+    { id: "a", name: "A", city: "1050 Wien", region: null, country: "AT", source: "mom" },
+    { id: "b", name: "B", city: "1070 Wien", region: null, country: "AT", source: "mom" },
+    { id: "c", name: "C", city: "-- .", region: null, country: "AT", source: "mom" },
+    { id: "d", name: "D", city: "Apenrader Str. 49", region: null, country: "DE", source: "mom" },
+    { id: "e", name: "E", city: "Berlin", region: null, country: "DE", source: "mom" },
+  ];
+
+  function cityNames() {
+    const select = screen.getByLabelText("City") as HTMLSelectElement;
+    return [...select.options].map((o) => o.text).filter((t) => t !== "All cities");
+  }
+
+  it("drops artifacts and merges postal-code variants", () => {
+    render(
+      <FacilityFilter facilities={messy} selectedIds={[]} onChange={vi.fn()} />,
+    );
+    const names = cityNames();
+    expect(names).toContain("Wien");
+    expect(names).toContain("Berlin");
+    // One Vienna, not two.
+    expect(names.filter((n) => n === "Wien")).toHaveLength(1);
+    expect(names).not.toContain("-- .");
+    expect(names).not.toContain("Apenrader Str. 49");
+  });
+
+  it("constrains cities to the selected country", async () => {
+    render(
+      <FacilityFilter facilities={messy} selectedIds={[]} onChange={vi.fn()} />,
+    );
+    expect(cityNames()).toContain("Berlin");
+
+    await userEvent.selectOptions(screen.getByLabelText("Country"), "Austria");
+
+    // Cities outside the chosen country are unselectable anyway — the geo
+    // filters are AND-ed — so offering them is noise.
+    expect(cityNames()).toContain("Wien");
+    expect(cityNames()).not.toContain("Berlin");
+  });
+});

--- a/frontend/src/features/match/FacilityFilter.tsx
+++ b/frontend/src/features/match/FacilityFilter.tsx
@@ -124,8 +124,7 @@ export function FacilityFilter({
     ),
     [countryScoped],
   );
-  // Normalised: the raw field holds postal codes, street addresses, and
-  // punctuation artifacts alongside real names. See network/cityNames.
+  // Raw city values include postal codes and addresses — see network/cityNames.
   const cityOptions = useMemo(
     () => normalizedCityOptions(countryScoped.map((f) => f.city)),
     [countryScoped],

--- a/frontend/src/features/match/FacilityFilter.tsx
+++ b/frontend/src/features/match/FacilityFilter.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { normalizedCityOptions } from "../network/cityNames";
 import {
   cityMatchKey,
   countryMatchKey,
@@ -106,19 +107,28 @@ export function FacilityFilter({
     ),
     [sourceScoped],
   );
+  // Region and city options are scoped to the chosen country. Offering every
+  // city in the world while a country is selected makes the list unusable and
+  // most of it unselectable — the geo filters are AND-ed, so a city outside the
+  // chosen country matches nothing.
+  const countryScoped = useMemo(() => {
+    if (!geo.country) return sourceScoped;
+    const want = countryMatchKey(geo.country);
+    return sourceScoped.filter((f) => countryMatchKey(f.country) === want);
+  }, [sourceScoped, geo.country]);
+
   const regionOptions = useMemo(
     () => uniqueSorted(
-      sourceScoped.map((f) => f.region),
+      countryScoped.map((f) => f.region),
       displayRegionName,
     ),
-    [sourceScoped],
+    [countryScoped],
   );
+  // Normalised: the raw field holds postal codes, street addresses, and
+  // punctuation artifacts alongside real names. See network/cityNames.
   const cityOptions = useMemo(
-    () => uniqueSorted(
-      sourceScoped.map((f) => f.city),
-      (v) => v,
-    ),
-    [sourceScoped],
+    () => normalizedCityOptions(countryScoped.map((f) => f.city)),
+    [countryScoped],
   );
 
   const geoFiltered = useMemo(
@@ -244,9 +254,9 @@ export function FacilityFilter({
                 onChange={(e) => setGeoField("city", e.target.value)}
               >
                 <option value="">All cities</option>
-                {cityOptions.map((o) => (
-                  <option key={o.value} value={o.value}>
-                    {o.label}
+                {cityOptions.map((name) => (
+                  <option key={name} value={name}>
+                    {name}
                   </option>
                 ))}
               </select>

--- a/frontend/src/features/match/geoDisplay.ts
+++ b/frontend/src/features/match/geoDisplay.ts
@@ -1,3 +1,5 @@
+import { normalizeCityName } from "../network/cityNames";
+
 /**
  * Display helpers so geo filter UIs always show full names, even when
  * facility payloads store ISO country codes or US state abbreviations.
@@ -185,5 +187,8 @@ export function regionMatchKey(raw: string | null | undefined): string {
 }
 
 export function cityMatchKey(raw: string | null | undefined): string {
-  return (raw ?? "").trim().toLowerCase();
+  // Normalised, so a facility stored as "1050 Wien" matches the "Wien" option.
+  // The filter dropdown offers normalised names; comparing raw values here
+  // would mean selecting a city silently matched nothing.
+  return (normalizeCityName(raw) ?? (raw ?? "").trim()).toLowerCase();
 }

--- a/frontend/src/features/match/geoDisplay.ts
+++ b/frontend/src/features/match/geoDisplay.ts
@@ -190,5 +190,5 @@ export function cityMatchKey(raw: string | null | undefined): string {
   // Normalised, so a facility stored as "1050 Wien" matches the "Wien" option.
   // The filter dropdown offers normalised names; comparing raw values here
   // would mean selecting a city silently matched nothing.
-  return (normalizeCityName(raw) ?? (raw ?? "").trim()).toLowerCase();
+  return (normalizeCityName(raw) ?? raw ?? "").trim().toLowerCase();
 }

--- a/frontend/src/features/network/cityNames.test.ts
+++ b/frontend/src/features/network/cityNames.test.ts
@@ -11,6 +11,8 @@ describe("drops values that are not city names", () => {
   });
 
   it.each([
+    // Regression: stripping the leading "134 " first would leave "Avenue du
+    // Général Leclerc", with no digit left for the address check to catch.
     "134 Avenue du Général Leclerc",
     "Apenrader Str. 49",
     "Neckarauer Straße 106-116",
@@ -19,12 +21,6 @@ describe("drops values that are not city names", () => {
     "Room 201 & 203 (2nd Floor) , 60 Avenue Victor Hugo , L-1750 Luxemburg",
   ])("drops the street address %j", (raw) => {
     expect(normalizeCityName(raw)).toBeNull();
-  });
-
-  it("drops an address even when its house number looks like a postal code", () => {
-    // Regression: stripping "134 " first left "Avenue du Général Leclerc",
-    // which no longer had a digit for the address check to catch.
-    expect(normalizeCityName("134 Avenue du Général Leclerc")).toBeNull();
   });
 
   it("drops empty and whitespace input", () => {

--- a/frontend/src/features/network/cityNames.test.ts
+++ b/frontend/src/features/network/cityNames.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCityName, normalizedCityOptions } from "./cityNames";
+
+// Every value below is real, taken from the live network's 2,021 distinct city
+// values. The false-positive cases matter most: dropping a legitimate city
+// hides real facilities, which is worse than showing one odd entry.
+
+describe("drops values that are not city names", () => {
+  it.each(["-", "--", "-- .", "107-0052"])("drops %j", (raw) => {
+    expect(normalizeCityName(raw)).toBeNull();
+  });
+
+  it.each([
+    "134 Avenue du Général Leclerc",
+    "Apenrader Str. 49",
+    "Neckarauer Straße 106-116",
+    "Palackého třída 742/82",
+    "7 Place Louis Chazette 69001 Lyon",
+    "Room 201 & 203 (2nd Floor) , 60 Avenue Victor Hugo , L-1750 Luxemburg",
+  ])("drops the street address %j", (raw) => {
+    expect(normalizeCityName(raw)).toBeNull();
+  });
+
+  it("drops an address even when its house number looks like a postal code", () => {
+    // Regression: stripping "134 " first left "Avenue du Général Leclerc",
+    // which no longer had a digit for the address check to catch.
+    expect(normalizeCityName("134 Avenue du Général Leclerc")).toBeNull();
+  });
+
+  it("drops empty and whitespace input", () => {
+    expect(normalizeCityName("")).toBeNull();
+    expect(normalizeCityName("   ")).toBeNull();
+    expect(normalizeCityName(null)).toBeNull();
+  });
+});
+
+describe("cleans up recoverable values", () => {
+  it.each([
+    ["1050 Wien", "Wien"],
+    ["4040 Linz", "Linz"],
+    ["9403 Goldach", "Goldach"],
+    ["114 28 Stockholm", "Stockholm"], // Swedish two-group postal code
+    ["212 18 Malmö", "Malmö"],
+    ["9000 St.Gallen", "St.Gallen"], // "St." is Saint, not Street
+  ])("strips the postal code from %j", (raw, want) => {
+    expect(normalizeCityName(raw)).toBe(want);
+  });
+
+  it("unwraps a fully parenthesised name", () => {
+    expect(normalizeCityName("(Incheon)")).toBe("Incheon");
+  });
+
+  it("strips a leading slash", () => {
+    expect(normalizeCityName("/Stavropol'")).toBe("Stavropol'");
+  });
+});
+
+describe("leaves legitimate names alone", () => {
+  it.each([
+    "'s-Hertogenbosch", // leading apostrophe is part of the name
+    "Halle (Saale)", // internal parens are the actual name
+    "Kempten (Allgäu)",
+    "Biel/Bienne", // bilingual name, not a separator
+    "Schwedt/Oder",
+    "Böblingen/Sindelfingen",
+    "ST BENOIT DE CARMAUX", // "ST" is Saint
+    "Aarhus N",
+    "A Coruna",
+    "Sheepscar Street South", // street word, but no number
+    "Abidjan, Bingerville",
+  ])("keeps %j unchanged", (raw) => {
+    expect(normalizeCityName(raw)).toBe(raw);
+  });
+});
+
+describe("normalizedCityOptions", () => {
+  it("collapses variants that normalise to the same name", () => {
+    const options = normalizedCityOptions([
+      "1050 Wien",
+      "1070 Wien",
+      "1220 Wien",
+      "Wien",
+    ]);
+    expect(options).toEqual(["Wien"]);
+  });
+
+  it("sorts and removes the unusable entries", () => {
+    const options = normalizedCityOptions(["Zürich", "-", "Aachen", "107-0052"]);
+    expect(options).toEqual(["Aachen", "Zürich"]);
+  });
+
+  it("is case-insensitive when deduping but keeps the first spelling", () => {
+    expect(normalizedCityOptions(["Berlin", "berlin", "BERLIN"])).toEqual(["Berlin"]);
+  });
+
+  it("handles an empty input", () => {
+    expect(normalizedCityOptions([])).toEqual([]);
+  });
+});

--- a/frontend/src/features/network/cityNames.ts
+++ b/frontend/src/features/network/cityNames.ts
@@ -1,0 +1,88 @@
+/**
+ * City-name normalisation for filter options (pure, unit-tested).
+ *
+ * Facility records carry whatever a space typed, so the city field holds a
+ * minority of postal codes, street addresses, and punctuation artifacts
+ * alongside real names. Left alone they fill the filter with entries like
+ * "-- .", "134 Avenue du Général Leclerc", and three separate Viennas
+ * ("1050 Wien", "1070 Wien", "1220 Wien").
+ *
+ * The rules are deliberately conservative, because most of what *looks*
+ * malformed is not:
+ *
+ *   's-Hertogenbosch      leading apostrophe is part of the name
+ *   Halle (Saale)         parenthesised qualifier is the actual name
+ *   Biel/Bienne           bilingual name, not a separator
+ *   Schwedt/Oder          likewise
+ *   Kempten (Allgäu)      likewise
+ *   ST BENOIT DE CARMAUX  "ST" is Saint, not Street
+ *
+ * Dropping a real city hides real facilities, which is worse than showing one
+ * odd entry. So this only fixes the unambiguous cases and leaves the rest.
+ *
+ * Safe to normalise for filtering because the API matches city as a
+ * case-insensitive SUBSTRING — sending "Wien" still matches "1050 Wien".
+ */
+
+/** Street words that indicate an address ONLY when digits are present too. */
+const STREET_WORDS =
+  /\b(street|str|straße|strasse|avenue|ave|road|rd|lane|weg|třída|vej|place)\b\.?/i;
+
+/**
+ * Normalise one raw city value.
+ *
+ * Returns null when the value is not a usable city name, so callers drop it
+ * rather than showing it as an option.
+ */
+export function normalizeCityName(raw: string | null | undefined): string | null {
+  let s = (raw ?? "").trim();
+  if (!s) return null;
+
+  // No letters at all: "-", "--", "-- .", "107-0052" (a bare postal code).
+  if (!/\p{L}/u.test(s)) return null;
+
+  // Whole value wrapped in parentheses: "(Incheon)" -> "Incheon".
+  // Deliberately not applied to "Halle (Saale)", where the parens are internal.
+  const wrapped = s.match(/^\((.+)\)$/);
+  if (wrapped) s = wrapped[1].trim();
+
+  // A leading slash is an artifact ("/Stavropol'"); an internal one is a real
+  // bilingual name ("Biel/Bienne"), so only the leading case is stripped.
+  s = s.replace(/^\/+/, "").trim();
+
+  // Address-like: a street word AND a number. Either alone is too common in
+  // legitimate names to act on ("ST BENOIT DE CARMAUX" is Saint; "Neckarauer
+  // Straße 106-116" is an address).
+  //
+  // Checked BEFORE the postal-code strip: "134 Avenue du Général Leclerc" would
+  // otherwise lose its house number first and survive as a street name.
+  if (STREET_WORDS.test(s) && /\d/.test(s)) return null;
+
+  // Leading postal code: "1050 Wien", "114 28 Stockholm", "212 18 Malmö".
+  // Requires 3+ digits so house numbers ("7 Place …") are not mistaken for one.
+  s = s.replace(/^\d{3,5}(\s+\d{2})?\s+/, "").trim();
+
+  // Re-check: stripping may have left nothing usable.
+  if (!/\p{L}/u.test(s)) return null;
+
+  return s;
+}
+
+/**
+ * Distinct, sorted, normalised city names.
+ *
+ * Values that normalise to the same name collapse, which is what merges the
+ * three Viennas into one option.
+ */
+export function normalizedCityOptions(
+  raws: (string | null | undefined)[],
+): string[] {
+  const seen = new Map<string, string>();
+  for (const raw of raws) {
+    const name = normalizeCityName(raw);
+    if (!name) continue;
+    const key = name.toLowerCase();
+    if (!seen.has(key)) seen.set(key, name);
+  }
+  return [...seen.values()].sort((a, b) => a.localeCompare(b));
+}

--- a/frontend/src/features/network/cityNames.ts
+++ b/frontend/src/features/network/cityNames.ts
@@ -20,8 +20,10 @@
  * Dropping a real city hides real facilities, which is worse than showing one
  * odd entry. So this only fixes the unambiguous cases and leaves the rest.
  *
- * Safe to normalise for filtering because the API matches city as a
- * case-insensitive SUBSTRING — sending "Wien" still matches "1050 Wien".
+ * Both filters that consume this agree with it: the API matches city as a
+ * case-insensitive substring, so "Wien" still matches "1050 Wien"; and
+ * `cityMatchKey` normalises before comparing, because it matches exactly and
+ * would otherwise find nothing for a normalised option.
  */
 
 /** Street words that indicate an address ONLY when digits are present too. */
@@ -43,8 +45,7 @@ export function normalizeCityName(raw: string | null | undefined): string | null
 
   // Whole value wrapped in parentheses: "(Incheon)" -> "Incheon".
   // Deliberately not applied to "Halle (Saale)", where the parens are internal.
-  const wrapped = s.match(/^\((.+)\)$/);
-  if (wrapped) s = wrapped[1].trim();
+  s = s.replace(/^\((.+)\)$/, "$1").trim();
 
   // A leading slash is an artifact ("/Stavropol'"); an internal one is a real
   // bilingual name ("Biel/Bienne"), so only the leading case is stripped.
@@ -60,12 +61,7 @@ export function normalizeCityName(raw: string | null | undefined): string | null
 
   // Leading postal code: "1050 Wien", "114 28 Stockholm", "212 18 Malmö".
   // Requires 3+ digits so house numbers ("7 Place …") are not mistaken for one.
-  s = s.replace(/^\d{3,5}(\s+\d{2})?\s+/, "").trim();
-
-  // Re-check: stripping may have left nothing usable.
-  if (!/\p{L}/u.test(s)) return null;
-
-  return s;
+  return s.replace(/^\d{3,5}(\s+\d{2})?\s+/, "").trim();
 }
 
 /**

--- a/src/core/services/okh_service.py
+++ b/src/core/services/okh_service.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import traceback
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
@@ -28,6 +29,7 @@ from ..storage.smart_discovery import (
     SmartFileDiscovery,
     minimal_okh_manifest_dict,
 )
+from ..cache.helper import cached
 from ..utils.logging import get_logger
 from ..validation.error_codes import VALIDATION_ERROR_CODE, VALIDATION_WARNING_CODE
 from ..validation.uuid_validator import UUIDValidator
@@ -38,6 +40,22 @@ if TYPE_CHECKING:
     from ..generation.engine import GenerationEngine
 
 logger = get_logger(__name__)
+
+# Blob reads issued at once when assembling the catalogue. Objects were
+# previously read one at a time, so the cost was one network round trip per
+# object in sequence — 287 of them in production, which is most of where the
+# ~7s catalogue load went. Bounded so a large catalogue cannot exhaust the
+# storage client's connection pool.
+CATALOG_FETCH_CONCURRENCY = 16
+
+# The assembled catalogue is cached so paging through it does not repeat the
+# whole scan; pagination is applied after assembly, so every page previously
+# paid the full cost. Writes invalidate the entry, so the TTL only covers
+# changes that bypass this service — a federation ingest, or another replica.
+CATALOG_CACHE_TTL_SECONDS = 120
+CATALOG_CACHE_SERVICE = "okh"
+CATALOG_CACHE_OPERATION = "catalog"
+CATALOG_CACHE_KEY = "all"
 
 
 async def extract_project_data(
@@ -203,6 +221,7 @@ class OKHService(BaseService["OKHService"]):
                     str(manifest.id), DEFAULT_VISIBILITY
                 )
 
+            self._invalidate_catalog_cache()
             return manifest
 
     def _provenance_store(self) -> ProvenanceStore:
@@ -409,60 +428,101 @@ class OKHService(BaseService["OKHService"]):
                 self.logger.warning("Storage service not available or not configured")
                 return [], 0
 
-            # Use smart discovery to find OKH files
-            discovery = SmartFileDiscovery(self.storage.manager)
-            file_infos = await discovery.discover_files("okh")
+            # The catalogue (discover -> fetch -> parse -> dedupe) is expensive
+            # and identical for every page, so it is assembled once and cached.
+            # Raw dicts are cached rather than OKHManifest objects: the Redis
+            # backend serialises with json.dumps(default=str), which would
+            # silently turn objects into strings, and to_dict() is a whitelist
+            # that drops ohm_* keys. Caching what we already feed to from_dict
+            # keeps the cached path identical to the uncached one.
+            raw_manifests = await cached(
+                service=CATALOG_CACHE_SERVICE,
+                operation=CATALOG_CACHE_OPERATION,
+                key=CATALOG_CACHE_KEY,
+                ttl_seconds=CATALOG_CACHE_TTL_SECONDS,
+                loader=self._assemble_okh_catalog,
+            )
 
-            self.logger.info(f"Found {len(file_infos)} OKH files using smart discovery")
+            all_manifests = [OKHManifest.from_dict(d) for d in raw_manifests]
+            total = len(all_manifests)
 
-            # Load and deduplicate manifests by ID (keep most recent)
-            manifest_map: Dict[UUID, Tuple[FileInfo, OKHManifest]] = {}
-            for file_info in file_infos:
+            start_idx = (page - 1) * page_size
+            paginated_manifests = all_manifests[start_idx : start_idx + page_size]
+
+            return paginated_manifests, total
+
+    def _invalidate_catalog_cache(self) -> None:
+        """Drop the cached catalogue after a write.
+
+        Without this a newly created design would not appear in the list until
+        the TTL expired, which is exactly the moment someone goes looking for it.
+        """
+        from ..cache.keys import namespaced_key
+        from .cache_service import get_cache_service
+
+        cache = get_cache_service()
+        cache.delete(
+            namespaced_key(
+                prefix=cache.key_prefix,
+                service=CATALOG_CACHE_SERVICE,
+                operation=CATALOG_CACHE_OPERATION,
+                key=CATALOG_CACHE_KEY,
+            )
+        )
+
+    async def _assemble_okh_catalog(self) -> List[Dict[str, Any]]:
+        """Discover, load and dedupe every OKH manifest under ``okh/``.
+
+        Returns raw manifest dicts, one per id — exactly what :meth:`list`
+        feeds to ``OKHManifest.from_dict``, so the cached and uncached paths
+        build identical objects.
+        """
+        discovery = SmartFileDiscovery(self.storage.manager)
+        file_infos = await discovery.discover_files("okh")
+        self.logger.info(f"Found {len(file_infos)} OKH files using smart discovery")
+
+        semaphore = asyncio.Semaphore(CATALOG_FETCH_CONCURRENCY)
+
+        async def load(file_info: FileInfo):
+            """``(file_info, id, raw_dict)``, or None when the object is unusable."""
+            async with semaphore:
                 try:
                     data = await self.storage.manager.get_object(file_info.key)
-                    content = data.decode("utf-8")
-                    okh_data = json.loads(content)
-
-                    # Validate and fix UUID issues
-                    fixed_okh_data = UUIDValidator.validate_and_fix_okh_data(okh_data)
-                    if not minimal_okh_manifest_dict(fixed_okh_data):
+                    fixed = UUIDValidator.validate_and_fix_okh_data(
+                        json.loads(data.decode("utf-8"))
+                    )
+                    if not minimal_okh_manifest_dict(fixed):
                         self.logger.warning(
                             "Skipping OKH storage key %s: not a minimal OKH manifest "
                             "(e.g. standalone BOM JSON or incomplete file)",
                             file_info.key,
                         )
-                        continue
-                    manifest = OKHManifest.from_dict(fixed_okh_data)
-
-                    # Deduplicate by ID, keeping the most recently modified
-                    if manifest.id not in manifest_map:
-                        manifest_map[manifest.id] = (file_info, manifest)
-                    else:
-                        existing_file_info, _ = manifest_map[manifest.id]
-                        if hasattr(file_info, "last_modified") and hasattr(
-                            existing_file_info, "last_modified"
-                        ):
-                            if (
-                                file_info.last_modified
-                                > existing_file_info.last_modified
-                            ):
-                                manifest_map[manifest.id] = (file_info, manifest)
-                                self.logger.debug(
-                                    f"Replacing duplicate manifest {manifest.id} with more recent version from {file_info.key}"
-                                )
+                        return None
+                    return file_info, OKHManifest.from_dict(fixed).id, fixed
                 except Exception as e:
                     self.logger.error(f"Failed to load OKH file {file_info.key}: {e}")
-                    continue
+                    return None
 
-            # Convert to list and apply pagination
-            all_manifests = [manifest for _, manifest in manifest_map.values()]
-            total = len(all_manifests)
+        loaded = await asyncio.gather(*(load(fi) for fi in file_infos))
 
-            start_idx = (page - 1) * page_size
-            end_idx = start_idx + page_size
-            paginated_manifests = all_manifests[start_idx:end_idx]
+        # Dedupe by id, newest file wins. gather preserves input order, so this
+        # sees the same sequence the previous sequential loop did.
+        winners: Dict[UUID, Tuple[FileInfo, Dict[str, Any]]] = {}
+        for entry in loaded:
+            if entry is None:
+                continue
+            file_info, manifest_id, raw = entry
+            existing = winners.get(manifest_id)
+            if existing is None:
+                winners[manifest_id] = (file_info, raw)
+                continue
+            existing_info, _ = existing
+            new_mtime = getattr(file_info, "last_modified", None)
+            old_mtime = getattr(existing_info, "last_modified", None)
+            if new_mtime and old_mtime and new_mtime > old_mtime:
+                winners[manifest_id] = (file_info, raw)
 
-            return paginated_manifests, total
+        return [raw for _, raw in winners.values()]
 
     async def list_manifests(
         self, limit: int = 100, offset: int = 0
@@ -517,6 +577,7 @@ class OKHService(BaseService["OKHService"]):
             )
             logger.info(f"Updated OKH manifest at {existing_key}")
 
+        self._invalidate_catalog_cache()
         return manifest
 
     async def import_repair_doc(
@@ -628,6 +689,7 @@ class OKHService(BaseService["OKHService"]):
                 return False
 
             result = await self.storage.manager.delete_object(existing_key)
+            self._invalidate_catalog_cache()
             logger.info(f"Deleted OKH manifest at {existing_key}")
             return result
 

--- a/tests/unit/test_okh_catalog_performance.py
+++ b/tests/unit/test_okh_catalog_performance.py
@@ -1,0 +1,204 @@
+"""The OKH catalogue is assembled concurrently and cached.
+
+Rendering the Designs page cost ~15s because ``OKHService.list`` fetched every
+OKH object from blob storage one at a time — 287 objects in production — and
+applied pagination only afterwards, so each page repeated the whole scan.
+
+These tests pin the two properties that fix it, and the dedup semantics that
+must survive the change.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timedelta
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+from src.core.services.okh_service import CATALOG_FETCH_CONCURRENCY, OKHService
+from src.core.storage.smart_discovery import FileInfo
+
+
+def manifest_dict(manifest_id: str, title: str = "Design") -> dict:
+    """The minimum shape OKHService.list accepts as a manifest."""
+    return {
+        "id": manifest_id,
+        "title": title,
+        "version": "1.0.0",
+        "license": {"hardware": "MIT"},
+        "licensor": {"name": "Someone"},
+        "documentation_language": "en",
+        "function": "Does a thing",
+    }
+
+
+class FakeStorageManager:
+    """Records concurrency and can simulate per-object latency."""
+
+    def __init__(self, objects: dict[str, dict], latency: float = 0.0):
+        self.objects = objects
+        self.latency = latency
+        self.in_flight = 0
+        self.max_in_flight = 0
+        self.get_calls = 0
+
+    async def get_object(self, key: str) -> bytes:
+        self.in_flight += 1
+        self.max_in_flight = max(self.max_in_flight, self.in_flight)
+        self.get_calls += 1
+        try:
+            if self.latency:
+                await asyncio.sleep(self.latency)
+            return json.dumps(self.objects[key]).encode("utf-8")
+        finally:
+            self.in_flight -= 1
+
+
+class FakeStorage:
+    def __init__(self, manager):
+        self.manager = manager
+
+
+def file_info(key: str, minutes_old: int = 0) -> FileInfo:
+    return FileInfo(
+        key=key,
+        file_type="okh",
+        size=100,
+        last_modified=datetime(2026, 1, 1) - timedelta(minutes=minutes_old),
+        metadata={},
+    )
+
+
+def build_service(objects, latency=0.0):
+    service = OKHService()
+    manager = FakeStorageManager(objects, latency=latency)
+    service.storage = FakeStorage(manager)
+    service._initialized = True
+    return service, manager
+
+
+async def run_list(service, keys, **kwargs):
+    """Call list() with discovery stubbed to the given keys."""
+
+    async def fake_discover(_prefix):
+        return keys
+
+    with (
+        patch("src.core.services.okh_service.SmartFileDiscovery") as Discovery,
+        patch.object(service, "ensure_initialized", return_value=None),
+    ):
+        Discovery.return_value.discover_files = fake_discover
+        return await service.list(**kwargs)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache():
+    """Each test starts with an empty catalogue cache."""
+    from src.core.services.cache_service import get_cache_service
+
+    get_cache_service().clear()
+    yield
+    get_cache_service().clear()
+
+
+@pytest.mark.asyncio
+class TestConcurrency:
+    async def test_objects_are_fetched_concurrently(self):
+        ids = [str(uuid4()) for _ in range(40)]
+        objects = {f"okh/{i}.json": manifest_dict(i) for i in ids}
+        service, manager = build_service(objects, latency=0.01)
+
+        await run_list(service, [file_info(k) for k in objects])
+
+        assert manager.get_calls == 40
+        # The point of the change: reads overlap instead of queueing one deep.
+        assert manager.max_in_flight > 1
+
+    async def test_concurrency_is_bounded(self):
+        """Unbounded fan-out would exhaust the storage client's connections."""
+        ids = [str(uuid4()) for _ in range(60)]
+        objects = {f"okh/{i}.json": manifest_dict(i) for i in ids}
+        service, manager = build_service(objects, latency=0.01)
+
+        await run_list(service, [file_info(k) for k in objects])
+
+        assert manager.max_in_flight <= CATALOG_FETCH_CONCURRENCY
+
+
+@pytest.mark.asyncio
+class TestCaching:
+    async def test_second_page_does_not_rescan_storage(self):
+        """Pagination happens after assembly, so page 2 used to repeat it all."""
+        ids = [str(uuid4()) for _ in range(30)]
+        objects = {f"okh/{i}.json": manifest_dict(i) for i in ids}
+        service, manager = build_service(objects)
+        keys = [file_info(k) for k in objects]
+
+        await run_list(service, keys, page=1, page_size=10)
+        after_first = manager.get_calls
+        await run_list(service, keys, page=2, page_size=10)
+
+        assert after_first == 30
+        assert manager.get_calls == 30, "second page refetched every object"
+
+    async def test_a_write_invalidates_the_catalogue(self):
+        ids = [str(uuid4()) for _ in range(5)]
+        objects = {f"okh/{i}.json": manifest_dict(i) for i in ids}
+        service, manager = build_service(objects)
+        keys = [file_info(k) for k in objects]
+
+        await run_list(service, keys)
+        service._invalidate_catalog_cache()
+        await run_list(service, keys)
+
+        # Otherwise a design someone just created stays invisible until the TTL.
+        assert manager.get_calls == 10
+
+
+@pytest.mark.asyncio
+class TestSemanticsPreserved:
+    async def test_paginates_and_totals_correctly(self):
+        ids = [str(uuid4()) for _ in range(25)]
+        objects = {f"okh/{i}.json": manifest_dict(i) for i in ids}
+        service, _ = build_service(objects)
+
+        page, total = await run_list(
+            service, [file_info(k) for k in objects], page=2, page_size=10
+        )
+
+        assert total == 25
+        assert len(page) == 10
+
+    async def test_duplicate_ids_keep_the_newest_file(self):
+        shared = str(uuid4())
+        objects = {
+            "okh/old.json": manifest_dict(shared, title="Old"),
+            "okh/new.json": manifest_dict(shared, title="New"),
+        }
+        service, _ = build_service(objects)
+
+        page, total = await run_list(
+            service,
+            [file_info("okh/old.json", minutes_old=60), file_info("okh/new.json")],
+        )
+
+        assert total == 1
+        assert page[0].title == "New"
+
+    async def test_unusable_objects_are_skipped_not_fatal(self):
+        good = str(uuid4())
+        objects = {
+            "okh/good.json": manifest_dict(good),
+            "okh/bom.json": {"components": []},  # a BOM sidecar, not a manifest
+        }
+        service, _ = build_service(objects)
+
+        page, total = await run_list(
+            service, [file_info("okh/good.json"), file_info("okh/bom.json")]
+        )
+
+        assert total == 1
+        assert str(page[0].id) == good


### PR DESCRIPTION
Four commits. The performance work is the headline.

## 1. Designs page: ~15s → 2.4s cold / 1.1s warm (`bc57c7e`)

Measured against production **before** changing anything:

| | |
|---|---|
| page 1 | 7.54s total, **TTFB 7.26s**, 678KB |
| page 2 | 7.44s — the full cost paid again |
| warm repeat | 7.20s — no server-side cache |

**96% is server-side**, so the payload was never the problem.

`OKHService.list()` fetched every object under `okh/` from blob storage **one at a time** — 287 objects at ~25ms per round trip — parsed each into an `OKHManifest`, and applied pagination **last**. Because the slice happened at the end, requesting page 2 repeated the whole scan. The client pages through the catalogue, so rendering the page cost **574 sequential blob reads**.

Fixed by fetching concurrently (bounded at 16 in flight, so a large catalogue cannot exhaust the storage client's connection pool) and caching the assembled catalogue for 120s via the existing cache helper.

```
                     before      after (production)
page 1 TTFB           7.26s      1.61s cold / 0.25s warm
page 1 total          7.54s      1.88s cold / 0.57s warm
page 2 total          7.44s      0.54s
whole page          ~15s        ~2.4s cold / ~1.1s warm
```

Measured against production after deploy (build `c9f90f8`, 287 objects); page-1
warm is the median of 6 requests. **Corrected from the simulated figures this
description originally carried** — see the note at the end.

**Two decisions worth review:**

- **Raw dicts are cached, not `OKHManifest` objects.** The Redis backend serialises with `json.dumps(default=str)`, so objects would cache fine on the memory backend and **silently corrupt on Redis** — a bug visible only where `CACHE_BACKEND=redis`. And `to_dict()` is a whitelist that drops `ohm_*` keys. Caching what we already feed to `from_dict` keeps both paths identical.
- **Writes invalidate the entry.** Otherwise a design someone just created stays invisible for 120s, which is exactly when they would look for it. The TTL then only covers changes that bypass the service — a federation ingest, or another replica.

Dedup is unchanged: `asyncio.gather` preserves input order, so the newest-file-wins pass sees the same sequence the sequential loop did. Tests cover concurrency and its bound, cache reuse across pages, invalidation, pagination totals, dedup, and skipping non-manifest objects.

## 2. Usable city filter (`0882bd1`)

The dropdown listed 2,021 raw values — punctuation artifacts, bare postal codes, street addresses, and three separate Viennas — and offered every city on earth while a country was selected, where the AND-ed geo filters meant most of them could not match anything.

City names are now normalised and the list is scoped to the selected country. Normalisation is deliberately conservative, because most of what *looks* malformed is legitimate: `'s-Hertogenbosch`, `Halle (Saale)`, `Biel/Bienne`, `Schwedt/Oder`, `ST BENOIT DE CARMAUX` ("ST" is Saint). Dropping a real city hides real facilities.

Validated against all 2,021 production values: **10 dropped, 22 cleaned, every legitimate name preserved.**

One subtlety: the client-side geo filter compares `cityMatchKey` **exactly**, unlike the API's substring match, so offering a normalised "Wien" while facilities store "1050 Wien" would have silently matched nothing. `cityMatchKey` normalises too.

## 3. Backward pass (`e16b452`)

Equivalence-preserving cleanup: removed a dead letter re-check that could never fire, collapsed a match/if/assign, flattened a nested `??`, corrected a module note written before I discovered the exact-vs-substring difference, and folded a duplicate test case.

Verified by running old and new implementations over all 2,021 values: **zero differences**.

## 4. MoM doc accuracy (`310dd97`)

Three pages claimed each space "publishes a small file on its own website, and the map is assembled by finding those files". The substance is right — the data is the space's own, and both MoM and OHM are readers — but the mechanism came from conversation, not their documentation. Their site says *"paste your endpoint URL if you've got one"*, with live endpoints queried over SPARQL. Softened to what their own copy supports.

Surfaced while drafting a proposal addressed to that partner.

## Verification

`make ready` 11/11 · `frontend-ready` all stages.

## Note on the numbers — corrected after deploy

This description originally reported **0.49s cold / 14.35s → 0.49s page total**,
from a simulation using production's object count and measured per-read latency.
Production measurement (build `c9f90f8`) came in **slower on the cold path than
modelled**: 1.61s TTFB rather than 0.49s. The model under-counted fixed per-request
cost — auth, storage client setup, and response serialisation — which the warm
path mostly avoids but a cold assembly does not. The figures above are the
measured ones; the shape of the win holds, the cold-path magnitude was optimistic.

The `get`-by-id path was untouched here and still took **3.26s for 3KB** — same
shape of problem (`_find_key_for_id` scanning). Fixed in #291; now **0.23s warm**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
