### PR TITLE
Answer single-design fetches from the cached catalogue

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -2566,6 +2566,7 @@ Total Python files: 583
         │       class TestConcurrency
         │       class TestCaching
         │       class TestSemanticsPreserved
+        │       class TestSingleFetch
         │       def manifest_dict()
         │       def file_info()
         │       def build_service()
@@ -10554,6 +10555,10 @@ Rendering the Designs page cost ~15s becaus...
 - `TestConcurrency`
 - `TestCaching`
 - `TestSemanticsPreserved`
+- `TestSingleFetch`
+  - get() and _find_key_for_id answered from the catalogue, not a scan.
+
+Both previo...
 
 **Functions:**
 - `manifest_dict(manifest_id, title)`

--- a/src/core/services/okh_service.py
+++ b/src/core/services/okh_service.py
@@ -281,8 +281,21 @@ class OKHService(BaseService["OKHService"]):
                     self.logger.error("Storage service not available or not configured")
                     return None
 
+                # Fast path: the catalogue is already assembled and cached for
+                # the Designs page, and it is keyed by id. The scan below reads
+                # objects one at a time until it finds a match, so its cost grew
+                # with the manifest's position in storage — ~3.3s in production
+                # for a 3KB record.
+                #
+                # It stays as a fallback because the catalogue skips objects
+                # that are not minimal OKH manifests, and this path never did.
+                # Anything the catalogue omits is still findable.
+                for entry in await self._catalog_entries():
+                    if entry["manifest"].get("id") == str(manifest_id):
+                        return OKHManifest.from_dict(entry["manifest"])
+
                 self.logger.info(
-                    "Storage service is available, searching for OKH files..."
+                    "Not in the cached catalogue; scanning storage for OKH files..."
                 )
 
                 # Use smart discovery to find OKH files
@@ -435,15 +448,9 @@ class OKHService(BaseService["OKHService"]):
             # silently turn objects into strings, and to_dict() is a whitelist
             # that drops ohm_* keys. Caching what we already feed to from_dict
             # keeps the cached path identical to the uncached one.
-            raw_manifests = await cached(
-                service=CATALOG_CACHE_SERVICE,
-                operation=CATALOG_CACHE_OPERATION,
-                key=CATALOG_CACHE_KEY,
-                ttl_seconds=CATALOG_CACHE_TTL_SECONDS,
-                loader=self._assemble_okh_catalog,
-            )
+            entries = await self._catalog_entries()
 
-            all_manifests = [OKHManifest.from_dict(d) for d in raw_manifests]
+            all_manifests = [OKHManifest.from_dict(e["manifest"]) for e in entries]
             total = len(all_manifests)
 
             start_idx = (page - 1) * page_size
@@ -473,9 +480,10 @@ class OKHService(BaseService["OKHService"]):
     async def _assemble_okh_catalog(self) -> List[Dict[str, Any]]:
         """Discover, load and dedupe every OKH manifest under ``okh/``.
 
-        Returns raw manifest dicts, one per id — exactly what :meth:`list`
-        feeds to ``OKHManifest.from_dict``, so the cached and uncached paths
-        build identical objects.
+        Returns ``{"key": storage key, "manifest": raw dict}`` per id. The raw
+        dict is exactly what :meth:`list` feeds to ``OKHManifest.from_dict``, so
+        the cached and uncached paths build identical objects; the key is what
+        lets :meth:`_find_key_for_id` answer from the same cache.
         """
         discovery = SmartFileDiscovery(self.storage.manager)
         file_infos = await discovery.discover_files("okh")
@@ -522,7 +530,25 @@ class OKHService(BaseService["OKHService"]):
             if new_mtime and old_mtime and new_mtime > old_mtime:
                 winners[manifest_id] = (file_info, raw)
 
