### PR TITLE
Make match results say one consistent thing

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 586
+Total Python files: 587
 
 ├── deploy/
 │   ├── __init__.py
@@ -2505,6 +2505,12 @@ Total Python files: 586
         │       class TestCoverageTaxonomyHierarchy (test_fdm_uri_covers_3d_printing_requirement, test_sla_uri_covers_3d_printing_requirement, test_3d_printing_plain_text_still_works)
         │       class _Stub
         │       def make_request_stub()
+        ├── test_match_coverage_summary.py
+        │       class Request
+        │       class TestCoverageReflectsTheMatch (test_a_fully_matched_design_reports_full_coverage, test_an_unmatched_requirement_is_still_reported_as_a_gap, test_coverage_is_the_union_across_solutions...)
+        │       class TestCollection (test_only_matched_requirements_are_collected, test_both_the_requirement_and_the_capability_are_kept, test_a_solution_without_an_explanation_contributes_nothing)
+        │       def solution()
+        │       def summarise()
         ├── test_match_debug_trace_ab.py
         │       class FakeOKHManifest
         ├── test_match_prefilter_cap.py
@@ -2915,7 +2921,7 @@ Total Python files: 586
 
 ## Overview
 
-Total files analyzed: 586
+Total files analyzed: 587
 
 ## Entry Points
 
@@ -10466,6 +10472,27 @@ Three documented root causes of coverage=0 despit...
   - Minimal MatchRequest-like object for _build_match_summary....
 
 **Internal Dependencies:** 9 imports
+
+### `tests/unit/test_match_coverage_summary.py`
+> Match coverage must be read from the matcher's own verdict.
+
+The summary reported ``coverage 0/N`` a...
+
+**Exports:** Request, solution, summarise, TestCoverageReflectsTheMatch, TestCollection
+
+**Classes:**
+- `Request`
+  - The fields _build_match_summary reads off the request....
+- `TestCoverageReflectsTheMatch`
+  - Methods: test_a_fully_matched_design_reports_full_coverage, test_an_unmatched_requirement_is_still_reported_as_a_gap, test_coverage_is_the_union_across_solutions, test_duplicate_requirements_are_counted_once, test_no_solutions_means_no_coverage
+- `TestCollection`
+  - Methods: test_only_matched_requirements_are_collected, test_both_the_requirement_and_the_capability_are_kept, test_a_solution_without_an_explanation_contributes_nothing
+
+**Functions:**
+- `solution()`
+- `summarise(required, solutions)`
+
+**Internal Dependencies:** 2 imports
 
 ### `tests/unit/test_match_debug_trace_ab.py`
 > A/B debug-trace regression for current vs baseline-like route behavior....

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Match results contradicted themselves.** A fully successful match was
+  presented as a total failure: a `coverage 0/3` headline and a warning-styled
+  "Coverage gaps" banner naming the exact processes the design needs, sitting
+  above ten facilities each reading "Meets every requirement". The summary read
+  `tree.capabilities_used`, a field that is present on every tree and **always
+  empty**, so nothing was ever counted as matched — every match reported zero
+  coverage. It now reads the matcher's own per-requirement verdict, the same
+  evidence the cards show.
+- **Requirement counts were doubled.** A design declaring a process in both
+  `manufacturing_processes` and `manufacturing_specs.process_requirements` — all
+  19 of the 100 designs sampled that have both — had each requirement counted
+  twice, so a three-requirement design reported six and the near-miss slider
+  offered to relax to four. A duplicate counts as matched only if every copy
+  did, so deduping cannot hide a gap.
+- **One confidence figure per result.** Cards showed "confidence 100%" beside
+  text reading "(confidence: 95%)". These are different fields: the former is
+  coverage-derived and reads 1.0 whenever everything matched, the latter is the
+  mean of the per-requirement confidences. The card now shows the figure with
+  per-requirement evidence under it.
+
+### Fixed
+
 - **A configured but unusable Redis now falls back to the memory cache.** Every
   Redis operation reports a miss on failure, so a broken instance cached
   *nothing* while reporting `backend: redis` — strictly worse than the memory

