### PR TITLE
Make infer-processes --all scan the whole catalogue

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -2794,6 +2794,7 @@ Total Python files: 587
         │       def test_check_file_url_relative_path()
         │       def test_write_probe_proposals_creates_markdown()
         ├── test_process_inference_service.py
+        │       class _FakeService (__init__)
         │       def _manifest()
         │       def service()
         │       def test_stl_paths_infer_3d_printing()
@@ -3567,6 +3568,10 @@ This module provides functionality for migrating files to organized direc...
 
 **Exports:** service, test_stl_paths_infer_3d_printing, test_3mf_and_gcode_infer_3d_printing, test_gerber_infers_pcb_fabrication, test_nc_infers_cnc_machining
 
+**Classes:**
+- `_FakeService`
+  - Exercises backfill_manufacturing_processes' selection logic only....
+
 **Functions:**
 - `service()`
 - `test_stl_paths_infer_3d_printing(service)`
@@ -3574,7 +3579,7 @@ This module provides functionality for migrating files to organized direc...
 - `test_gerber_infers_pcb_fabrication(service)`
 - `test_nc_infers_cnc_machining(service)`
 
-**Internal Dependencies:** 11 imports
+**Internal Dependencies:** 14 imports
 
 ### `tests/unit/test_service_provenance_stamping.py`
 > OKH/OKW create persists provenance to its own plane (Slice 3).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`ohm okh infer-processes --all` now scans everything.** It defaulted to
+  `--limit 100` and the service capped an unlimited run at 500, so against 175
+  designs it reported `scanned=100` and looked complete — a partial backfill
+  presented as success. `--limit` is now an opt-in cap, and a capped run says
+  how many manifests it left behind.
+
+### Fixed
+
 - **Process inference now reads TSDC codes**, the DIN SPEC 3105 codes a design's
   own manifest declares. It previously read only design-file extensions and the
   title, so **123 of 175 catalogue designs carried no manufacturing processes at

