### PR TITLE
Fix supply-tree 404s from match, and bound the MoM failure path behind the 504s

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 583
+Total Python files: 585
 
 ├── deploy/
 │   ├── __init__.py
@@ -1568,7 +1568,7 @@ Total Python files: 583
 │       │   ├── matching_service.py
 │       │   │       class MatchingService (__init__, is_ready, _normalize_req_cap_lists...)
 │       │   ├── mom_bridge.py
-│       │   │       class MoMSpacesCache (__init__, is_fresh, invalidate)
+│       │   │       class MoMSpacesCache (__init__, is_fresh, in_failure_cooldown...)
 │       │   │       def _normalize_process_tags()
 │       │   │       def _cell()
 │       │   ├── okh_file_resolver.py
@@ -2500,6 +2500,13 @@ Total Python files: 583
         │       def make_request_stub()
         ├── test_match_debug_trace_ab.py
         │       class FakeOKHManifest
+        ├── test_match_prefilter_cap.py
+        │       class Facility (__init__)
+        │       def pool()
+        │       def test_the_no_overlap_fallback_respects_the_cap()
+        │       def test_the_no_overlap_fallback_keeps_everything_when_uncapped()
+        │       def test_the_cap_applies_on_the_scored_path_too()
+        │       def test_an_empty_pool_stays_empty()
         ├── test_matching_capability_rules.py
         │       class TestCapabilityRuleConstruction (test_valid_rule_creates_without_error, test_empty_id_raises, test_whitespace_id_raises...)
         │       class TestCanSatisfyRequirement (test_matching_requirement_returns_true, test_case_insensitive_match, test_no_match_returns_false...)
@@ -2558,6 +2565,11 @@ Total Python files: 583
         │       def test_apply_material_triage_rejects_and_renames()
         │       def test_review_interface_materials_queue_drop()
         │       def test_rejected_keys_suppress_reharvest()
+        ├── test_mom_cache_resilience.py
+        │       class TestFailureCooldown
+        │       class TestNoQueueingBehindARefresh
+        │       def patch_fetch()
+        │       def test_the_fetch_timeout_is_bounded()
         ├── test_mom_okw_source_routing.py
         │       def _mock_network()
         ├── test_okh_catalog_performance.py
@@ -2896,7 +2908,7 @@ Total Python files: 583
 
 ## Overview
 
-Total files analyzed: 583
+Total files analyzed: 585
 
 ## Entry Points
 
@@ -3230,7 +3242,7 @@ Orchestrates direc...
 
 **Classes:**
 - `MoMSpacesCache`
-  - Methods: is_fresh, invalidate
+  - Methods: is_fresh, in_failure_cooldown, invalidate
   - TTL cache for the MoM all-spaces map layer.
 
 Serves the last successful fetch fo...
@@ -10422,6 +10434,25 @@ Three documented root causes of coverage=0 despit...
 
 **Internal Dependencies:** 2 imports
 
+### `tests/unit/test_match_prefilter_cap.py`
+> The requirement-aware prefilter must respect its cap on every path.
+
+When no facility advertises a r...
+
+**Exports:** Facility, pool, test_the_no_overlap_fallback_respects_the_cap, test_the_no_overlap_fallback_keeps_everything_when_uncapped, test_the_cap_applies_on_the_scored_path_too
+
+**Classes:**
+- `Facility`
+
+**Functions:**
+- `pool(n, processes)`
+- `test_the_no_overlap_fallback_respects_the_cap()`
+- `test_the_no_overlap_fallback_keeps_everything_when_uncapped()`
+- `test_the_cap_applies_on_the_scored_path_too()`
+- `test_an_empty_pool_stays_empty()`
+
+**Internal Dependencies:** 1 imports
+
 ### `tests/unit/test_matching_capability_rules.py`
 > Characterization tests for capability_rules.py.
 
@@ -10533,6 +10564,24 @@ Tests current behavior of BaseMatchingLayer uti...
   - Short tokens in any discrete list/table cell count; instruction mentions do not....
 
 **Internal Dependencies:** 21 imports
