### PR TITLE
Give the worker the LLM encryption secrets it needs to boot

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -2389,6 +2389,7 @@ Total Python files: 613
         │       def test_worker_inherits_the_jobs_flag_rather_than_setting_its_own()
         │       def test_worker_carries_storage_key_and_both_git_tokens()
         │       def test_mirrored_names_match_the_live_secret_names()
+        │       def test_worker_carries_the_llm_encryption_secrets_even_without_llm()
         │       def _run_worker_deploy()
         │       def _worker_command()
         │       def test_worker_deploys_with_no_ingress_and_worker_mode()

--- a/deploy/providers/azure/app_secrets.py
+++ b/deploy/providers/azure/app_secrets.py
@@ -23,6 +23,15 @@ MIRRORED_SECRET_ENV_REFS: Dict[str, str] = {
     "AZURE_STORAGE_KEY": "azure-storage-key",
     "GITHUB_ACCESS_TOKEN": "gihub-token",
     "GITLAB_ACCESS_TOKEN": "gitlab-token",
+    # Required by ANY app that imports src.config with ENVIRONMENT=production —
+    # settings.py builds LLMConfigManager at import time, and CredentialManager
+    # raises without these. That is true whether or not the app ever touches an
+    # LLM, so the worker needs them even with LLM generation out of scope.
+    # Omitting them crash-looped the production worker at startup; a `staging`
+    # environment cannot catch it, because the guard only fires when ENVIRONMENT
+    # is literally "production".
+    "LLM_ENCRYPTION_SALT": "llm-encryption-salt",
+    "LLM_ENCRYPTION_PASSWORD": "llm-encryption-password",
 }
 
 # The API additionally serves authenticated routes; a worker consumes jobs and

--- a/tests/unit/test_azure_worker_deploy.py
+++ b/tests/unit/test_azure_worker_deploy.py
@@ -98,7 +98,23 @@ def test_mirrored_names_match_the_live_secret_names():
         "azure-storage-key",
         "gihub-token",
         "gitlab-token",
+        "llm-encryption-password",
+        "llm-encryption-salt",
     ]
+
+
+def test_worker_carries_the_llm_encryption_secrets_even_without_llm():
+    """settings.py builds LLMConfigManager at IMPORT time.
+
+    With ENVIRONMENT=production, CredentialManager raises without these — so any
+    app importing src.config needs them, LLM or not. Omitting them crash-looped
+    the production worker, and a `staging` rehearsal cannot catch it because the
+    guard only fires when ENVIRONMENT is literally "production".
+    """
+    env_vars = mirrored_secret_env_vars()
+
+    assert env_vars["LLM_ENCRYPTION_SALT"] == "secretref:llm-encryption-salt"
+    assert env_vars["LLM_ENCRYPTION_PASSWORD"] == "secretref:llm-encryption-password"
 
 
 # --- The deploy itself -------------------------------------------------------


### PR DESCRIPTION
The v0.10.6 release deployed the worker, the API and the frontend, then **failed at the final gate** — the end-to-end job probe reported *"Generation job was accepted but never consumed."*

That is exactly the failure the probe was built to catch, and nothing else would have. Every container reported healthy, the digest checks passed, and the API happily accepted jobs. Only submitting a real job and waiting for it revealed that nothing was consuming them.

## Root cause

The worker crash-looped at startup:

```
ValueError: LLM_ENCRYPTION_SALT and LLM_ENCRYPTION_PASSWORD must be set in production.
  celery_app.py → src.config.schema → settings.py:200 LLM_CONFIG = get_llm_config()
    → LLMConfigManager() → CredentialManager() → _initialize_encryption()
```

`settings.py` builds `LLMConfigManager` at **import** time, so any app importing `src.config` with `ENVIRONMENT=production` requires these secrets — whether or not it ever touches an LLM.

#307 deliberately withheld them, reasoning that LLM generation was out of scope. That reasoning was wrong: the requirement is at import time, not use time.

## Why staging did not catch it

The guard fires only when `environment == "production"`, and staging's is `"staging"` — so the staging worker booted cleanly on the same code path.

`ENVIRONMENT` does double duty here: it selects the config file *and* gates production-only behaviour. A `staging` environment therefore cannot exercise any `== "production"` branch, which is a real limit on what a rehearsal can prove. Worth a follow-up; the two responsibilities probably want separating.

## Status

Production is already repaired — I ran the fixed deploy script directly — and verified:

- worker `ready`, connected to `rediss://…/1` (production's broker index)
- `make secrets-check` — all six shared secrets agree across API and worker
- `probe_async_generation` — **clean** against production
- `POST /v1/api/okh/generate-from-url/jobs` → **202** (was 503 before this work)
- `/health` → 0.10.6, storage `production`, 276 OKH — the `cache-redis-url` overwrite was non-destructive

This PR lands the same fix in the repo so future deploys and fresh environments get it. `make ready` green, 1166 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
