### PR TITLE
Infer manufacturing processes from TSDC codes

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -1145,7 +1145,7 @@ Total Python files: 587
 │       │   │   │       class FileCategorizationService (__init__, _parse_llm_response, _extract_json_from_response...)
 │       │   │   ├── process_inference_service.py
 │       │   │   │       class ProcessInferenceResult
-│       │   │   │       class ProcessInferenceService (__init__, infer_from_paths, infer_from_text...)
+│       │   │   │       class ProcessInferenceService (__init__, infer_from_tsdc, infer_from_paths...)
 │       │   │   ├── prompts/
 │       │   │   │   ├── __init__.py
 │       │   │   │   └── file_categorization_prompts.py
@@ -2812,6 +2812,15 @@ Total Python files: 587
         │       def test_face_in_title_does_not_infer_surface_finishing()
         │       def test_manifest_title_used_when_no_file_types()
         │       def test_file_type_and_title_merge()
+        │       def test_tsdc_codes_infer_their_processes()
+        │       def test_tsdc_is_case_and_whitespace_insensitive()
+        │       def test_unknown_tsdc_codes_are_skipped()
+        │       def test_tsdc_outranks_filename_and_title_confidence()
+        │       def test_manifest_tsdc_is_used_when_title_and_files_say_nothing()
+        │       def test_tsdc_merges_with_the_other_signals()
+        │       def test_apply_to_manifest_populates_from_tsdc()
+        │       def test_a_string_tsdc_is_tolerated()
+        │       def test_absent_tsdc_changes_nothing()
         ├── test_provenance_model.py
         │       def test_credit_requires_exactly_one_identifier()
         │       def test_provenance_sign_and_verify_round_trip()
@@ -3010,7 +3019,7 @@ Lives in ``src/core/generatio...
 **Classes:**
 - `ProcessInferenceResult`
 - `ProcessInferenceService`
-  - Methods: infer_from_paths, infer_from_text, infer, infer_from_manifest, apply_to_manifest
+  - Methods: infer_from_tsdc, infer_from_paths, infer_from_text, infer, infer_from_manifest
   - File-type + title/keyword → manufacturing process inference....
 
 **Internal Dependencies:** 1 imports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Process inference now reads TSDC codes**, the DIN SPEC 3105 codes a design's
+  own manifest declares. It previously read only design-file extensions and the
+  title, so **123 of 175 catalogue designs carried no manufacturing processes at
+  all — and a design with no processes returns zero matches.** Inference was
+  riding on a filename convention: designs *titled* `3DP-…` got `3D Printing`,
+  while an identical `tsdc: ['3DP']` on `3D-Simple-Bias-Tape-Maker` got nothing.
+  The taxonomy already resolved these codes; only inference never asked. A
+  dry-run backfill over production fills 100 of the 123 (81%).
+
+### Fixed
+
 - **Match results contradicted themselves.** A fully successful match was
   presented as a total failure: a `coverage 0/3` headline and a warning-styled
   "Coverage gaps" banner naming the exact processes the design needs, sitting

--- a/docs/architecture/generation.md
+++ b/docs/architecture/generation.md
@@ -678,6 +678,21 @@ useful, by OKH storage backfill:
 **Process inference** fills empty `manufacturing_processes` during generation
 (heuristic layer, plus an engine post-normalize safety net) and via
 `ohm okh infer-processes` / `OKHService.backfill_manufacturing_processes`.
+
+Three signals, in descending confidence:
+
+| signal | confidence | why |
+|---|---|---|
+| `tsdc` codes (DIN SPEC 3105) | 0.95 | the author declaring the process |
+| design-file extensions | 0.85 | strong but inferred |
+| title / keywords | 0.72 | a guess from prose |
+
+TSDC was added after an audit found **123 of 175 catalogue designs carried no
+processes, 100 of them holding a TSDC code the taxonomy already resolved**.
+Inference read only filenames and titles, so a design *titled* `3DP-…` got
+`3D Printing` while an identical `tsdc: ['3DP']` on a differently-named design
+got nothing — and a design with no processes matches nothing at all.
+
 It resolves display names through the [canonical process taxonomy](process-taxonomy-adr.md)
 using **exact** alias/TSDC lookup for tokens (avoids substring false positives
 such as `face` ⊂ `surface_finish`). Extension → process mappings are defined