--- a/frontend/src/api/ohm/match.ts
+++ b/frontend/src/api/ohm/match.ts
@@ -30,9 +30,13 @@ export interface RawSolution {
   explanation_human?: string | null;
   /** Structured explanation; carries per-requirement match status. */
   explanation?: {
-    requirement_matches?: { status?: string | null }[] | null;
+    requirement_matches?:
+      | { status?: string | null; requirement_value?: string | null }[]
+      | null;
     missing_capabilities?: unknown[] | null;
     overall_status?: string | null;
+    /** Mean of the per-requirement confidences; see matchViewModel. */
+    overall_confidence?: number | null;
   } | null;
   match_type?: string | null;
   tree?: { id?: string | null } | null;

--- a/frontend/src/features/match/matchViewModel.test.ts
+++ b/frontend/src/features/match/matchViewModel.test.ts
@@ -60,3 +60,34 @@ describe("toRfqSolutions", () => {
     expect(rfq[0].facility.contact?.website).toBe("https://example.org");
   });
 });
+
+// The card showed "confidence 100%" beside text reading "(confidence: 95%)".
+// They are different fields: `confidence` is coverage-derived and reads 1.0
+// whenever every requirement matched, while `overall_confidence` is the mean of
+// the per-requirement confidences the text quotes.
+describe("confidence is a single, evidenced figure", () => {
+  const raw = (solution: Record<string, unknown>) => ({
+    data: { solutions: [solution] },
+  });
+
+  it("prefers the explanation's overall confidence", () => {
+    const view = toMatchView(
+      raw({
+        facility_name: "FabLab",
+        confidence: 1.0,
+        explanation: { overall_confidence: 0.95, requirement_matches: [] },
+      }),
+    );
+    expect(view.solutions[0].confidence).toBe(0.95);
+  });
+
+  it("falls back to the solution confidence when the explanation omits it", () => {
+    const view = toMatchView(raw({ facility_name: "FabLab", confidence: 0.8 }));
+    expect(view.solutions[0].confidence).toBe(0.8);
+  });
+
+  it("defaults to zero rather than undefined", () => {
+    const view = toMatchView(raw({ facility_name: "FabLab" }));
+    expect(view.solutions[0].confidence).toBe(0);
+  });
+});

