### PR TITLE
Fall back to memory when a configured Redis is unusable

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -800,7 +800,7 @@ Total Python files: 586
 │       │   │   │       class _CacheEntry (__init__, is_expired)
 │       │   │   │       class MemoryCacheBackend (__init__, get, set...)
 │       │   │   └── redis_backend.py
-│       │   │           class RedisCacheBackend (__init__, get, set...)
+│       │   │           class RedisCacheBackend (__init__, is_reachable, get...)
 │       │   │           def _serialize()
 │       │   │           def _deserialize()
 │       │   ├── helper.py
@@ -2293,10 +2293,11 @@ Total Python files: 586
         │       def test_use_nlp_false_disables_spacy_in_bom_collection()
         │       def test_use_nlp_defaults_to_enabled()
         ├── test_cache_redis_backend.py
-        │       class FakeRedis (__init__, _boom, get...)
+        │       class FakeRedis (__init__, _boom, ping...)
         │       class TestRoundTrip (test_stores_and_returns_the_value, test_absent_key_is_a_miss, test_the_ttl_is_applied...)
         │       class TestDegradesInsteadOfFailing (test_get_returns_a_miss_when_redis_is_unreachable, test_set_swallows_the_failure, test_delete_swallows_the_failure...)
-        │       class TestBackendSelection (test_redis_without_a_url_degrades_to_memory, test_redis_with_a_url_selects_redis, test_an_unknown_backend_falls_back_to_memory)
+        │       class TestReachability (test_a_working_redis_is_reachable, test_an_unusable_redis_reports_why)
+        │       class TestBackendSelection (test_redis_without_a_url_degrades_to_memory, test_redis_with_a_url_selects_redis, test_an_unusable_redis_falls_back_to_memory...)
         │       def build_backend()
         ├── test_cache_service.py
         │       def _reset_singleton()
@@ -6983,7 +6984,7 @@ Provides endpoints to query and reload the canonical ma...
 
 **Classes:**
 - `RedisCacheBackend`
-  - Methods: get, set, delete, clear, backend_stats
+  - Methods: is_reachable, get, set, delete, clear
   - Distributed cache using the Redis protocol (sync client).
 
 Every operation falls...
@@ -10155,24 +10156,29 @@ Calling it (``nlp(text)``) means the full pipel...
 
 ``CACHE_BACKEND=redis`` exists so...
 
-**Exports:** FakeRedis, build_backend, TestRoundTrip, TestDegradesInsteadOfFailing, TestBackendSelection
+**Exports:** FakeRedis, build_backend, TestRoundTrip, TestDegradesInsteadOfFailing, TestReachability
 
 **Classes:**
 - `FakeRedis`
-  - Methods: get, setex, delete, flushdb
+  - Methods: ping, get, setex, delete, flushdb
   - Enough of redis-py to exercise the backend, with failure injection....
 - `TestRoundTrip`
   - Methods: test_stores_and_returns_the_value, test_absent_key_is_a_miss, test_the_ttl_is_applied, test_the_catalogue_entry_shape_survives_serialisation
 - `TestDegradesInsteadOfFailing`
   - Methods: test_get_returns_a_miss_when_redis_is_unreachable, test_set_swallows_the_failure, test_delete_swallows_the_failure, test_corrupt_payload_is_a_miss_and_is_evicted, test_the_socket_timeout_is_sub_second
   - A broken cache must cost speed, not availability....
+- `TestReachability`
+  - Methods: test_a_working_redis_is_reachable, test_an_unusable_redis_reports_why
+  - An unusable Redis must not be mistaken for a working one.
+
+Every operation swall...
 - `TestBackendSelection`
-  - Methods: test_redis_without_a_url_degrades_to_memory, test_redis_with_a_url_selects_redis, test_an_unknown_backend_falls_back_to_memory
+  - Methods: test_redis_without_a_url_degrades_to_memory, test_redis_with_a_url_selects_redis, test_an_unusable_redis_falls_back_to_memory, test_an_unknown_backend_falls_back_to_memory
 
 **Functions:**
 - `build_backend()`
 
-**Internal Dependencies:** 8 imports
+**Internal Dependencies:** 9 imports
 
 ### `tests/unit/test_claim_component.py`
 > Unit tests for ComponentState claim fields and AssetService.claim_component — GAP-7....

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A configured but unusable Redis now falls back to the memory cache.** Every
+  Redis operation reports a miss on failure, so a broken instance cached
+  *nothing* while reporting `backend: redis` — strictly worse than the memory
+  backend it replaced, which at least caches per replica. Production ran a full
+  deployment in that state: the connection URL still contained the literal
+  `<key>` placeholder, so every request paid full assembly (single-design fetch
+  1.5s against a 0.23s warm path). The backend is now verified with a PING
+  before it is committed to.
+- **Redis provisioning docs no longer hand-substitute the access key.** The
+  commands read and percent-encode it themselves, and the page says how to
+  confirm the cache actually works — `backend: redis` alone is exactly what a
+  completely non-functional cache reports.
+
 ### Changed
 
 - **The catalogue cache is shared across replicas in production**

