### PR TITLE
Add sewing to the taxonomy; purge test fixtures from production

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -2822,6 +2822,10 @@ Total Python files: 587
         │       def test_apply_to_manifest_populates_from_tsdc()
         │       def test_a_string_tsdc_is_tolerated()
         │       def test_absent_tsdc_changes_nothing()
+        │       def test_sewing_is_inferred_from_the_title()
+        │       def test_the_short_token_sew_is_matched()
+        │       def test_product_names_do_not_imply_sewing()
+        │       def test_sewing_is_not_reachable_from_assembly()
         ├── test_provenance_model.py
         │       def test_credit_requires_exactly_one_identifier()
         │       def test_provenance_sign_and_verify_round_trip()
@@ -3579,7 +3583,7 @@ This module provides functionality for migrating files to organized direc...
 - `test_gerber_infers_pcb_fabrication(service)`
 - `test_nc_infers_cnc_machining(service)`
 
-**Internal Dependencies:** 14 imports
+**Internal Dependencies:** 15 imports
 
 ### `tests/unit/test_service_provenance_stamping.py`
 > OKH/OKW create persists provenance to its own plane (Slice 3).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`sewing` process** (Wikidata Q652122). The taxonomy had 48 processes and
+  none could describe sewn work, so the COVID-response textile PPE in the
+  catalogue — gowns, scrubs, masks — was *unclassifiable*, not merely
+  unclassified. Deliberately top-level rather than a child of `assembly`: the
+  hierarchy is consulted during matching, and a metal-fabrication shop
+  advertising "assembly" cannot sew a surgical gown.
+
 ### Fixed
 
 - **`ohm okh infer-processes --all` now scans everything.** It defaulted to

--- a/src/config/taxonomy/processes.yaml
+++ b/src/config/taxonomy/processes.yaml
@@ -489,6 +489,32 @@ processes:
       - "shear"
 
   # ---------------------------------------------------------------------------
+  # Textile Processes
+  # ---------------------------------------------------------------------------
+  #
+  # Added for the sewn PPE in the catalogue (gowns, scrubs, masks), which no
+  # process here could describe — they were unclassifiable, not unclassified.
+  #
+  # Top-level on purpose, NOT a child of `assembly`: the hierarchy is consulted
+  # during matching, so a metal-fabrication shop advertising "assembly" would
+  # otherwise be treated as able to sew a surgical gown.
+  #
+  # No tsdc_code: we could not verify one in DIN SPEC 3105, and inventing a
+  # standards code is worse than leaving it unset.
+  sewing:
+    display_name: "Sewing"
+    wikidata_qid: "Q652122"
+    aliases:
+      - "sewing"
+      - "sew"
+      - "sewn"
+      - "stitching"
+      - "stitch"
+      - "textile"
+      - "garment construction"
+      - "cut and sew"
+
+  # ---------------------------------------------------------------------------
   # Quality & Logistics
   # ---------------------------------------------------------------------------
 