--- a/src/cli/okh.py
+++ b/src/cli/okh.py
@@ -3283,7 +3283,10 @@ async def set_compatible_manifests_cmd(
     help="Scan stored OKHs (use with --limit)",
 )
 @click.option(
-    "--limit", default=100, show_default=True, help="Max manifests when --all"
+    "--limit",
+    type=int,
+    default=None,
+    help="Cap manifests scanned with --all (default: no cap, scan everything)",
 )
 @click.option(
     "--apply",
@@ -3346,6 +3349,12 @@ async def infer_processes_cmd(
         f"missing={report['missing']}",
         "success" if report["updated_count"] or report["dry_run"] else "info",
     )
+    if report.get("not_scanned"):
+        cli_ctx.log(
+            f"{report['not_scanned']} manifest(s) were NOT scanned because of "
+            f"--limit. Re-run without it to cover the whole catalogue.",
+            "warning",
+        )
     for entry in report.get("updated") or []:
         cli_ctx.log(
             f"  {entry['id']}: {entry['before']} → {entry['after']}",

--- a/src/core/services/okh_service.py
+++ b/src/core/services/okh_service.py
@@ -1035,6 +1035,7 @@ class OKHService(BaseService["OKHService"]):
         service = ProcessInferenceService()
 
         targets: List[OKHManifest] = []
+        not_scanned = 0
         if manifest_ids:
             for mid in manifest_ids:
                 manifest = await self.get(mid)
@@ -1042,9 +1043,15 @@ class OKHService(BaseService["OKHService"]):
                     continue
                 targets.append(manifest)
         else:
-            page_size = limit or 500
-            manifests, _total = await self.list(page=1, page_size=page_size)
-            targets = manifests[:limit] if limit is not None else list(manifests)
+            # Probe the size before deciding how many to take, so an unlimited
+            # run means all of them. The catalogue is cached, so the extra call
+            # is cheap. `not_scanned` is what makes a capped run say so.
+            _, total = await self.list(page=1, page_size=1)
+            take = total if limit is None else min(limit, total)
+            # page_size floors at 1; the slice is what honours take == 0.
+            manifests, _ = await self.list(page=1, page_size=max(take, 1))
+            targets = list(manifests[:take])
+            not_scanned = total - len(targets)
 
         scanned = 0
         updated: List[Dict[str, Any]] = []
@@ -1086,6 +1093,7 @@ class OKHService(BaseService["OKHService"]):
             "dry_run": dry_run,
             "only_if_empty": only_if_empty,
             "scanned": scanned,
+            "not_scanned": not_scanned,
             "missing": missing,
             "skipped_nonempty": skipped_nonempty,
             "no_inference": no_inference,

--- a/tests/unit/test_process_inference_service.py
+++ b/tests/unit/test_process_inference_service.py
@@ -320,3 +320,72 @@ def test_a_string_tsdc_is_tolerated(service: ProcessInferenceService) -> None:
 def test_absent_tsdc_changes_nothing(service: ProcessInferenceService) -> None:
     manifest = _manifest(title="Widget")
     assert service.infer_from_manifest(manifest).processes == []
+
+
+# The backfill must not report success for a partial run.
+#
+# `ohm okh infer-processes --all` defaulted to `--limit 100`, and the service
+# capped an unlimited run at 500 (`page_size = limit or 500`). Against 175
+# designs it printed "scanned=100" with no indication that 75 were untouched.
+
+
+class _FakeService:
+    """Exercises backfill_manufacturing_processes' selection logic only."""
+
+    def __init__(self, count):
+        from src.core.models.okh import License, OKHManifest
+
+        self._manifests = [
+            OKHManifest(
+                title=f"D{i}",
+                version="1.0.0",
+                license=License(hardware="MIT"),
+                licensor="T",
+                documentation_language="en",
+                function="f",
+            )
+            for i in range(count)
+        ]
+
+    async def list(self, page=1, page_size=100):
+        return self._manifests[:page_size], len(self._manifests)
+
+    async def ensure_initialized(self):
+        return None
+
+
+async def _run_backfill(count, limit):
+    from src.core.services.okh_service import OKHService
+
+    fake = _FakeService(count)
+    return await OKHService.backfill_manufacturing_processes(
+        fake, only_if_empty=True, dry_run=True, limit=limit
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_limit_scans_every_manifest() -> None:
+    report = await _run_backfill(175, None)
+    assert report["scanned"] == 175
+    assert report["not_scanned"] == 0
+
+
+@pytest.mark.asyncio
+async def test_no_limit_is_not_silently_capped_at_500() -> None:
+    report = await _run_backfill(620, None)
+    assert report["scanned"] == 620
+
+
+@pytest.mark.asyncio
+async def test_a_limit_reports_what_it_left_behind() -> None:
+    """The footgun: 100 of 175 scanned, previously reported as success."""
+    report = await _run_backfill(175, 100)
+    assert report["scanned"] == 100
+    assert report["not_scanned"] == 75
+
+
+@pytest.mark.asyncio
+async def test_a_limit_larger_than_the_catalogue_leaves_nothing_behind() -> None:
+    report = await _run_backfill(175, 500)
+    assert report["scanned"] == 175
+    assert report["not_scanned"] == 0


### PR DESCRIPTION
`ohm okh infer-processes --all` reported success for a **partial** run.

Two independent caps: the CLI defaulted `--limit` to 100, and the service capped an unlimited run at 500 (`page_size = limit or 500`). Against 175 designs the command printed:

```
✅ [DRY-RUN] scanned=100 updated=52 ...
```

Nothing indicated that 75 manifests were never looked at. This is the same shape as the Redis bug earlier in this sequence — a component reporting healthy output while quietly doing a fraction of its job.

I hit it myself: the first `--all` run of the TSDC backfill covered 100 of 175, and I only noticed because I had an independent count of the catalogue.

## Changes

- `--limit` is an opt-in cap, not a default
- the service takes its size from the catalogue rather than a magic 500
- a capped run reports `not_scanned`, and the CLI surfaces it:

```
✅ [DRY-RUN] scanned=100 ...
⚠️  75 manifest(s) were NOT scanned because of --limit. Re-run without it to cover the whole catalogue.
```

## Verified against the live catalogue

```
--all              → scanned=175  not_scanned=0
--all --limit 100  → scanned=100  not_scanned=75  + warning
```

## Tests

4 new: no limit scans everything, no limit is not silently capped at 500, a limit reports what it left behind, and a limit larger than the catalogue leaves nothing behind.

`make ready` passes (1053). Backward pass applied — trimmed the explanatory comment once the tests carried the narrative, and kept the `manifests[:take]` slice after confirming it is load-bearing for the `take == 0` case (page_size floors at 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)