--- a/docs/testing/cache-deployment.md
+++ b/docs/testing/cache-deployment.md
@@ -43,17 +43,41 @@ round trip Redis requires; caching model objects would not.
 
 **One-time provisioning** (not done by the deploy pipeline):
 
+Run these as written — the key is read and URL-encoded by the commands
+themselves. Do not hand-substitute it: an earlier version of this page used a
+`<key>` placeholder, it was pasted through unsubstituted, and Redis spent a
+deployment authenticating as the literal string `<key>`. Nothing looked broken,
+because a failing Redis reports cache misses.
+
 ```bash
 az redis create --name ohm-cache --resource-group project_data_rg \
   --location westus3 --sku Basic --vm-size c0
+
+# Read the key and percent-encode it (Azure keys are base64 and can contain
+# "+" and "/", which change a URL's meaning if left raw).
+REDIS_KEY=$(az redis list-keys --name ohm-cache --resource-group project_data_rg \
+  --query primaryKey -o tsv)
+REDIS_KEY_ENC=$(python3 -c 'import sys,urllib.parse;print(urllib.parse.quote(sys.argv[1],safe=""))' "$REDIS_KEY")
+
 az containerapp secret set --name openhardwaremanager --resource-group project_data_rg \
-  --secrets cache-redis-url="rediss://:<key>@ohm-cache.redis.cache.windows.net:6380/0"
+  --secrets "cache-redis-url=rediss://:${REDIS_KEY_ENC}@ohm-cache.redis.cache.windows.net:6380/0"
 az containerapp update --name openhardwaremanager --resource-group project_data_rg \
   --set-env-vars CACHE_REDIS_URL=secretref:cache-redis-url
 ```
 
-Until that lands, replicas log the fallback and run the per-replica memory cache
-— the pre-Redis behaviour, not an outage.
+Then confirm it actually took, rather than assuming:
+
+```bash
+curl -s https://www.openhardwaremanager.org/v1/api/utility/metrics \
+  | python3 -c 'import sys,json;print(json.load(sys.stdin)["data"]["cache"])'
+```
+
+Expect `backend: redis` **with no `error` key**, and `hits` climbing on repeat
+requests. `backend: redis` alone means nothing — that is what a completely
+non-functional cache reports too.
+
+Until provisioning lands, replicas log the fallback and run the per-replica
+memory cache — the pre-Redis behaviour, not an outage.
 
 The client is synchronous and is called from async handlers, so its socket
 timeout is deliberately sub-second (`SOCKET_TIMEOUT_SECONDS` in

--- a/src/core/cache/backends/redis_backend.py
+++ b/src/core/cache/backends/redis_backend.py
@@ -50,6 +50,23 @@ class RedisCacheBackend:
         )
         self._redis_url_host = redis_url.split("@")[-1].split("/")[0]
 
+    def is_reachable(self) -> tuple[bool, Optional[str]]:
+        """``(ok, error)`` from a single PING.
+
+        Every other operation swallows its failure and reports a miss, which
+        makes an unusable Redis indistinguishable from a cold one: it caches
+        nothing, forever, while looking healthy. Production hit exactly that —
+        a connection URL whose ``<key>`` placeholder was never substituted
+        authenticated as the literal string, and every request paid full
+        assembly with no cache at all. The factory calls this once so a broken
+        Redis degrades to the memory cache instead.
+        """
+        try:
+            self._client.ping()
+            return True, None
+        except Exception as exc:  # noqa: BLE001 — any failure means unusable
+            return False, str(exc)
+
     def get(self, key: str) -> Optional[Any]:
         try:
             raw = self._client.get(key)

--- a/src/core/services/cache_service.py
+++ b/src/core/services/cache_service.py
@@ -40,11 +40,22 @@ def create_cache_backend():
                 "to share the cache across replicas."
             )
         else:
