### PR TITLE
Remove catalogue designs whose files cannot be resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **Seven catalogue designs whose file references were exclusively Google Drive
+  viewer pages.** No file type is recoverable from those URLs, so the designs
+  could never be classified and matched nothing — noise in every result set.
+  Their source URLs are recorded in the removing PR; all were generated from a
+  URL and can be regenerated. Also removed four integration-test fixtures
+  (`licensor: "Test Suite"`) that were live in the production catalogue.
+
 ### Fixed
 
 - **`ohm okh infer-processes --all` now scans everything.** It defaulted to

--- a/docs/architecture/generation.md
+++ b/docs/architecture/generation.md
@@ -693,6 +693,24 @@ Inference read only filenames and titles, so a design *titled* `3DP-…` got
 `3D Printing` while an identical `tsdc: ['3DP']` on a differently-named design
 got nothing — and a design with no processes matches nothing at all.
 
+### Designs whose files cannot be resolved
+
+A generated design is only useful if something about it can be classified. Where
+a design's file references all point at hosts that expose no filename — Google
+Drive `/file/d/<id>/view` pages being the case in practice — no signal is
+recoverable: the extension is absent, the download endpoint yields a `.pdf`
+pattern sheet, and the title names the product rather than the process.
+
+Such designs match nothing and are removed from the catalogue rather than left
+as noise. Seven were removed on this basis (see the `chore/exclude-unresolvable-designs`
+PR for the list and their source URLs — every one was generated from a URL and
+can be regenerated if the host later becomes resolvable).
+
+This is a **curation** decision, not a code path: generation still accepts these
+designs, and nothing prevents another from being created. If they recur at
+volume, the durable fix is a generation-time warning when no file reference
+resolves to a known type.
+
 It resolves display names through the [canonical process taxonomy](process-taxonomy-adr.md)
 using **exact** alias/TSDC lookup for tokens (avoids substring false positives
 such as `face` ⊂ `surface_finish`). Extension → process mappings are defined


### PR DESCRIPTION
Seven designs referenced files **only** as Google Drive `/file/d/<id>/view` pages.

Nothing about them is recoverable. The URL carries no extension; the download endpoint (which I verified does work — 5/6) resolves to `.pdf` pattern sheets; and their titles name the *product* rather than the process. They could never be classified, so they matched nothing and were noise in every result set.

## Removed

| design | id | source (for regeneration) |
|---|---|---|
| Badger-Shield:-Open-Source-Surgical-Face-Shield-V2 | `09597d26-8417-4190-a6a7-48bc5a216bed` | https://drive.google.com/file/d/1l8ZNx5NN9ZkyUR5Z0VP2tPWTfRIMs9SF/view |
| DIY-Mask-for-Singers | `53f45221-2fd2-450b-af52-b1d59d292a0b` | https://www.youtube.com/watch?v=azEIkHsa7uE |
| EPAM-Continuum-GENTL-Mask | `00ebee94-86ee-45d6-a777-499312a5211d` | https://solutionshub.epam.com/solution/epam-gentl-face-mask |
| LMAG-Reusable-Gown-(Raglan-sleeve-files) | `7d1d80ce-fd9f-4e66-9917-8feb59e8a694` | https://drive.google.com/drive/folders/1KDnzI0eZvRh6eTzourbCW6AY1b9YioKe?usp=sharing |
| Makers-Unite-Hardhat-Face-Shield | `81dafd20-2269-4d96-8725-dcf136766325` | https://drive.google.com/drive/folders/1O7JifqSD2cZepNq1Q-eP-8O93xcTE7AX |
| Something-Labs-Impermeable-Gown | `39477809-10e1-4619-8a7b-361cedc35171` | https://drive.google.com/drive/folders/1Ru_9RBYsmFNV6vcSD15HPQwzRf03KuJH |
| Zero-Waste-Scrub-Set | `59987cb9-1ace-4776-8458-f7e38de93f5b` | https://decodecodecode.com/ZERO-WASTE-SCRUB-SET |

Every one was generated from a URL, so this table is the recovery path — they can be regenerated if a host later becomes resolvable. Full manifests were backed up before deletion.

Also removed **four integration-test fixtures** — `Integration Test Widget` ×2 and `Widget With Components` ×2, all `licensor: "Test Suite"`, `function: "Smoke-tests the OHM API"` — which were live in the production catalogue and matchable by users.

## Catalogue state

| | session start | now |
|---|---|---|
| designs | 175 | **164** |
| with manufacturing processes | 52 (30%) | **152 (93%)** |
| unclassified | 123 | 12 |

Of the 12 remaining, 3 (`Hello-Sewing-3D-Window-Mask`, `So-Sew-Easy-Unisex-Scrubs-Top/Pants`) classify once #298 deploys, taking it to ~95%.

## Scope

**The code change is documentation only.** Generation still accepts such designs and nothing stops another being created — this is a curation decision, not a guard. A generation-time warning when no file reference resolves to a known type is the durable fix, and I have left it until there is evidence they recur at volume rather than building it speculatively.

`make ready` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)