--- a/src/core/generation/services/process_inference_service.py
+++ b/src/core/generation/services/process_inference_service.py
@@ -65,6 +65,9 @@ SHORT_TOKEN_TO_PROCESS: Dict[str, str] = {
     "dlp": "3d_printing",
     "cnc": "cnc_machining",
     "pcb": "pcb_fabrication",
+    # Not an acronym, but the token path skips anything under four characters,
+    # and "sew" is how half the textile designs name themselves ("So-Sew-Easy").
+    "sew": "sewing",
 }
 
 _TEXT_TOKEN_BLOCKLIST = frozenset(

--- a/src/core/taxonomy/process_taxonomy.py
+++ b/src/core/taxonomy/process_taxonomy.py
@@ -727,6 +727,25 @@ PROCESS_DEFINITIONS: List[ProcessDefinition] = [
         ),
     ),
     ProcessDefinition(
+        canonical_id="sewing",
+        display_name="Sewing",
+        tsdc_code=None,
+        parent=None,
+        aliases=frozenset(
+            {
+                "cut and sew",
+                "garment construction",
+                "sew",
+                "sewing",
+                "sewn",
+                "stitch",
+                "stitching",
+                "textile",
+            }
+        ),
+        wikidata_qid="Q652122",
+    ),
+    ProcessDefinition(
         canonical_id="testing",
         display_name="Testing",
         tsdc_code=None,

--- a/tests/unit/test_process_inference_service.py
+++ b/tests/unit/test_process_inference_service.py
@@ -389,3 +389,39 @@ async def test_a_limit_larger_than_the_catalogue_leaves_nothing_behind() -> None
     report = await _run_backfill(175, 500)
     assert report["scanned"] == 175
     assert report["not_scanned"] == 0
+
+
+# Sewing — added because the taxonomy could not describe 12 catalogue designs
+# (sewn PPE from the COVID response: gowns, scrubs, masks). They were
+# unclassifiable, not merely unclassified.
+
+
+def test_sewing_is_inferred_from_the_title(service: ProcessInferenceService) -> None:
+    manifest = _manifest(title="Hello-Sewing-3D-Window-Mask")
+    assert "Sewing" in service.infer_from_manifest(manifest).processes
+
+
+def test_the_short_token_sew_is_matched(service: ProcessInferenceService) -> None:
+    """Tokens under four characters are skipped unless listed explicitly."""
+    manifest = _manifest(title="So-Sew-Easy-Unisex-Scrubs-Top")
+    assert service.infer_from_manifest(manifest).processes == ["Sewing"]
+
+
+def test_product_names_do_not_imply_sewing(service: ProcessInferenceService) -> None:
+    """The deliberate limit of this change.
+
+    "mask" appears in 27 catalogue titles, 13 of them 3D-printed and 7
+    assembled; "shield" in 19, mostly 3D printing and laser cutting. Mapping a
+    product name to a process would mislabel roughly twenty designs to recover
+    nine, so these stay unclassified until a real signal exists.
+    """
+    for title in ("Duckbill-Mask-with-Filter", "Badger-Shield-V4", "Reusable-Gown"):
+        assert service.infer_from_manifest(_manifest(title=title)).processes == []
+
+
+def test_sewing_is_not_reachable_from_assembly() -> None:
+    """Hierarchy drives matching: an assembly shop cannot sew a surgical gown."""
+    from src.core.taxonomy import taxonomy
+
+    assert taxonomy.normalize("sewing") == "sewing"
+    assert taxonomy.are_related("assembly", "sewing") is False


### PR DESCRIPTION
## First: the proposed work was the wrong fix, and I stopped

The plan was to apply 0.10.2's remote file-type resolution to the 23 unclassified designs. It does not help them.

They are not Thingiverse links (what 0.10.2 solved) — they are Google Drive **viewer** pages:

```
probing 8 real URLs from these designs  →  0/8 resolved
```

I then tried the obvious extension, rewriting `/file/d/<id>/view` to Drive's download endpoint. That *does* resolve (5/6) — but into `Surgical Face Shield v02.pdf`, `Raglan Sleeve.PDF`, `GOWN RAGLAN GRADED ASTM.RUL`. PDFs and sewing patterns. `.pdf` maps to no process, so building it would have added a network dependency to inference and recovered **zero** designs.

## The actual blocker

**The taxonomy had 48 processes and none described sewn work.** `normalize("sewing")`, `"sew"`, `"textile"`, `"garment"` all returned `None`. Twelve catalogue designs — COVID-response gowns, scrubs and masks — were *unclassifiable*, not merely unclassified. Same shape as the `vinyl_cutting` gap: our own vocabulary was the limit.

Added `sewing`, Wikidata **Q652122** (verified against Wikidata, not assumed). No `tsdc_code` — none could be verified in DIN SPEC 3105, and inventing a standards code is worse than leaving it unset.

**Top-level, not a child of `assembly`.** The hierarchy is consulted during matching, so a metal-fabrication shop advertising "assembly" would otherwise be treated as able to sew a surgical gown. There is a test pinning that.

## What it recovers — and where I deliberately stopped

**3 of 19**, not 12. The other titles name the *product*, not the process, and mapping product names to processes would be actively harmful:

| term in title | designs | what they actually are |
|---|---|---|
| `mask` | 27 | 13 3D Printing, 7 Assembly |
| `shield` | 19 | mostly 3D Printing and Laser Cutting |

Mapping `mask → sewing` would mislabel roughly twenty designs to recover nine. Materials would have been the principled signal, but all 19 carry an **empty materials list** — their BOM is a URL, not parsed content.

So the vocabulary gap is closed and the classification gap is documented rather than papered over. Getting the rest needs a signal that is not in the manifest: parsed BOM content, or LLM extraction from the source page.

## Production data changes (authorised)

**4 test fixtures deleted** — `Integration Test Widget` ×2 and `Widget With Components` ×2, all `licensor: "Test Suite"`, `function: "Smoke-tests the OHM API"`. They were in the live catalogue and matchable by users. Backed up before deletion.

I could **not** confirm how they got there: `Integration Test Widget` matches `tests/integration/test_api_171_176.py`, but that file only calls `/validate` and `dry_run=true` imports, and `Widget With Components` appears nowhere in the repo. What I did confirm is a live vector — a locally-run API pointed at `AZURE_STORAGE_CONTAINER=production` writes straight into the production catalogue, which is exactly what a developer `.env` looks like. Worth a guard, but I would rather not invent one against an unconfirmed vector.

## Catalogue state

| | start of session | now |
|---|---|---|
| designs | 175 | 171 (4 fixtures removed) |
| with processes | 52 (30%) | **152 (89%)** |
| unmatchable | 123 | 19 |

`make ready` passes (1057). Backward pass applied: the taxonomy comment came down from 12 lines to 8, keeping only the two decisions a future editor might undo (the top-level placement and the absent TSDC code), and verified the new `textile` alias does not capture `cutting_textile`, `vinyl_cutting` or `laser_cutting`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)