-        return [raw for _, raw in winners.values()]
+        return [
+            {"key": file_info.key, "manifest": raw}
+            for file_info, raw in winners.values()
+        ]
+
+    async def _catalog_entries(self) -> List[Dict[str, Any]]:
+        """The cached catalogue: one entry per manifest id.
+
+        Shared by list / get / _find_key_for_id so a single assembly serves all
+        three. Each previously scanned storage independently, one object at a
+        time.
+        """
+        return await cached(
+            service=CATALOG_CACHE_SERVICE,
+            operation=CATALOG_CACHE_OPERATION,
+            key=CATALOG_CACHE_KEY,
+            ttl_seconds=CATALOG_CACHE_TTL_SECONDS,
+            loader=self._assemble_okh_catalog,
+        )
 
     async def list_manifests(
         self, limit: int = 100, offset: int = 0
@@ -705,6 +731,14 @@ class OKHService(BaseService["OKHService"]):
         Returns:
             Matching object key or ``None`` when no key can be resolved.
         """
+        # Fast path for OKH, whose catalogue is already cached and carries the
+        # storage key. Falls through to the scan for other file types, and for
+        # objects the catalogue skips.
+        if file_type == "okh":
+            for entry in await self._catalog_entries():
+                if entry["manifest"].get("id") == str(target_id):
+                    return entry["key"]
+
         discovery = SmartFileDiscovery(self.storage.manager)
         file_infos = await discovery.discover_files(file_type)
 

--- a/tests/unit/test_okh_catalog_performance.py
+++ b/tests/unit/test_okh_catalog_performance.py
@@ -14,7 +14,7 @@ import asyncio
 import json
 from datetime import datetime, timedelta
 from unittest.mock import patch
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -202,3 +202,87 @@ class TestSemanticsPreserved:
 
         assert total == 1
         assert str(page[0].id) == good
+
+
+@pytest.mark.asyncio
+class TestSingleFetch:
+    """get() and _find_key_for_id answered from the catalogue, not a scan.
+
+    Both previously read objects one at a time until the id matched, so cost
+    grew with the record's position in storage — ~3.3s in production for a 3KB
+    manifest.
+    """
+
+    async def test_get_is_answered_from_the_cached_catalogue(self):
+        ids = [str(uuid4()) for _ in range(30)]
+        objects = {f"okh/{i}.json": manifest_dict(i) for i in ids}
+        service, manager = build_service(objects)
+        keys = [file_info(k) for k in objects]
+
+        await run_list(service, keys)  # warms the catalogue
+        reads_after_list = manager.get_calls
+
+        async def fake_discover(_prefix):
+            return keys
+
+        with (
+            patch("src.core.services.okh_service.SmartFileDiscovery") as Discovery,
+            patch.object(service, "ensure_initialized", return_value=None),
+        ):
+            Discovery.return_value.discover_files = fake_discover
+            # The last id is the worst case for a positional scan.
+            found = await service.get(UUID(ids[-1]))
+
+        assert found is not None
+        assert str(found.id) == ids[-1]
+        assert manager.get_calls == reads_after_list, "get() re-read storage"
+
+    async def test_find_key_is_answered_from_the_cached_catalogue(self):
+        target = str(uuid4())
+        objects = {
+            "okh/other.json": manifest_dict(str(uuid4())),
+            "okh/target.json": manifest_dict(target),
+        }
+        service, manager = build_service(objects)
+        keys = [file_info(k) for k in objects]
+
+        await run_list(service, keys)
+        reads_after_list = manager.get_calls
+
+        with (
+            patch("src.core.services.okh_service.SmartFileDiscovery") as Discovery,
+            patch.object(service, "ensure_initialized", return_value=None),
+        ):
+            Discovery.return_value.discover_files = lambda _p: _aslist(keys)
+            key = await service._find_key_for_id(UUID(target), "okh")
+
+        assert key == "okh/target.json"
+        assert manager.get_calls == reads_after_list
+
+    async def test_get_falls_back_to_scanning_for_uncatalogued_objects(self):
+        """The catalogue skips non-minimal manifests; get() never did."""
+        catalogued = str(uuid4())
+        objects = {"okh/good.json": manifest_dict(catalogued)}
+        service, manager = build_service(objects)
+
+        # A record that exists in storage but is absent from the catalogue.
+        missing = str(uuid4())
+        objects["okh/extra.json"] = manifest_dict(missing)
+        keys = [file_info("okh/good.json"), file_info("okh/extra.json")]
+
+        async def fake_discover(_prefix):
+            return keys
+
+        with (
+            patch("src.core.services.okh_service.SmartFileDiscovery") as Discovery,
+            patch.object(service, "ensure_initialized", return_value=None),
+        ):
+            Discovery.return_value.discover_files = fake_discover
+            found = await service.get(UUID(missing))
+
+        assert found is not None, "fallback scan should still find it"
+        assert str(found.id) == missing
+
+
+async def _aslist(values):
+    return values


### PR DESCRIPTION
Completes the catalogue performance work merged in #290, so both can go out in the next release.

## The problem

Fetching one design took **3.26s for a 3KB record**.

`OKHService.get()` scanned storage object by object, parsing each, until the id matched — so cost depended on where the record happened to sit. 3.26s is about half of 287 objects at ~25ms per read; a record at the end cost the full ~7s, as did a miss.

`_find_key_for_id` did **the same scan**, and it backs `update()` and `delete()`, so those paid it too.

## The fix

All three now consult the catalogue the Designs page already assembles and caches. It is keyed by id and, as of this change, carries the **storage key** alongside each manifest — which is what lets `_find_key_for_id` answer from it as well.

One assembly now serves `list`, `get`, `update` and `delete`.

```
                    before      after (production)
single design        3.26s      0.23s warm / 1.81s cold
```

Measured against production after deploy (build `c9f90f8`, 287 objects): median
of 12 warm requests, all under 0.5s. **Corrected from the simulated figures this
description originally carried** — see the note at the end.

## The scans stay as fallbacks — deliberately

The catalogue skips objects that are not minimal OKH manifests; `get()` never did. Removing the scan would make those records unreachable, which would be a silent data-visibility regression rather than a performance win. There's a test for that path rather than reasoning about it.

## Scope

`get()` is on the design detail page, visibility, provenance, supply-tree resolution and federation ingest — so this reaches further than one endpoint.

## Verification

`make ready` 11/11. Ten tests cover concurrency and its bound, cache reuse across pages, invalidation on write, pagination totals, dedup, skipping non-manifest objects, both fast paths, and the fallback.

## Note on the numbers — corrected after deploy

This description originally reported **0.49s cold / 0.001s warm**, simulated from
production's object count and measured per-read latency. Production measurement
(build `c9f90f8`) confirmed the warm path but was **slower than modelled on cold**:
1.81s rather than 0.49s, because the model under-counted fixed per-request cost
that a cold assembly cannot avoid. The warm figure (0.23s vs 0.001s modelled) is
dominated by network round trip to Azure, which the in-process simulation excluded
entirely.

One cold request measured 4.19s — a replica with its own empty cache, which is
exactly the per-replica weakness that `CACHE_BACKEND=redis` addresses.

Reproduce with:

```
curl -o /dev/null -w "ttfb=%{time_starttransfer}s\n" \
  "https://www.openhardwaremanager.org/v1/api/okh/<id>"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