+
+### `tests/unit/test_mom_cache_resilience.py`
+> The MoM cache must not turn an unreachable MoM into a gateway timeout.
+
+A failed refresh leaves the ...
+
+**Exports:** patch_fetch, TestFailureCooldown, TestNoQueueingBehindARefresh, test_the_fetch_timeout_is_bounded
+
+**Classes:**
+- `TestFailureCooldown`
+- `TestNoQueueingBehindARefresh`
+
+**Functions:**
+- `patch_fetch()`
+- `test_the_fetch_timeout_is_bounded()`
+  - ~2s in production for 3,193 spaces; 30s let callers cross the gateway....
+
+**Internal Dependencies:** 2 imports
 
 ### `tests/unit/test_mom_okw_source_routing.py`
 > OKW_SOURCE=mom routing under the unified resolver (#240).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Every "View supply tree" link on the match page 404'd.** The card linked by
+  *tree* id, but the route it lands on loads
+  `/supply-tree/solution/{id}/visualization`, which only accepts a *solution* id.
+  Confirmed against production: a tree id returns 404 where the solution id
+  returns 200. Cards now link by solution id.
+- **A match saved only the best result's tree**, discarding the other nine, so
+  even a corrected link could not have shown most facilities' trees. The saved
+  solution now carries every returned tree; each becomes a node in the
+  visualization bundle.
+- **An unreachable Maps of Making could produce 504s on unrelated matches.** A
+  failed refresh left the cache empty, so every later request re-attempted the
+  fetch and, serialized on the cache lock, queued behind the one in flight —
+  callers crossed nginx's 120s `proxy_read_timeout`. A failure now suppresses
+  retries for 60s, a caller holding stale data no longer waits for an in-flight
+  refresh, and the fetch ceiling drops from 30s to 15s (production measures ~2s
+  for 3,193 spaces).
+- **The prefilter's no-overlap fallback ignored its candidate cap**, the one path
+  by which an entire network could reach heavy matching unbounded. It is taken
+  by every electronics design, since MoM advertises zero facilities for
+  soldering, assembly and drilling.
+
 ## [0.10.4] - 2026-07-27
 
 ### Added

--- a/frontend/src/features/match/MatchResultCard.test.tsx
+++ b/frontend/src/features/match/MatchResultCard.test.tsx
@@ -16,25 +16,46 @@ const solution: RankedSolution = {
   coverage: null,
 };
 
+function renderCard(props: Partial<Parameters<typeof MatchResultCard>[0]> = {}) {
+  const onToggle = vi.fn();
+  render(
+    <MemoryRouter>
+      <MatchResultCard
+        solution={solution}
+        selected={false}
+        onToggle={onToggle}
+        selectionKey="okw-1"
+        solutionId="sol-1"
+        {...props}
+      />
+    </MemoryRouter>,
+  );
+  return { onToggle };
+}
+
 describe("MatchResultCard", () => {
-  it("is selectable and links to its own supply tree", async () => {
-    const onToggle = vi.fn();
-    render(
-      <MemoryRouter>
-        <MatchResultCard
-          solution={solution}
-          selected={false}
-          onToggle={onToggle}
-          selectionKey="okw-1"
-        />
-      </MemoryRouter>,
-    );
+  it("is selectable", async () => {
+    const { onToggle } = renderCard();
     expect(screen.getByRole("heading", { name: "FabLab Drome" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /view supply tree/i })).toHaveAttribute(
-      "href",
-      "/visualization/tree-1",
-    );
     await userEvent.click(screen.getByRole("checkbox", { name: /select fablab drome/i }));
     expect(onToggle).toHaveBeenCalled();
+  });
+
+  // The link previously used the TREE id. The route loads
+  // /supply-tree/solution/{id}/visualization, which only accepts a SOLUTION id,
+  // so every "View supply tree" link 404'd. Verified against production: a tree
+  // id returns 404 where the solution id returns 200.
+  it("links by solution id, not tree id", () => {
+    renderCard();
+    expect(screen.getByRole("link", { name: /view supply tree/i })).toHaveAttribute(
+      "href",
+      "/visualization/sol-1",
+    );
+  });
+
+  it("offers no link when the match was not persisted", () => {
+    // Inline manifests are deliberately unsaved, so there is nothing to load.
+    renderCard({ solutionId: null });
+    expect(screen.queryByRole("link", { name: /view supply tree/i })).toBeNull();
   });
 });

--- a/frontend/src/features/match/MatchResultCard.tsx
+++ b/frontend/src/features/match/MatchResultCard.tsx
@@ -9,17 +9,22 @@ export function MatchResultCard({
   selected,
   onToggle,
   selectionKey,
+  solutionId,
 }: {
   solution: RankedSolution;
   selected: boolean;
   onToggle: () => void;
   selectionKey: string;
+  /** Persisted solution id — the only id the visualization endpoint accepts. */
+  solutionId: string | null;
 }) {
   const token = confidenceToken(solution.confidence);
   const firstLine = solution.explanation?.split("\n")[0]?.trim() ?? null;
-  const treeHref = solution.treeId
-    ? `/visualization/${solution.treeId}`
-    : null;
+  // Link by SOLUTION id, not tree id. The route loads
+  // /supply-tree/solution/{id}/visualization, which only accepts a solution id,
+  // so linking by tree id 404'd on every card. The solution now carries every
+  // result's tree, so this page shows the clicked facility among them.
+  const treeHref = solutionId ? `/visualization/${solutionId}` : null;
 
   return (
     <div

--- a/frontend/src/features/match/MatchView.tsx
+++ b/frontend/src/features/match/MatchView.tsx
@@ -466,6 +466,7 @@ export function MatchView({
                 <MatchResultCard
                   key={key}
                   solution={s}
+                  solutionId={view.solutionId}
                   selectionKey={key}
                   selected={selectedSolutionKeys.includes(key)}
                   onToggle={() =>

--- a/frontend/src/features/match/matchViewModel.ts
+++ b/frontend/src/features/match/matchViewModel.ts
@@ -31,7 +31,13 @@ export interface MatchView {
   coverageGaps: string[];
   summary: string | null;
   totalSolutions: number;
-  /** Persisted top-level solution id (legacy hand-off; prefer per-solution treeId). */
+  /**
+   * Persisted solution id — what the supply-tree explorer loads.
+   *
+   * Null when the match was not saved (inline manifests), in which case no card
+   * offers a tree link. `treeId` identifies a tree WITHIN this solution and is
+   * not addressable on its own.
+   */
   solutionId: string | null;
 }
 

--- a/src/core/api/routes/match.py
+++ b/src/core/api/routes/match.py
@@ -534,12 +534,30 @@ async def match_requirements_to_capabilities(
                     from ...models.supply_trees import SupplyTree, SupplyTreeSolution
 
                     best_solution_dict = solutions[0]
-                    tree_dict = best_solution_dict.get("tree", {})
-                    tree = SupplyTree.from_dict(tree_dict)
 
-                    # Create SupplyTreeSolution from single tree
+                    # Persist every returned solution's tree, not just the best.
+                    # The UI offers "View supply tree" on each result card, so a
+                    # solution holding one tree left nine of ten cards pointing at
+                    # a tree that was never stored. Each tree becomes a node in
+                    # the visualization bundle, keyed by its own id.
+                    trees = []
+                    for solution_dict in solutions:
+                        tree_dict = solution_dict.get("tree")
+                        if not tree_dict:
+                            continue
+                        try:
+                            trees.append(SupplyTree.from_dict(tree_dict))
+                        except Exception:  # noqa: BLE001 — one bad tree must not
+                            # cost the whole solution; the rest still resolve.
+                            logger.warning(
+                                "Skipping unparseable tree while saving solution",
+                                extra={"request_id": request_id},
+                            )
+                    if not trees:
+                        raise ValueError("no parseable supply tree to save")
+
                     solution = SupplyTreeSolution(
-                        all_trees=[tree],
+                        all_trees=trees,
                         score=best_solution_dict.get(
                             "score", best_solution_dict.get("confidence", 0.0)
                         ),
@@ -2266,15 +2284,25 @@ def _prefilter_facilities_by_required_processes(
             scored.append((score, facility))
 
     if not scored:
+        # No facility advertises a required process (MoM has zero coverage for
+        # soldering, assembly and drilling today), so fall back to the full pool
+        # rather than returning nothing. The cap still applies: this path used to
+        # return `facilities` unbounded, which was the one route by which a whole
+        # network could reach heavy matching with no ceiling at all.
+        fallback = facilities
+        if max_candidates is not None:
+            fallback = facilities[: max(1, int(max_candidates))]
         logger.info(
             "Requirement-aware prefilter found no overlap; keeping full facility pool",
             extra={
                 "request_id": request_id,
                 "required_process_count": len(normalized_required),
                 "facility_count": len(facilities),
+                "selected_candidates": len(fallback),
+                "max_candidates": max_candidates,
             },
         )
-        return facilities
+        return fallback
 
     scored.sort(key=lambda item: item[0], reverse=True)
     trimmed = [facility for _, facility in scored]

--- a/src/core/services/mom_bridge.py
+++ b/src/core/services/mom_bridge.py
@@ -19,6 +19,15 @@ MOM_SPARQL_ENDPOINT = "https://mapsofmaking.org/sparql/query"
 # query is heavy (thousands of rows), so we avoid re-querying on every map load.
 MOM_CACHE_TTL_SECONDS = 24 * 60 * 60
 
+# How long a failed refresh suppresses further attempts. Without this, an
+# unreachable MoM made every request retry the fetch, serialized on the cache
+# lock, until callers crossed nginx's 120s proxy_read_timeout and saw a 504.
+MOM_FAILURE_COOLDOWN_SECONDS = 60.0
+
+# Ceiling for the all-spaces fetch. Production measures ~2s for 3,193 spaces;
+# 30s was long enough that a few queued callers exceeded the gateway timeout.
+MOM_FETCH_TIMEOUT_SECONDS = 15.0
+
 _SPARQL_TEMPLATE = """
 SELECT DISTINCT ?space ?name ?lat ?lon WHERE {{
   GRAPH ?g {{
@@ -192,7 +201,7 @@ def _cell(binding: dict, key: str) -> "str | None":
 
 async def fetch_all_mom_spaces(
     endpoint: str = MOM_SPARQL_ENDPOINT,
-    timeout: float = 30.0,
+    timeout: float = MOM_FETCH_TIMEOUT_SECONDS,
 ) -> list[dict]:
     """Fetch every MoM space with coordinates, enriched for the network surface.
 
@@ -252,10 +261,16 @@ class MoMSpacesCache:
     :meth:`refresh` or drop the cache via :meth:`invalidate`.
     """
 
-    def __init__(self, ttl_seconds: float = MOM_CACHE_TTL_SECONDS) -> None:
+    def __init__(
+        self,
+        ttl_seconds: float = MOM_CACHE_TTL_SECONDS,
+        failure_cooldown_seconds: float = MOM_FAILURE_COOLDOWN_SECONDS,
+    ) -> None:
         self.ttl_seconds = ttl_seconds
+        self.failure_cooldown_seconds = failure_cooldown_seconds
         self._data: Optional[list[dict]] = None
         self._fetched_at: float = 0.0
+        self._failed_at: float = 0.0
         self._lock = asyncio.Lock()
 
     def is_fresh(self) -> bool:
@@ -264,18 +279,43 @@ class MoMSpacesCache:
             and (time.monotonic() - self._fetched_at) < self.ttl_seconds
         )
 
+    def in_failure_cooldown(self) -> bool:
+        """True while a recent refresh failure should suppress another attempt."""
+        return (
+            self._failed_at > 0.0
+            and (time.monotonic() - self._failed_at) < self.failure_cooldown_seconds
+        )
+
     async def get(self, force_refresh: bool = False) -> tuple[list[dict], bool]:
         """Return ``(spaces, available)``.
 
-        ``available`` is True when MoM data is present (fresh or stale). A single
-        in-flight refresh is serialized so a cold cache doesn't trigger a
-        thundering herd of SPARQL queries.
+        ``available`` is True when MoM data is present (fresh or stale).
+
+        Two guards keep a slow or unreachable MoM from turning into a gateway
+        timeout here. Both exist because a failed refresh leaves the cache
+        empty, so *every* later request used to re-attempt the fetch and, being
+        serialized on the lock, queue behind the one in flight — the fifth
+        caller waited past nginx's 120s proxy_read_timeout and the browser saw
+        a 504 on a request that had nothing to do with MoM being down.
+
+        1. After a failure, no refresh is attempted for ``failure_cooldown_seconds``
+           — one caller pays the timeout, the rest return immediately.
+        2. When data is already held and a refresh is in flight, the stale copy
+           is served rather than waiting for it.
+
+        ``force_refresh`` bypasses both: an explicit refresh is a deliberate act.
         """
-        if force_refresh or not self.is_fresh():
-            async with self._lock:
-                # Re-check under the lock: another coroutine may have refreshed.
-                if force_refresh or not self.is_fresh():
-                    await self._refresh_locked()
+        if not force_refresh and (self.is_fresh() or self.in_failure_cooldown()):
+            return (self._data or [], self._data is not None)
+
+        # Someone else is already refreshing; stale data now beats fresh later.
+        if not force_refresh and self._data is not None and self._lock.locked():
+            return (self._data, True)
+
+        async with self._lock:
+            # Re-check under the lock: another coroutine may have refreshed.
+            if force_refresh or not (self.is_fresh() or self.in_failure_cooldown()):
+                await self._refresh_locked()
         return (self._data or [], self._data is not None)
 
     async def refresh(self) -> bool:
@@ -287,15 +327,23 @@ class MoMSpacesCache:
         try:
             self._data = await fetch_all_mom_spaces()
             self._fetched_at = time.monotonic()
+            self._failed_at = 0.0
             return True
         except Exception as e:  # noqa: BLE001 — degrade gracefully, keep stale data
-            logger.warning("MoM all-spaces refresh failed; keeping stale data: %s", e)
+            self._failed_at = time.monotonic()
+            logger.warning(
+                "MoM all-spaces refresh failed; keeping stale data and "
+                "suppressing retries for %ss: %s",
+                self.failure_cooldown_seconds,
+                e,
+            )
             return False
 
     def invalidate(self) -> None:
         """Drop cached data so the next ``get`` refetches (cache-refresh hook)."""
         self._data = None
         self._fetched_at = 0.0
+        self._failed_at = 0.0
 
 
 # Process-wide cache instance for the map layer.

--- a/tests/unit/test_match_prefilter_cap.py
+++ b/tests/unit/test_match_prefilter_cap.py
@@ -1,0 +1,58 @@
+"""The requirement-aware prefilter must respect its cap on every path.
+
+When no facility advertises a required process the prefilter falls back to the
+full pool — correct, since returning nothing would make the design unmatchable.
+But that path used to return the pool *unbounded*, ignoring ``max_candidates``:
+the one route by which an entire network (3,193 facilities in production) could
+reach heavy matching with no ceiling at all.
+
+This is not hypothetical. MoM advertises zero facilities for soldering,
+assembly and drilling, so every electronics design takes this path.
+"""
+
+from __future__ import annotations
+
+from src.core.api.routes.match import _prefilter_facilities_by_required_processes
+
+
+class Facility:
+    def __init__(self, processes):
+        self.manufacturing_processes = processes
+
+
+def pool(n: int, processes):
+    return [Facility(list(processes)) for _ in range(n)]
+
+
+def test_the_no_overlap_fallback_respects_the_cap():
+    facilities = pool(3193, ["knitting"])
+
+    kept = _prefilter_facilities_by_required_processes(
+        facilities, ["soldering"], "req-1", 200
+    )
+
+    assert len(kept) == 200
+
+
+def test_the_no_overlap_fallback_keeps_everything_when_uncapped():
+    facilities = pool(50, ["knitting"])
+
+    kept = _prefilter_facilities_by_required_processes(
+        facilities, ["soldering"], "req-1", None
+    )
+
+    assert len(kept) == 50, "an absent cap must not silently truncate"
+
+
+def test_the_cap_applies_on_the_scored_path_too():
+    facilities = pool(500, ["3d printing"])
+
+    kept = _prefilter_facilities_by_required_processes(
+        facilities, ["3d printing"], "req-1", 25
+    )
+
+    assert len(kept) == 25
+
+
+def test_an_empty_pool_stays_empty():
+    assert _prefilter_facilities_by_required_processes([], ["soldering"], "r", 10) == []

--- a/tests/unit/test_mom_cache_resilience.py
+++ b/tests/unit/test_mom_cache_resilience.py
@@ -1,0 +1,143 @@
+"""The MoM cache must not turn an unreachable MoM into a gateway timeout.
+
+A failed refresh leaves the cache empty, so ``is_fresh()`` stays False and every
+later request used to re-attempt the fetch. Those attempts serialize on the
+cache lock, so callers queued behind each other: with a 30s fetch ceiling the
+fifth caller waited past nginx's 120s ``proxy_read_timeout`` and the browser saw
+a 504 on a match that had nothing to do with MoM being down.
+
+These tests pin the two guards that bound that wait.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from src.core.services.mom_bridge import (
+    MOM_FETCH_TIMEOUT_SECONDS,
+    MoMSpacesCache,
+)
+
+SPACES = [{"space": "urn:a", "name": "A"}]
+
+
+def patch_fetch(*, result=None, error=None, delay=0.0):
+    calls = {"n": 0}
+
+    async def fake_fetch(*_a, **_kw):
+        calls["n"] += 1
+        if delay:
+            await asyncio.sleep(delay)
+        if error:
+            raise error
+        return list(result or [])
+
+    return (
+        patch(
+            "src.core.services.mom_bridge.fetch_all_mom_spaces", side_effect=fake_fetch
+        ),
+        calls,
+    )
+
+
+@pytest.mark.asyncio
+class TestFailureCooldown:
+    async def test_a_failure_suppresses_further_fetches(self):
+        """One caller pays the timeout; the rest return immediately."""
+        patcher, calls = patch_fetch(error=RuntimeError("MoM down"))
+        cache = MoMSpacesCache(failure_cooldown_seconds=60.0)
+        with patcher:
+            for _ in range(5):
+                spaces, available = await cache.get()
+
+        assert calls["n"] == 1, "every request re-attempted the failed fetch"
+        assert spaces == []
+        assert available is False
+
+    async def test_the_cooldown_expires(self):
+        patcher, calls = patch_fetch(error=RuntimeError("MoM down"))
+        cache = MoMSpacesCache(failure_cooldown_seconds=0.0)
+        with patcher:
+            await cache.get()
+            await cache.get()
+
+        assert calls["n"] == 2, "a zero cooldown must not suppress the retry"
+
+    async def test_force_refresh_bypasses_the_cooldown(self):
+        """An explicit refresh is a deliberate act, not incidental traffic."""
+        patcher, calls = patch_fetch(error=RuntimeError("MoM down"))
+        cache = MoMSpacesCache(failure_cooldown_seconds=60.0)
+        with patcher:
+            await cache.get()
+            await cache.get(force_refresh=True)
+
+        assert calls["n"] == 2
+
+    async def test_recovery_clears_the_failure_state(self):
+        cache = MoMSpacesCache(failure_cooldown_seconds=0.0)
+        failing, _ = patch_fetch(error=RuntimeError("MoM down"))
+        with failing:
+            await cache.get()
+        assert cache.in_failure_cooldown() is False  # cooldown 0
+
+        ok, _ = patch_fetch(result=SPACES)
+        with ok:
+            spaces, available = await cache.get()
+
+        assert spaces == SPACES
+        assert available is True
+        assert cache.in_failure_cooldown() is False
+
+    async def test_stale_data_is_still_served_after_a_failure(self):
+        """Degrading to stale is the point; the cooldown must not lose it."""
+        cache = MoMSpacesCache(ttl_seconds=0.0, failure_cooldown_seconds=60.0)
+        ok, _ = patch_fetch(result=SPACES)
+        with ok:
+            await cache.get()
+
+        failing, _ = patch_fetch(error=RuntimeError("MoM down"))
+        with failing:
+            spaces, available = await cache.get()
+
+        assert spaces == SPACES
+        assert available is True
+
+
+@pytest.mark.asyncio
+class TestNoQueueingBehindARefresh:
+    async def test_holders_of_stale_data_do_not_wait_for_an_in_flight_refresh(self):
+        """The queueing that produced the 504, in miniature."""
+        cache = MoMSpacesCache(ttl_seconds=0.0)
+        ok, _ = patch_fetch(result=SPACES)
+        with ok:
+            await cache.get()  # seed, now stale
+
+        slow, calls = patch_fetch(result=SPACES, delay=0.3)
+        with slow:
+            refresher = asyncio.create_task(cache.get())
+            await asyncio.sleep(0.05)  # let it take the lock
+
+            waiter = await asyncio.wait_for(cache.get(), timeout=0.1)
+            await refresher
+
+        assert waiter == (SPACES, True)
+        assert calls["n"] == 1, "the second caller triggered its own fetch"
+
+    async def test_a_cold_cache_still_waits_for_data(self):
+        """With nothing to serve, waiting is correct — there is no stale copy."""
+        cache = MoMSpacesCache()
+        slow, calls = patch_fetch(result=SPACES, delay=0.05)
+        with slow:
+            first, second = await asyncio.gather(cache.get(), cache.get())
+
+        assert first == (SPACES, True)
+        assert second == (SPACES, True)
+        assert calls["n"] == 1, "the lock must still collapse a thundering herd"
+
+
+def test_the_fetch_timeout_is_bounded():
+    """~2s in production for 3,193 spaces; 30s let callers cross the gateway."""
+    assert MOM_FETCH_TIMEOUT_SECONDS <= 15.0

--- a/tests/unit/test_okw_spaces.py
+++ b/tests/unit/test_okw_spaces.py
@@ -166,7 +166,11 @@ async def test_cache_keeps_stale_on_failure_and_unavailable_when_never_fetched(
 
     monkeypatch.setattr("src.core.services.mom_bridge.fetch_all_mom_spaces", fake_fetch)
 
-    cache = MoMSpacesCache(ttl_seconds=0)
+    # Cooldown disabled: this test covers stale-keeping and availability, and a
+    # failure now suppresses retries for a minute by default (see
+    # test_mom_cache_resilience.py — it is what stops a down MoM from queueing
+    # callers past the gateway timeout). Recovery here is immediate by design.
+    cache = MoMSpacesCache(ttl_seconds=0, failure_cooldown_seconds=0)
     spaces, avail = await cache.get()  # never succeeded
     assert spaces == [] and avail is False
     state["fail"] = False


### PR DESCRIPTION
Two reported defects, plus one found alongside them.

## 1. Supply-tree 404 — root cause confirmed

Every "View supply tree" link on the match page 404'd.

The card linked to `/visualization/{treeId}`. That route loads `/supply-tree/solution/{id}/visualization`, which accepts only a **solution** id. A tree id is not a solution id.

Confirmed against production:

```
GET /supply-tree/solution/501d610f-.../visualization   404   <- tree id (what the UI sent)
GET /supply-tree/solution/99c695b4-.../visualization   200   <- solution id
```

**Correcting the link alone was not enough.** The save built the solution from `solutions[0]` only, so nine of ten trees were never persisted — most cards would still have had nothing to show, even by the right id. The solution now carries every returned tree; each becomes a node in the visualization bundle keyed by its own id, so the clicked facility appears among them.

## 2. The periodic 504 — mechanism found, not reproduced

I could not reproduce it. Against the live system every path returns in 1–4s: a whole-network match (1.0–2.3s), a design whose only process has **zero** network coverage (2.0s), a 196-part design (1.9s), and six concurrent whole-network matches (all 3.9s). A forced cold MoM refresh is 3.4s. The system is currently healthy.

What the code does show is a mechanism that fits a failure that comes and goes with an **external** service's health:

`MoMSpacesCache` leaves `_data` as `None` when a refresh fails, so `is_fresh()` never becomes true. Every subsequent request therefore re-attempts the fetch, and those attempts serialize on the cache lock. Callers queue behind the one in flight: at the 30s ceiling the fifth waits past nginx's `proxy_read_timeout 120s` and the browser gets a **504 on a match that had nothing to do with MoM being down**.

Three changes bound it:

- a failed refresh suppresses further attempts for 60s — one caller pays the timeout, the rest return immediately;
- a caller that already holds data serves it rather than waiting for an in-flight refresh;
- the fetch ceiling drops 30s → 15s (production measures ~2s for 3,193 spaces).

**Trade-off:** recovery after an outage can lag by up to the cooldown. An existing test asserted immediate recovery; it now passes `failure_cooldown_seconds=0` with the reasoning recorded rather than being deleted.

I'd rather be plain that this is hypothesis-driven hardening than claim a fix I did not observe. If 504s continue, the next thing to capture is the `request_id` and timestamp of one, so it can be traced in the container logs.

## 3. Found alongside

The requirement-aware prefilter's no-overlap fallback returned the pool **unbounded**, ignoring `max_candidates` — the one route by which an entire network (3,193 facilities) could reach heavy matching with no ceiling at all. This is not a corner case: MoM advertises zero facilities for soldering, assembly and drilling, so **every electronics design takes it**.

## Tests

12 new. The MoM ones pin the retry storm directly, including the queueing behaviour in miniature (a caller with stale data must not block on an in-flight refresh) and that the lock still collapses a thundering herd on a genuinely cold cache. The card test previously asserted the buggy `href` — it now pins the solution-id link and that an unsaved match offers no link at all.

`make ready` and `frontend-ready` both pass.

## Note

`?focus={treeId}` was in an earlier revision of this branch so the page could highlight the clicked facility. Nothing read it, so it came out. Worth doing properly as a follow-up: all cards currently link to the same page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)