--- a/frontend/src/features/match/matchViewModel.ts
+++ b/frontend/src/features/match/matchViewModel.ts
@@ -47,7 +47,11 @@ export function toMatchView(raw: RawMatchResponse): MatchView {
     .map((s) => ({
       facilityName: s.facility_name ?? "Unknown facility",
       facilityId: s.facility_id ?? null,
-      confidence: s.confidence ?? 0,
+      // `confidence` is coverage-derived and reads 1.0 whenever everything
+      // matched; `overall_confidence` is the mean of the per-requirement
+      // figures the card's own text quotes. Showing the former put "confidence
+      // 100%" next to "(confidence: 95%)" on the same card.
+      confidence: s.explanation?.overall_confidence ?? s.confidence ?? 0,
       score: s.score ?? 0,
       rank: s.rank ?? 0,
       explanation: s.explanation_human ?? null,

--- a/frontend/src/features/match/nearMiss.test.ts
+++ b/frontend/src/features/match/nearMiss.test.ts
@@ -94,3 +94,60 @@ describe("coverageLabel", () => {
     expect(coverageLabel(null)).toBe("Coverage unknown");
   });
 });
+
+// The API extracts the same process twice when a design declares it in both
+// `manufacturing_processes` and `manufacturing_specs.process_requirements` —
+// which is every catalogue design that has both. A three-requirement design
+// reported six, and the tolerance slider offered to relax to four.
+describe("requirementStats deduplicates requirements", () => {
+  const dup = (value: string, status: string) => ({
+    requirement_value: value,
+    status,
+  });
+
+  it("counts a process declared in both sources once", () => {
+    const stats = requirementStats({
+      requirement_matches: [
+        dup("3D Printing", "matched"),
+        dup("Laser Cutting", "matched"),
+        dup("Assembly", "matched"),
+        dup("3D Printing", "matched"),
+        dup("Laser Cutting", "matched"),
+        dup("Assembly", "matched"),
+      ],
+    });
+    expect(stats).toEqual({ total: 3, missing: 0 });
+  });
+
+  it("treats a requirement as missing if any copy is unmatched", () => {
+    // Deduping must never hide a gap.
+    const stats = requirementStats({
+      requirement_matches: [
+        dup("Soldering", "matched"),
+        dup("Soldering", "not_matched"),
+      ],
+    });
+    expect(stats).toEqual({ total: 1, missing: 1 });
+  });
+
+  it("is case- and whitespace-insensitive", () => {
+    const stats = requirementStats({
+      requirement_matches: [dup("3D Printing", "matched"), dup(" 3d printing ", "matched")],
+    });
+    expect(stats).toEqual({ total: 1, missing: 0 });
+  });
+
+  it("keeps unlabelled requirements distinct", () => {
+    // Without a value there is nothing to dedupe on; collapsing them would
+    // under-count real requirements.
+    const stats = requirementStats({
+      requirement_matches: [{ status: "matched" }, { status: "not_matched" }],
+    });
+    expect(stats).toEqual({ total: 2, missing: 1 });
+  });
+
+  it("still returns null when the API sent no explanation", () => {
+    expect(requirementStats(null)).toBeNull();
+    expect(requirementStats({ requirement_matches: [] })).toBeNull();
+  });
+});

--- a/frontend/src/features/match/nearMiss.ts
+++ b/frontend/src/features/match/nearMiss.ts
@@ -29,6 +29,7 @@ export interface RequirementStats {
 
 interface RequirementMatch {
   status?: string | null;
+  requirement_value?: string | null;
 }
 
 interface ExplanationLike {
@@ -38,9 +39,15 @@ interface ExplanationLike {
 }
 
 /**
- * Read requirement counts out of a structured explanation.
+ * Read requirement counts out of a structured explanation, counting each
+ * requirement ONCE.
  *
- * Returns null when the API did not include one — callers must not infer
+ * The API extracts the same process twice when a design declares it in both
+ * `manufacturing_processes` and `manufacturing_specs.process_requirements`, so
+ * a three-requirement design reported six. A duplicate counts as matched only
+ * if every copy did, so deduping cannot hide a gap.
+ *
+ * Returns null when the API sent no explanation — callers must not infer
  * "nothing missing" from missing data, which would resurrect the original bug
  * in a quieter form.
  */
@@ -49,8 +56,18 @@ export function requirementStats(
 ): RequirementStats | null {
   const matches = explanation?.requirement_matches;
   if (!Array.isArray(matches) || matches.length === 0) return null;
-  const missing = matches.filter((m) => m?.status !== "matched").length;
-  return { total: matches.length, missing };
+
+  const satisfied = new Map<string, boolean>();
+  matches.forEach((m, i) => {
+    // Fall back to the index when the value is absent, so an unlabelled
+    // requirement stays its own entry rather than collapsing with others.
+    const key = m?.requirement_value?.trim().toLowerCase() || `#${i}`;
+    const ok = m?.status === "matched";
+    satisfied.set(key, (satisfied.get(key) ?? true) && ok);
+  });
+
+  const missing = [...satisfied.values()].filter((ok) => !ok).length;
+  return { total: satisfied.size, missing };
 }
 
 /** Most missing requirements a user may choose to tolerate, given `r`. */

--- a/src/core/api/routes/match.py
+++ b/src/core/api/routes/match.py
@@ -1459,11 +1459,15 @@ def _extract_required_processes_from_manifest(okh_manifest: OKHManifest) -> List
 
 
 def _collect_matched_processes_from_solutions(solutions: List[dict]) -> List[str]:
-    """Collect process-like capability names from single-level solution payloads.
+    """Collect the processes the returned solutions actually satisfy.
 
-    For composite solutions (multiple facilities) all constituent facilities are
-    inspected so that the coverage summary reflects the union of their capabilities,
-    not just the representative tree.
+    Reads each solution's ``explanation.requirement_matches`` — the matcher's own
+    per-requirement verdict, and the same evidence the result cards show. It
+    previously read ``tree.capabilities_used``, which is always empty, so every
+    match reported zero coverage (see tests/unit/test_match_coverage_summary.py).
+
+    Composite solutions still use their facilities' processes: a composite's
+    coverage is the union across its members, not any one facility's verdict.
     """
     values: List[str] = []
     for solution in solutions:
@@ -1476,13 +1480,19 @@ def _collect_matched_processes_from_solutions(solutions: List[dict]) -> List[str
                     proc_text = str(proc).strip()
                     if proc_text:
                         values.append(proc_text)
-        else:
-            tree = solution.get("tree", {}) or {}
-            capabilities = tree.get("capabilities_used", []) or []
-            for cap in capabilities:
-                cap_text = str(cap).strip()
-                if cap_text:
-                    values.append(cap_text)
+            continue
+
+        explanation = solution.get("explanation") or {}
+        for match in explanation.get("requirement_matches") or []:
+            if not match or match.get("status") != "matched":
+                continue
+            # Keep both forms — the capability the facility offers and the value
+            # the design asked for — so _processes_match can resolve whichever
+            # one the taxonomy recognises.
+            for field in ("matched_capability", "requirement_value"):
+                text = str(match.get(field) or "").strip()
+                if text:
+                    values.append(text)
     return values
 
 

--- a/tests/unit/test_match_coverage_summary.py
+++ b/tests/unit/test_match_coverage_summary.py
@@ -1,0 +1,171 @@
+"""Match coverage must be read from the matcher's own verdict.
+
+The summary reported ``coverage 0/N`` and listed every requirement as a gap on
+*every* match, while the result cards beside it said "Meets every requirement".
+Both were rendering the same response.
+
+``_collect_matched_processes_from_solutions`` read ``tree.capabilities_used``,
+a key that is present on every tree and always empty, so nothing was ever
+counted as matched. The summary was not describing a failed match — it was
+describing a field nobody populates.
+
+This fires in the worst direction: a successful match is presented as a total
+failure, in a warning-styled banner naming the exact capabilities the user
+needs, above ten facilities that can in fact build the design.
+"""
+
+from __future__ import annotations
+
+from src.core.api.routes.match import (
+    _build_match_summary,
+    _collect_matched_processes_from_solutions,
+)
+
+
+class Request:
+    """The fields _build_match_summary reads off the request."""
+
+    allow_facility_combinations = False
+    max_facilities_per_solution = None
+    return_alternative_solutions = False
+    combination_strategy = None
+
+
+def solution(*matches, composite=False, facilities=()):
+    if composite:
+        return {
+            "is_composite": True,
+            "facility_details": [
+                {"facility": {"manufacturing_processes": list(p)}} for p in facilities
+            ],
+        }
+    return {
+        "tree": {"capabilities_used": []},  # always empty in practice
+        "explanation": {
+            "requirement_matches": [
+                {
+                    "requirement_value": value,
+                    "matched_capability": capability,
+                    "status": status,
+                }
+                for value, capability, status in matches
+            ]
+        },
+    }
+
+
+def summarise(required, solutions):
+    return _build_match_summary(
+        required_processes=required,
+        matched_processes=_collect_matched_processes_from_solutions(solutions),
+        solution_count=len(solutions),
+        matching_mode="single-level",
+        request=Request(),
+    )
+
+
+class TestCoverageReflectsTheMatch:
+    def test_a_fully_matched_design_reports_full_coverage(self):
+        """The reported bug: this said 0/3 with every process listed as a gap."""
+        solutions = [
+            solution(
+                ("3D Printing", "3d_printing", "matched"),
+                ("Laser Cutting", "laser_cutting", "matched"),
+                ("Assembly", "electronics_assembly", "matched"),
+            )
+        ]
+
+        summary, gaps = summarise(
+            ["3D Printing", "Laser Cutting", "Assembly"], solutions
+        )
+
+        assert summary["covered_process_count"] == 3
+        assert summary["required_process_count"] == 3
+        assert summary["coverage_ratio"] == 1.0
+        assert gaps == []
+
+    def test_an_unmatched_requirement_is_still_reported_as_a_gap(self):
+        """The fix must not make every match look complete instead."""
+        solutions = [
+            solution(
+                ("3D Printing", "3d_printing", "matched"),
+                ("Soldering", None, "not_matched"),
+            )
+        ]
+
+        summary, gaps = summarise(["3D Printing", "Soldering"], solutions)
+
+        assert summary["covered_process_count"] == 1
+        assert gaps == ["Soldering"]
+
+    def test_coverage_is_the_union_across_solutions(self):
+        """No single facility covers everything, but the network does."""
+        solutions = [
+            solution(("3D Printing", "3d_printing", "matched")),
+            solution(("Laser Cutting", "laser_cutting", "matched")),
+        ]
+
+        summary, gaps = summarise(["3D Printing", "Laser Cutting"], solutions)
+
+        assert summary["coverage_ratio"] == 1.0
+        assert gaps == []
+
+    def test_duplicate_requirements_are_counted_once(self):
+        """Designs declaring a process in both sources must not report 6 of 3."""
+        solutions = [
+            solution(
+                ("3D Printing", "3d_printing", "matched"),
+                ("3D Printing", "3d_printing", "matched"),
+            )
+        ]
+
+        summary, _ = summarise(["3D Printing", "3D Printing"], solutions)
+
+        assert summary["required_process_count"] == 1
+        assert summary["covered_process_count"] == 1
+
+    def test_no_solutions_means_no_coverage(self):
+        summary, gaps = summarise(["3D Printing"], [])
+
+        assert summary["covered_process_count"] == 0
+        assert gaps == ["3D Printing"]
+
+    def test_composite_solutions_still_use_facility_processes(self):
+        """A composite's coverage is the union of its members, not one verdict."""
+        solutions = [
+            solution(
+                composite=True,
+                facilities=(["3D Printing"], ["Laser Cutting"]),
+            )
+        ]
+
+        summary, gaps = summarise(["3D Printing", "Laser Cutting"], solutions)
+
+        assert summary["coverage_ratio"] == 1.0
+        assert gaps == []
+
+
+class TestCollection:
+    def test_only_matched_requirements_are_collected(self):
+        collected = _collect_matched_processes_from_solutions(
+            [
+                solution(
+                    ("3D Printing", "3d_printing", "matched"),
+                    ("Soldering", None, "not_matched"),
+                )
+            ]
+        )
+
+        assert "Soldering" not in collected
+        assert "3D Printing" in collected
+
+    def test_both_the_requirement_and_the_capability_are_kept(self):
+        """Either form may be the one the taxonomy recognises."""
+        collected = _collect_matched_processes_from_solutions(
+            [solution(("Assembly", "electronics_assembly", "matched"))]
+        )
+
+        assert set(collected) == {"Assembly", "electronics_assembly"}
+
+    def test_a_solution_without_an_explanation_contributes_nothing(self):
+        assert _collect_matched_processes_from_solutions([{"tree": {}}]) == []


### PR DESCRIPTION
A fully successful match was presented as a total failure.

The page led with `coverage 0/3 (0.000)` and a warning-styled "Coverage gaps" banner naming the exact processes the design needs — above ten facilities each reading "Meets every requirement". All rendered from a single response.

**The cards were right.** Three defects, all in the data rather than the rendering.

## 1. Coverage was read from a field nobody populates

`_collect_matched_processes_from_solutions` read `tree.capabilities_used`. That key is present on every tree and is **always empty**, so nothing was ever counted as matched — **every** match reported zero coverage and listed every requirement as a gap, not just this one.

It now reads `explanation.requirement_matches`, the matcher's own per-requirement verdict and the same evidence the cards show. Verified against the exact payload from the report:

```
before:  coverage 0/3 (0.0)   gaps: [3D Printing, Laser Cutting, Assembly]
after:   coverage 3/3 (1.0)   gaps: []
```

This one fires in the worst direction — a false negative, styled as a warning, above ten facilities that can actually build the design.

## 2. Requirement counts were doubled

A design declaring a process in both `manufacturing_processes` and `manufacturing_specs.process_requirements` has it extracted twice. Across 100 catalogue designs: **19 have both sources and all 19 duplicate every process name**; `process_requirements` never appears alone. So a three-requirement design reported six, and the near-miss slider offered to relax to four.

**Deduped when counting, not when extracting.** Extraction dedupe is arithmetically safe today — `coverage` is a ratio and `overall_confidence` a mean, so identical duplicates cancel — but only *because* the matcher reads `process_name` and ignores `parameters`, `validation_criteria` and `required_tools`. When those start mattering (the MoM v3 "who can cut 3mm aluminium" direction), a spec requirement and a bare top-level one stop being the same requirement, and a dedupe baked into extraction becomes silently wrong. It would also need merge semantics to avoid dropping detail like `required_tools: ['printer']`.

A duplicate counts as matched only if every copy did, so deduping cannot hide a gap.

## 3. Confidence was two different numbers

`confidence` is coverage-derived and reads 1.0 whenever everything matched. `overall_confidence` is the mean of the per-requirement confidences — the ones the card's own text quotes. The card rendered the first beside text quoting the second: "confidence 100%" next to "(confidence: 95%)". It now shows the figure with per-requirement evidence under it.

## Deliberately not changed

`explanation_human` still reads "All 6 requirement(s) satisfied" and lists each requirement twice. It is **not rendered in the UI** — the card shows only its first line — and deduping it means restructuring a widely-used explanation format with its own tests. Worth doing separately rather than smuggling into this fix.

## Tests

9 backend, 8 frontend. The backend set pins the union-across-solutions case, that a genuine gap is still reported (the fix must not make everything look complete instead), and that composites still use their facilities' processes. The frontend set pins that an unmatched copy makes the whole requirement unmatched, and that unlabelled requirements stay distinct rather than collapsing.

`make ready` (1040) and `frontend-ready` (66) both pass. Written with a backward pass — the narrative lives in the test module docstring rather than being repeated across three comment blocks.

## Related finding

**63 of the 100 designs sampled declare no manufacturing processes at all.** That is a generation-pipeline problem, not a display one, and is being picked up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)