--- a/src/cli/okh.py
+++ b/src/cli/okh.py
@@ -3303,10 +3303,10 @@ async def set_compatible_manifests_cmd(
 async def infer_processes_cmd(
     ctx, manifest_id, all_manifests, limit, apply, merge, output
 ):
-    """Infer manufacturing_processes from design/manufacturing file types.
+    """Infer manufacturing_processes for manifests that declare none.
 
-    Uses the modular ProcessInferenceService (file extensions + title/keywords
-    → taxonomy processes).
+    Uses ProcessInferenceService: TSDC codes (DIN SPEC 3105), then design-file
+    extensions, then title/keywords → taxonomy processes.
     Default is dry-run; pass --apply to write storage.
 
     \b

--- a/src/core/generation/services/process_inference_service.py
+++ b/src/core/generation/services/process_inference_service.py
@@ -92,6 +92,9 @@ _TEXT_TOKEN_BLOCKLIST = frozenset(
 
 DEFAULT_FILE_TYPE_CONFIDENCE = 0.85
 DEFAULT_TEXT_CONFIDENCE = 0.72
+# A TSDC code is the author declaring the process under DIN SPEC 3105, not a
+# guess from a filename or a word in a title, so it outranks both.
+DEFAULT_TSDC_CONFIDENCE = 0.95
 
 _TOKEN_SPLIT = re.compile(r"[^a-zA-Z0-9]+")
 
@@ -111,6 +114,27 @@ class ProcessInferenceService:
         self.extension_map = dict(EXTENSION_TO_PROCESS)
         self.confidence = DEFAULT_FILE_TYPE_CONFIDENCE
         self.text_confidence = DEFAULT_TEXT_CONFIDENCE
+        self.tsdc_confidence = DEFAULT_TSDC_CONFIDENCE
+
+    def infer_from_tsdc(self, codes: Iterable[str]) -> ProcessInferenceResult:
+        """Infer from DIN SPEC 3105 TSDC codes (``3DP``, ``ASM``, ``LAS``…).
+
+        ``taxonomy.normalize`` already resolves these, so values that are not
+        codes (``OSH``, ``MEC/ASM/etc.``) return None and are skipped.
+        """
+        seen_ids: Dict[str, List[str]] = {}
+        for raw in codes:
+            if not raw or not isinstance(raw, str):
+                continue
+            code = raw.strip()
+            canonical = taxonomy.normalize(code)
+            if canonical is None:
+                continue
+            evidence = f"tsdc:{code}"
+            bucket = seen_ids.setdefault(canonical, [])
+            if evidence not in bucket:
+                bucket.append(evidence)
+        return self._result_from_ids(seen_ids, self.tsdc_confidence)
 
     def infer_from_paths(self, paths: Iterable[str]) -> ProcessInferenceResult:
         seen_ids: Dict[str, List[str]] = {}
@@ -178,8 +202,10 @@ class ProcessInferenceService:
         paths: Optional[Iterable[str]] = None,
         text: str = "",
         keywords: Optional[Sequence[str]] = None,
+        tsdc: Optional[Iterable[str]] = None,
     ) -> ProcessInferenceResult:
         return self._merge_results(
+            self.infer_from_tsdc(tsdc or ()),
             self.infer_from_paths(paths or ()),
             self.infer_from_text(text, keywords=keywords),
         )
@@ -190,7 +216,12 @@ class ProcessInferenceService:
         keywords = getattr(manifest, "keywords", None) or []
         if isinstance(keywords, str):
             keywords = [keywords]
-        return self.infer(paths=paths, text=str(title), keywords=list(keywords))
+        return self.infer(
+            paths=paths,
+            text=str(title),
+            keywords=list(keywords),
+            tsdc=self._tsdc_from_manifest(manifest),
+        )
 
     def apply_to_manifest(
         self,
@@ -276,6 +307,13 @@ class ProcessInferenceService:
         if key in taxonomy._alias_map:
             return taxonomy._alias_map[key]
         return taxonomy._tsdc_map.get(token.strip().upper())
+
+    @staticmethod
+    def _tsdc_from_manifest(manifest: object) -> List[str]:
+        codes = getattr(manifest, "tsdc", None)
+        if isinstance(codes, str):
+            return [codes]
+        return [c for c in (codes or []) if isinstance(c, str)]
 
     @staticmethod
     def _extension_of(path: str) -> str:

--- a/src/core/services/okh_service.py
+++ b/src/core/services/okh_service.py
@@ -1022,7 +1022,7 @@ class OKHService(BaseService["OKHService"]):
         limit: Optional[int] = None,
     ) -> Dict[str, Any]:
         """
-        Infer manufacturing_processes from file types / title on stored OKHs.
+        Infer manufacturing_processes from TSDC codes / file types / title.
 
         By default only fills empty process lists and does not write (dry_run=True).
         Pass dry_run=False to persist updates via :meth:`update`.

--- a/tests/unit/test_process_inference_service.py
+++ b/tests/unit/test_process_inference_service.py
@@ -244,3 +244,79 @@ async def test_heuristic_layer_infers_from_stl() -> None:
     assert result.has_field("manufacturing_processes")
     processes = result.get_field("manufacturing_processes").value
     assert "3D Printing" in processes
+
+
+# TSDC — DIN SPEC 3105 codes the author declared, rather than a guess from a
+# filename or a word in a title.
+#
+# This signal was missing entirely, and it was the largest data-quality problem
+# in the catalogue: 123 of 175 designs had no processes, 100 of them carried a
+# TSDC code the taxonomy already resolves, and a design with no processes
+# returns ZERO matches. Processes were populated only for designs *titled*
+# "3DP-…", so `tsdc=['3DP']` on "3D-Simple-Bias-Tape-Maker" inferred nothing
+# while the identical code on "3DP-Accessible-Pill-Bottle" worked.
+
+
+def test_tsdc_codes_infer_their_processes(service: ProcessInferenceService) -> None:
+    result = service.infer_from_tsdc(["3DP", "LAS"])
+    assert set(result.processes) == {"3D Printing", "Laser Cutting"}
+    assert result.evidence["3d_printing"] == ["tsdc:3DP"]
+
+
+def test_tsdc_is_case_and_whitespace_insensitive(
+    service: ProcessInferenceService,
+) -> None:
+    assert service.infer_from_tsdc([" 3dp "]).processes == ["3D Printing"]
+
+
+def test_unknown_tsdc_codes_are_skipped(service: ProcessInferenceService) -> None:
+    """Real catalogue values that are not codes must not invent a process."""
+    result = service.infer_from_tsdc(["OSH", "MEC/ASM/etc.", ""])
+    assert result.processes == []
+    assert result.confidence == 0.0
+
+
+def test_tsdc_outranks_filename_and_title_confidence(
+    service: ProcessInferenceService,
+) -> None:
+    """A declaration should carry more weight than a guess."""
+    assert (
+        service.infer_from_tsdc(["3DP"]).confidence
+        > service.infer_from_paths(["a.stl"]).confidence
+    )
+
+
+def test_manifest_tsdc_is_used_when_title_and_files_say_nothing(
+    service: ProcessInferenceService,
+) -> None:
+    """The exact shape of the 100 broken designs."""
+    manifest = _manifest(title="4cm-Bias-Tape-Maker", tsdc=["3DP"])
+    result = service.infer_from_manifest(manifest)
+    assert result.processes == ["3D Printing"]
+
+
+def test_tsdc_merges_with_the_other_signals(
+    service: ProcessInferenceService,
+) -> None:
+    manifest = _manifest(title="Laser cut enclosure", tsdc=["ASM"])
+    result = service.infer_from_manifest(manifest)
+    assert set(result.processes) == {"Assembly", "Laser Cutting"}
+
+
+def test_apply_to_manifest_populates_from_tsdc(
+    service: ProcessInferenceService,
+) -> None:
+    manifest = _manifest(title="Air-Cleaner", tsdc=["ASM"])
+    result = service.apply_to_manifest(manifest)
+    assert result.applied is True
+    assert manifest.manufacturing_processes == ["Assembly"]
+
+
+def test_a_string_tsdc_is_tolerated(service: ProcessInferenceService) -> None:
+    manifest = _manifest(title="Widget", tsdc="3DP")
+    assert service.infer_from_manifest(manifest).processes == ["3D Printing"]
+
+
+def test_absent_tsdc_changes_nothing(service: ProcessInferenceService) -> None:
+    manifest = _manifest(title="Widget")
+    assert service.infer_from_manifest(manifest).processes == []


### PR DESCRIPTION
**123 of 175 catalogue designs carried no manufacturing processes — and a design with no processes returns zero matches.** 70% of the catalogue was unmatchable.

Confirmed against production:

```
4cm-Bias-Tape-Maker            tsdc=['3DP']  solutions=0
3M-6000_7500-Half-Face-Mask    tsdc=['3DP']  solutions=0
Air-Cleaner-2-Modular          tsdc=['ASM']  solutions=0
3DP-Accessible-Pill-Bottle     tsdc=['3DP']  solutions=5   ← has processes
```

## Root cause

`ProcessInferenceService` read three signals — design-file extensions, title, keywords. It never read `tsdc`, the DIN SPEC 3105 code the manifest itself declares and which the taxonomy already resolves.

So inference was riding on a filename convention. Identical inputs diverge on the title alone:

```
tsdc=['3DP']  title="3DP-Accessible-Pill-Bottle"  →  ['3D Printing']
tsdc=['3DP']  title="3D-Simple-Bias-Tape-Maker"   →  []
```

Designs titled `3DP…` are **0% missing**; everything else is **75% missing**.

## It is the generator, as suspected

| pipeline (`okhv`) | designs | missing |
|---|---|---|
| **2.4** — generate-from-url | 143 | **119 (83%)** |
| OKH-LOSHv1.0 — bulk import | 31 | 4 (13%) |

## One proposed step turned out to be unnecessary

I had planned to add a reverse `tsdc → process` index to the taxonomy. `taxonomy.normalize()` already resolves TSDC codes (it is step 3 of its documented resolution order), so that work was dropped rather than built. Values that are not codes — real catalogue junk like `OSH` and `MEC/ASM/etc.` — resolve to `None` and are skipped.

TSDC is ranked **above** the other signals (0.95 vs 0.85 for filenames, 0.72 for titles) because it is the author declaring the process, not a guess.

## Dry-run over the production catalogue

```
scanned=175  updated=100  skipped_nonempty=52  no_inference=23
```

Restored: `Assembly` 49, `3D Printing` 38, `Mechanical Assembly` 7, `Laser Cutting` 6. **Zero disagreement** with the 52 designs that already declare processes.

**An honest caveat on impact:** of the 100, only the 3DP (38) and LAS (6) designs will actually start matching, because those map to processes with 2,597 and 2,185 facilities. The 49 `ASM` designs map to `assembly`, which **zero** MoM facilities advertise — the exact gap the MoM vocabulary proposal addresses. Those move from *silently* unmatchable to *honestly* unmatchable with a named gap. Worth doing, but it is ~44 designs that become genuinely matchable, not 100.

## Follow-ups, not in this PR

- **The remaining 23** carry no `tsdc`. 15 have design files, but they are `.jpg`/`.pdf` or extensionless Thingiverse download links, so file-type inference legitimately cannot help. They want the remote file-type resolution from 0.10.2 applied to extensionless links.
- **`ohm okh infer-processes --all` defaults to `--limit 100`.** With 175 designs it reports `scanned=100` and looks complete. I hit this myself during verification. It is pre-existing and the default is shown in `--help`, so I have not changed it here, but a silent partial backfill that reports success is worth fixing.

## Tests

9 new, including the exact shape of the 100 broken designs, that non-code values invent nothing, and that TSDC outranks filename confidence. `make ready` passes (1049).

Written with a backward pass: the 10-line docstring came down to 3 once the narrative was in the tests and the architecture doc, and a redundant empty-string guard came out after confirming `normalize("")` already returns `None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)