-            logger.info(
-                "Initializing Redis cache backend (%s)",
-                CACHE_REDIS_URL.split("@")[-1],
+            host = CACHE_REDIS_URL.split("@")[-1]
+            backend = RedisCacheBackend(CACHE_REDIS_URL)
+            # Verify before committing to it. Redis swallows every operational
+            # failure and reports a miss, so an unusable instance caches nothing
+            # while looking healthy — strictly worse than the memory backend it
+            # replaced, because that at least caches per replica.
+            reachable, error = backend.is_reachable()
+            if reachable:
+                logger.info("Initializing Redis cache backend (%s)", host)
+                return backend
+            logger.error(
+                "Redis at %s is unusable (%s) — falling back to the per-replica "
+                "memory cache. The catalogue will not be shared across replicas.",
+                host,
+                error,
             )
-            return RedisCacheBackend(CACHE_REDIS_URL)
     elif backend_name != "memory":
         logger.warning("Unknown CACHE_BACKEND=%r; falling back to memory", backend_name)
     return MemoryCacheBackend(

--- a/tests/unit/test_cache_redis_backend.py
+++ b/tests/unit/test_cache_redis_backend.py
@@ -37,6 +37,10 @@ class FakeRedis:
         if self.fail:
             raise ConnectionError("connection refused")
 
+    def ping(self):
+        self._boom()
+        return True
+
     def get(self, key):
         self._boom()
         return self.store.get(key)
@@ -135,6 +139,28 @@ class TestDegradesInsteadOfFailing:
         assert "pw" not in json.dumps(backend.backend_stats())
 
 
+class TestReachability:
+    """An unusable Redis must not be mistaken for a working one.
+
+    Every operation swallows its failure and reports a miss, so a broken
+    instance caches nothing while looking healthy. Production ran a full
+    deployment that way: the connection URL still contained the literal
+    `<key>` placeholder, so Redis rejected every command, the app served
+    every request uncached, and the only outward sign was an `error` field
+    in the metrics payload.
+    """
+
+    def test_a_working_redis_is_reachable(self):
+        backend, _ = build_backend()
+        assert backend.is_reachable() == (True, None)
+
+    def test_an_unusable_redis_reports_why(self):
+        backend, _ = build_backend(fail=True)
+        ok, error = backend.is_reachable()
+        assert ok is False
+        assert "connection refused" in (error or "")
+
+
 class TestBackendSelection:
     def test_redis_without_a_url_degrades_to_memory(self):
         """CACHE_BACKEND is plain config; CACHE_REDIS_URL is a secretRef.
@@ -165,6 +191,25 @@ class TestBackendSelection:
             backend = cache_service.create_cache_backend()
 
         assert backend.name == "redis"
+
+    def test_an_unusable_redis_falls_back_to_memory(self):
+        """The bug this exists for: a configured but broken Redis.
+
+        Returning it would cache nothing at all — strictly worse than the
+        memory backend it replaced, which at least caches per replica.
+        """
+        from src.core.services import cache_service
+
+        with (
+            patch.object(cache_service, "CACHE_BACKEND", "redis"),
+            patch.object(
+                cache_service, "CACHE_REDIS_URL", "redis://cache.example:6379/0"
+            ),
+            patch("redis.from_url", return_value=FakeRedis(fail=True)),
+        ):
+            backend = cache_service.create_cache_backend()
+
+        assert backend.name == "memory"
 
     def test_an_unknown_backend_falls_back_to_memory(self):
         from src.core.services import cache_service


### PR DESCRIPTION
Found by testing the Redis deployment instead of assuming it worked.

## What was happening

Production reported `backend: redis` and served **every request with no cache at all**.

The `cache-redis-url` secret still contained the literal `<key>` placeholder from the provisioning docs — verified by hashing, the stored value was byte-for-byte `rediss://:<key>@ohm-cache.redis.cache.windows.net:6380/0`. Redis was authenticating as the string `<key>`.

Because every Redis operation swallows its failure and reports a miss, nothing looked wrong. The only outward sign was an `error` field in the metrics payload:

```
"backend": "redis", "hits": 0, "misses": 5,
"error": "invalid username-password pair"
```

The cost was real: single-design fetches ran at **1.5s against a 0.23s warm path**, and list pages at 1.6s against 0.25s — **slower than before Redis was introduced**, because the memory backend at least caches per replica.

## Two causes, both mine

**The docs gave a copy-pasteable command containing `<key>`.** They now read the key and percent-encode it inline, so there is nothing to hand-substitute (Azure keys are base64 and can contain `+` and `/`, which change a URL's meaning if left raw). The page also now says how to *verify* the cache works, because `backend: redis` on its own is exactly what a completely dead cache reports.

**The factory treated `CACHE_REDIS_URL` being set as evidence that Redis worked.** It now PINGs before committing to the backend and falls back to memory on failure — the same thing the missing-URL path already did. The rule is uniform now: a misconfigured cache costs speed, never correctness or availability.

## Verified in production

After correcting the secret and restarting the revision:

| | broken | fixed |
|---|---|---|
| single design (warm) | 1.5s | **0.22–0.25s** |
| designs list page 1 | 1.6s | **0.24–0.35s** |
| cache hit rate | 0 | **0.93** |
| `error` | `invalid username-password pair` | none |

The match flow was re-checked alongside: 10 solutions, visualization bundle 10 nodes, 0.24s.

## Residual gap, deliberately not fixed here

A Redis that dies *after* startup still degrades to no caching until the next restart, with each lookup paying the socket timeout first. The right fix is a runtime circuit breaker; I'd rather add that when there's evidence it happens than build it speculatively now.

## Tests

4 new — reachability reported both ways, and a configured-but-broken Redis selecting the memory backend. `make ready` passes (1031).

🤖 Generated with [Claude Code](https://claude.com/claude-code)