### PR TITLE
Separate "which config" from "how strict": one derived predicate for real deployments

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 615
+Total Python files: 616
 
 ├── deploy/
 │   ├── __init__.py
@@ -2557,6 +2557,11 @@ Total Python files: 615
         │       def test_secret_field_is_commented_and_labeled()
         │       def test_non_secret_default_is_active()
         │       def test_committed_template_is_not_stale()
+        ├── test_environment_rule_ratchet.py
+        │       def _offenders()
+        │       def test_nothing_decides_strictness_by_comparing_the_environment_name()
+        │       def test_the_detector_actually_detects()
+        │       def test_allowlist_entries_are_justified()
         ├── test_file_path_display.py
         │       def test_relative_path_unchanged()
         │       def test_github_raw_url()
@@ -3146,7 +3151,7 @@ Total Python files: 615
 
 ## Overview
 
-Total files analyzed: 615
+Total files analyzed: 616
 
 ## Entry Points
 
@@ -10811,6 +10816,20 @@ Pin the lockfile behaviour: the gener...
 - `test_committed_template_is_not_stale()`
 
 **Internal Dependencies:** 1 imports
+
+### `tests/unit/test_environment_rule_ratchet.py`
+> Ratchet: nothing may decide strictness by comparing the environment name.
+
+`ENVIRONMENT` selects whi...
+
+**Exports:** test_nothing_decides_strictness_by_comparing_the_environment_name, test_the_detector_actually_detects, test_allowlist_entries_are_justified
+
+**Functions:**
+- `test_nothing_decides_strictness_by_comparing_the_environment_name()`
+- `test_the_detector_actually_detects(tmp_path)`
+  - A gate that cannot fail is worse than no gate....
+- `test_allowlist_entries_are_justified()`
+  - Each exemption carries its reason, so the gate cannot rot silently....
 
 ### `tests/unit/test_file_path_display.py`
 > Tests for file path display normalization....

--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 614
+Total Python files: 615
 
 ├── deploy/
 │   ├── __init__.py
@@ -2543,6 +2543,13 @@ Total Python files: 614
         │       def test_whats_built_groups_by_status()
         │       def test_whats_built_lists_unbuilt_capabilities_without_links()
         │       def test_whats_built_links_are_relative_to_reference_dir()
+        ├── test_entrypoint_server_choice.py
+        │       def _extract_auto_detect_block()
+        │       def _shell_choice()
+        │       def test_entrypoint_agrees_with_the_application()
+        │       def test_sandboxes_get_the_reloading_dev_server()
+        │       def test_staging_gets_the_production_server()
+        │       def test_an_explicit_override_still_wins()
         ├── test_env_template_generation.py
         │       def _load_generator()
         │       def test_block_is_deterministic()
@@ -3087,7 +3094,7 @@ Total Python files: 614
         ├── test_staging_deploy.py
         │       def test_staging_writes_to_its_own_blob_container()
         │       def test_staging_uses_different_redis_databases_than_production()
-        │       def test_staging_forces_the_production_server()
+        │       def test_staging_is_treated_as_a_real_deployment()
         │       def test_staging_matches_production_worker_shape()
         │       def test_both_environments_enable_jobs()
         │       def test_staging_holds_no_secrets()
@@ -3139,7 +3146,7 @@ Total Python files: 614
 
 ## Overview
 
-Total files analyzed: 614
+Total files analyzed: 615
 
 ## Entry Points
 
@@ -10770,6 +10777,25 @@ The staging step is what ...
   - Never silently drop the status claim just because a page is malformed....
 - `test_unknown_status_leaves_the_page_untouched(build_docs_site)`
 
+### `tests/unit/test_entrypoint_server_choice.py`
+> The container entrypoint must agree with the application about strictness.
+
+The entrypoint picks the...
+
+**Exports:** test_entrypoint_agrees_with_the_application, test_sandboxes_get_the_reloading_dev_server, test_staging_gets_the_production_server, test_an_explicit_override_still_wins
+
+**Functions:**
+- `test_entrypoint_agrees_with_the_application(environment)`
+  - The one place the predicate cannot be shared, so it is checked instead....
+- `test_sandboxes_get_the_reloading_dev_server(environment)`
+- `test_staging_gets_the_production_server()`
+  - It previously got `uvicorn --reload` — a different process model from the
+enviro...
+- `test_an_explicit_override_still_wins()`
+  - `USE_GUNICORN` set explicitly must not be overwritten by auto-detection....
+
+**Internal Dependencies:** 2 imports
+
 ### `tests/unit/test_env_template_generation.py`
 > Tests for the env.template generator (config Slice 1 / #238).
 
@@ -11665,23 +11691,23 @@ Verifies that:
 
 Staging is a rehearsal ...
 
-**Exports:** test_staging_writes_to_its_own_blob_container, test_staging_uses_different_redis_databases_than_production, test_staging_forces_the_production_server, test_staging_matches_production_worker_shape, test_both_environments_enable_jobs
+**Exports:** test_staging_writes_to_its_own_blob_container, test_staging_uses_different_redis_databases_than_production, test_staging_is_treated_as_a_real_deployment, test_staging_matches_production_worker_shape, test_both_environments_enable_jobs
 
 **Functions:**
 - `test_staging_writes_to_its_own_blob_container()`
 - `test_staging_uses_different_redis_databases_than_production()`
   - Sharing an instance is fine; sharing a broker db would cross the streams....
-- `test_staging_forces_the_production_server()`
-  - USE_GUNICORN=auto starts `uvicorn --reload` for any non-production env.
+- `test_staging_is_treated_as_a_real_deployment()`
+  - A rehearsal on a laxer posture or a different server proves very little.
 
-A rehea...
+Stagin...
 - `test_staging_matches_production_worker_shape()`
 - `test_both_environments_enable_jobs()`
   - Staging led; production followed once the path was proven there.
 
 They must agre...
 
-**Internal Dependencies:** 3 imports
+**Internal Dependencies:** 4 imports
 
 ### `tests/unit/test_storage_fingerprint.py`
 > Tests for StorageService.get_config_fingerprint (config drift guard / #241).

--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 613
+Total Python files: 614
 
 ├── deploy/
 │   ├── __init__.py
@@ -473,6 +473,7 @@ Total Python files: 613
 │   │   │       class Settings (_normalize_environment, okw_source_resolved, cors_allow_origins...)
 │   │   │       def _find_project_env()
 │   │   │       def strip_quotes()
+│   │   │       def is_production_like()
 │   │   │       def resolve_cors_origins()
 │   │   │       def get_settings()
 │   │   │       def storage_config_problems()
@@ -2990,6 +2991,17 @@ Total Python files: 613
         │       def test_the_short_token_sew_is_matched()
         │       def test_product_names_do_not_imply_sewing()
         │       def test_sewing_is_not_reachable_from_assembly()
+        ├── test_production_like_predicate.py
+        │       def test_known_sandboxes_are_relaxed()
+        │       def test_everything_else_is_a_real_deployment()
+        │       def test_matching_ignores_case_and_surrounding_space()
+        │       def test_missing_environment_is_treated_as_a_real_deployment()
+        │       def test_settings_exposes_the_same_answer()
+        │       def test_staging_now_demands_the_encryption_secrets_that_broke_v0_10_6()
+        │       def test_a_sandbox_still_boots_without_encryption_secrets()
+        │       def test_cors_denies_by_default_on_any_real_deployment()
+        │       def test_startup_validation_hard_fails_on_any_real_deployment()
+        │       def test_write_auth_is_enforced_on_any_real_deployment()
         ├── test_provenance_model.py
         │       def test_credit_requires_exactly_one_identifier()
         │       def test_provenance_sign_and_verify_round_trip()
@@ -3127,7 +3139,7 @@ Total Python files: 613
 
 ## Overview
 
-Total files analyzed: 613
+Total files analyzed: 614
 
 ## Entry Points
 
@@ -5684,7 +5696,7 @@ This module provides configuration management for L...
 
 Single source of truth for a first, narrow slice of sett...
 
-**Exports:** strip_quotes, resolve_cors_origins, Settings, get_settings, storage_config_problems
+**Exports:** strip_quotes, is_production_like, resolve_cors_origins, Settings, get_settings
 
 **Classes:**
 - `_NormalizingEnvSource` (inherits: EnvSettingsSource)
@@ -5693,7 +5705,7 @@ Single source of truth for a first, narrow slice of sett...
 
 Keeps ``...
 - `Settings` (inherits: BaseSettings)
-  - Methods: okw_source_resolved, cors_allow_origins, settings_customise_sources
+  - Methods: okw_source_resolved, cors_allow_origins, is_production_like, settings_customise_sources
   - Slice-1 typed configuration.
 
 Field names map case-insensitively to their histor...
@@ -5703,6 +5715,10 @@ Field names map case-insensitively to their histor...
   - Strip surrounding whitespace + quotes; empty becomes ``None``.
 
 ``docker run --e...
+- `is_production_like(environment)`
+  - True when ``environment`` names a real deployment rather than a sandbox.
+
+This i...
 - `resolve_cors_origins(raw, environment)`
   - Resolve the raw ``CORS_ORIGINS`` string into a list of allowed origins.
 
@@ -5715,10 +5731,6 @@ Intentiona...
   - Return human-readable problems with the storage config (empty list = OK).
 
 Valid...
-- `enforce_startup_config(settings)`
-  - Validate configuration at startup with an environment-dependent posture.
-
-Hard-f...
 
 ### `src/config/security_policy.py`
 > Security posture presets for identity, authorization, and trust.
@@ -11504,6 +11516,26 @@ Covers the enriched M...
 - `test_probe_match_flags_503_rate(mock_api)`
 - `test_run_match_attempts_returns_diagnostics()`
 - `test_probe_latency_exceeds_error_slo(mock_api)`
+
+### `tests/unit/test_production_like_predicate.py`
+> One question — "is this a real deployment?" — asked the same way everywhere.
+
+`ENVIRONMENT` used to ...
+
+**Exports:** test_known_sandboxes_are_relaxed, test_everything_else_is_a_real_deployment, test_matching_ignores_case_and_surrounding_space, test_missing_environment_is_treated_as_a_real_deployment, test_settings_exposes_the_same_answer
+
+**Functions:**
+- `test_known_sandboxes_are_relaxed(environment)`
+- `test_everything_else_is_a_real_deployment(environment)`
+  - Fail CLOSED: a name nobody anticipated is strict, not lax.
+
+An opt-in 'strict' s...
+- `test_matching_ignores_case_and_surrounding_space(environment)`
+- `test_missing_environment_is_treated_as_a_real_deployment(environment)`
+  - Unset is the most dangerous case, so it must not be the laxest....
+- `test_settings_exposes_the_same_answer()`
+
+**Internal Dependencies:** 7 imports
 
 ### `tests/unit/test_provenance_store.py`
 > Unit tests for ProvenanceStore (Slice 3)....

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **One predicate decides whether a deployment is "real".** `ENVIRONMENT` was
+  doing two unrelated jobs: selecting `config/environments/<env>.toml`, and
+  gating how strictly the app behaves. Only the first legitimately uses the name.
+  All six strictness checks — write-auth enforcement, CORS deny-by-default, the
+  missing-API-keys warning, hard-fail startup validation, and the LLM encryption
+  requirement — now ask `is_production_like()`, which is **derived**: anything
+  outside `{development, test}` is a real deployment. It fails *closed*, so a new
+  environment is strict by default rather than silently lax.
+  This closes the hole behind the v0.10.6 incident: the production worker
+  crash-looped on missing `LLM_ENCRYPTION_*` while the staging rehearsal built to
+  catch it booted the same image clean, because the guard compared against
+  `"production"` and staging's environment was `"staging"`. A regression test now
+  reproduces that crash under a staging-like environment.
+
 ## [0.10.6] - 2026-08-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `"production"` and staging's environment was `"staging"`. A regression test now
   reproduces that crash under a staging-like environment.
 
+  The container entrypoint mirrors the same rule (it is shell and cannot import
+  the predicate), with a test that **executes** the real decision block and fails
+  if shell and Python ever disagree — so `staging` no longer runs
+  `uvicorn --reload` while rehearsing a gunicorn deployment. A merge-gate ratchet
+  now fails on any direct `== "production"` comparison in Python or Terraform,
+  and the Terraform module mirrors the derived rule so a node named anything but
+  `production` still provisions the encryption secrets the app demands of it.
+
 ## [0.10.6] - 2026-08-03
 
 ### Added
@@ -92,6 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one failed deploys that had actually succeeded). `get_status` reads the FQDN
   from the response it already has instead of a second lookup. Web-service argv
   is pinned by regression tests — the API and frontend deploys are unchanged.
+
 ## [0.10.5] - 2026-08-02
 
 ### Added

--- a/config/environments/staging.toml
+++ b/config/environments/staging.toml
@@ -18,11 +18,10 @@ azure_storage_container = "staging"
 
 cache_backend = "redis"
 
-# Without this, the entrypoint's USE_GUNICORN=auto resolves to gunicorn ONLY for
-# ENVIRONMENT=production and starts `uvicorn --reload` everywhere else — a
-# different process model, which would make this environment worthless as a
-# rehearsal. Workers/timeout match production for the same reason.
-use_gunicorn = "true"
+# The entrypoint's USE_GUNICORN=auto now derives the server the same way the
+# application derives its strictness — anything outside {development, test} is a
+# real deployment — so staging gets the production server without asking. Workers
+# and timeout match production so the rehearsal runs under production's limits.
 gunicorn_workers = "1"
 gunicorn_timeout = "300"
 

--- a/deploy/docker/docker-entrypoint.sh
+++ b/deploy/docker/docker-entrypoint.sh
@@ -27,13 +27,23 @@ start_api() {
     ENVIRONMENT=${ENVIRONMENT:-${ENV:-development}}
     USE_GUNICORN=${USE_GUNICORN:-"auto"}
 
-    # Auto-detect: use Gunicorn in production, uvicorn in development
+    # Auto-detect the server from the environment. This MIRRORS
+    # src/config/schema.py::is_production_like — anything outside the relaxed
+    # sandboxes is a real deployment and gets the production server.
+    #
+    # The rule is duplicated because this is shell and cannot import the
+    # predicate; asking Python here would add an interpreter start to every boot
+    # AND a confusing new failure point, since that import can itself raise.
+    # tests/unit/test_entrypoint_server_choice.py fails if the two ever diverge.
+    #
+    # Previously this compared only against "production", so `staging` ran
+    # `uvicorn --reload` — a different process model from the environment it was
+    # meant to rehearse.
     if [ "$USE_GUNICORN" = "auto" ]; then
-        if [ "$ENVIRONMENT" = "production" ]; then
-            USE_GUNICORN="true"
-        else
-            USE_GUNICORN="false"
-        fi
+        case "$(echo "$ENVIRONMENT" | tr '[:upper:]' '[:lower:]' | tr -d ' ')" in
+            development|test) USE_GUNICORN="false" ;;
+            *)                USE_GUNICORN="true" ;;
+        esac
     fi
 
     if [ "$USE_GUNICORN" = "true" ] || [ "$USE_GUNICORN" = "1" ]; then

--- a/deploy/terraform/azure/modules/ohm_node/main.tf
+++ b/deploy/terraform/azure/modules/ohm_node/main.tf
@@ -27,7 +27,14 @@ locals {
   env_name      = "${var.name}-${local.location_slug}-env"
   redis_name    = substr(replace(lower("${var.name}-redis"), "/[^a-z0-9-]/", ""), 0, 63)
 
-  provision_encryption = var.environment == "production"
+  # Mirrors src/config/schema.py::is_production_like — anything outside the
+  # relaxed sandboxes is a real deployment. The application REQUIRES these
+  # secrets for every such environment and refuses to boot without them, so a
+  # node named anything but "production" would otherwise crash-loop exactly as
+  # the production worker did before v0.10.6 was fixed. Currently unreachable
+  # because `environment` is validated to test|development|production, which is
+  # precisely why it would bite whoever first adds a name to that list.
+  provision_encryption = !contains(["development", "test"], var.environment)
   # Celery + cache DB split matches docker-compose.yml (0=cache, 1=broker, 2=results).
   redis_password = var.enable_jobs ? azurerm_redis_cache.jobs[0].primary_access_key : ""
   redis_host     = var.enable_jobs ? azurerm_redis_cache.jobs[0].hostname : ""

--- a/src/config/llm_config.py
+++ b/src/config/llm_config.py
@@ -217,7 +217,7 @@ class CredentialManager:
             # Check if we're in production mode
             from src.config.schema import get_settings
 
-            is_production = get_settings().environment == "production"
+            is_production = get_settings().is_production_like
 
             # Get encryption credentials from environment
             salt_env = os.getenv("LLM_ENCRYPTION_SALT")

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -77,6 +77,34 @@ def strip_quotes(value: Optional[str]) -> Optional[str]:
     return stripped if stripped else None
 
 
+# Environments that are deliberately relaxed: a developer's laptop and the test
+# suite. EVERYTHING else — staging, demo, a name nobody anticipated — is treated
+# as a real deployment.
+#
+# The rule is derived rather than configured, and it is derived this way round on
+# purpose: it fails CLOSED. An opt-in "strict" setting would reproduce the bug
+# this exists to prevent the first time someone forgets it on a new environment.
+#
+# It also fixes a real failure. v0.10.6 crash-looped in production on missing LLM
+# encryption secrets while the staging rehearsal built to catch exactly that
+# booted clean, because the guard compared the environment to "production" and
+# staging's was "staging". Staging was LAXER than production, so the rehearsal
+# passed and production broke.
+RELAXED_ENVIRONMENTS: frozenset = frozenset({"development", "test"})
+
+
+def is_production_like(environment: Optional[str]) -> bool:
+    """True when ``environment`` names a real deployment rather than a sandbox.
+
+    This is the single question every strictness check should ask. The
+    environment NAME still selects ``config/environments/<env>.toml``; nothing
+    else compares it.
+
+    Unknown names are production-like — see :data:`RELAXED_ENVIRONMENTS`.
+    """
+    return (environment or "").strip().lower() not in RELAXED_ENVIRONMENTS
+
+
 def resolve_cors_origins(
     raw: Optional[str], environment: str, *, log: bool = False
 ) -> List[str]:
@@ -88,7 +116,7 @@ def resolve_cors_origins(
     allowlist. Pass ``log=True`` to emit the operational warnings once.
     """
     if raw is None or raw.strip() == "":
-        if environment == "production":
+        if is_production_like(environment):
             if log:
                 logger.warning(
                     "CORS_ORIGINS not set in production. No CORS origins allowed "
@@ -103,7 +131,7 @@ def resolve_cors_origins(
         return ["*"]
 
     if raw.strip() == "*":
-        if environment == "production" and log:
+        if is_production_like(environment) and log:
             logger.warning(
                 "CORS_ORIGINS is set to '*' in production. This allows all origins. "
                 "Consider restricting to specific origins for better security."
@@ -249,6 +277,14 @@ class Settings(BaseSettings):
     def cors_allow_origins(self) -> List[str]:
         return resolve_cors_origins(self.cors_origins, self.environment)
 
+    @property
+    def is_production_like(self) -> bool:
+        """Whether this is a real deployment — see :func:`is_production_like`.
+
+        Every strictness check asks this, never the environment name.
+        """
+        return is_production_like(self.environment)
+
     @classmethod
     def settings_customise_sources(
         cls,
@@ -317,7 +353,7 @@ def enforce_startup_config(settings: Optional[Settings] = None) -> List[str]:
     if not problems:
         return problems
     detail = "; ".join(problems)
-    if settings.environment == "production":
+    if settings.is_production_like:
         raise RuntimeError(f"Invalid production configuration: {detail}")
     logger.warning(
         "Configuration problems (continuing in %s, degraded): %s",

--- a/src/config/security_policy.py
+++ b/src/config/security_policy.py
@@ -122,9 +122,10 @@ def _peacetime_requires_auth_for_writes() -> bool:
     hole for real deployments. Override by running with ``ENVIRONMENT=production``.
     Crisis and shielded always enforce writes.
     """
+    from .schema import is_production_like
     from .settings import ENVIRONMENT
 
-    return ENVIRONMENT == "production"
+    return is_production_like(ENVIRONMENT)
 
 
 def get_security_policy(mode: str | SecurityMode | None = None) -> SecurityPolicy:

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -8,7 +8,7 @@ from src.core.storage.base import StorageConfig
 
 from .auth_constants import AUTH_MODE_HYBRID
 from .llm_config import get_llm_config, is_llm_enabled, validate_llm_config
-from .schema import get_settings, resolve_cors_origins
+from .schema import get_settings, is_production_like, resolve_cors_origins
 from .storage_config import StorageConfigError, get_default_storage_config
 
 # Import secrets manager (lazy import to avoid circular dependencies)
@@ -129,8 +129,8 @@ API_KEYS = (
     else []
 )
 
-# Validate API keys in production
-if ENVIRONMENT == "production":
+# Validate API keys on any real deployment (see schema.is_production_like)
+if is_production_like(ENVIRONMENT):
     if not API_KEYS:
         logger.warning(
             "API_KEYS not set in production. API authentication is disabled. "

--- a/tests/unit/test_entrypoint_server_choice.py
+++ b/tests/unit/test_entrypoint_server_choice.py
@@ -1,0 +1,116 @@
+"""The container entrypoint must agree with the application about strictness.
+
+The entrypoint picks the server (production vs auto-reloading dev server) in
+shell, so it cannot import ``is_production_like``. That leaves two copies of one
+rule, and a comment asking the next person to keep them aligned is not a
+mechanism — this test is.
+
+It executes the REAL decision block extracted from the real script, rather than
+matching its text, so a behavioural change is caught even if the wording is
+unchanged.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.config.schema import RELAXED_ENVIRONMENTS, is_production_like
+
+pytestmark = pytest.mark.unit
+
+_ENTRYPOINT = _REPO_ROOT / "deploy" / "docker" / "docker-entrypoint.sh"
+
+# Names to compare on: the relaxed sandboxes, real deployments, an unanticipated
+# name, and the odd casing/spacing a deploy tool might hand us.
+_ENVIRONMENTS = [
+    "development",
+    "test",
+    "production",
+    "staging",
+    "demo",
+    "preprod",
+    "PRODUCTION",
+    "Staging",
+    "",
+]
+
+
+def _extract_auto_detect_block() -> str:
+    """The entrypoint's `USE_GUNICORN=auto` branch, verbatim from the script."""
+    lines = _ENTRYPOINT.read_text(encoding="utf-8").splitlines()
+    start = next(
+        (
+            i
+            for i, line in enumerate(lines)
+            if re.search(r'USE_GUNICORN.*=.*"auto"', line)
+            and line.strip().startswith("if ")
+        ),
+        None,
+    )
+    assert start is not None, "could not find the auto-detect branch in the entrypoint"
+
+    indent = len(lines[start]) - len(lines[start].lstrip())
+    for end in range(start + 1, len(lines)):
+        stripped = lines[end].strip()
+        if stripped == "fi" and (len(lines[end]) - len(lines[end].lstrip())) == indent:
+            return "\n".join(lines[start : end + 1])
+    raise AssertionError("could not find the end of the auto-detect branch")
+
+
+def _shell_choice(environment: str) -> bool:
+    """Run the extracted block for `environment`; True means the production server."""
+    script = (
+        f"ENVIRONMENT={environment!r}\n"
+        "USE_GUNICORN=auto\n"
+        f"{_extract_auto_detect_block()}\n"
+        'printf "%s" "$USE_GUNICORN"\n'
+    )
+    result = subprocess.run(
+        ["sh", "-c", script], capture_output=True, text=True, check=True
+    )
+    value = result.stdout.strip()
+    assert value in {"true", "false"}, f"unexpected USE_GUNICORN={value!r}"
+    return value == "true"
+
+
+@pytest.mark.parametrize("environment", _ENVIRONMENTS)
+def test_entrypoint_agrees_with_the_application(environment):
+    """The one place the predicate cannot be shared, so it is checked instead."""
+    assert _shell_choice(environment) is is_production_like(environment), (
+        f"entrypoint and is_production_like() disagree for {environment!r} — "
+        "the shell rule must mirror src/config/schema.py::is_production_like"
+    )
+
+
+@pytest.mark.parametrize("environment", sorted(RELAXED_ENVIRONMENTS))
+def test_sandboxes_get_the_reloading_dev_server(environment):
+    assert _shell_choice(environment) is False
+
+
+def test_staging_gets_the_production_server():
+    """It previously got `uvicorn --reload` — a different process model from the
+    environment it exists to rehearse."""
+    assert _shell_choice("staging") is True
+
+
+def test_an_explicit_override_still_wins():
+    """`USE_GUNICORN` set explicitly must not be overwritten by auto-detection."""
+    script = (
+        "ENVIRONMENT=production\n"
+        "USE_GUNICORN=false\n"
+        f"{_extract_auto_detect_block()}\n"
+        'printf "%s" "$USE_GUNICORN"\n'
+    )
+    result = subprocess.run(
+        ["sh", "-c", script], capture_output=True, text=True, check=True
+    )
+    assert result.stdout.strip() == "false"

--- a/tests/unit/test_environment_rule_ratchet.py
+++ b/tests/unit/test_environment_rule_ratchet.py
@@ -1,0 +1,114 @@
+"""Ratchet: nothing may decide strictness by comparing the environment name.
+
+`ENVIRONMENT` selects which per-environment config file to load. It must not
+also decide how strictly the system behaves — that question has one answer,
+`src.config.schema.is_production_like`, and it is derived so that an
+unanticipated environment name errs toward safety.
+
+Writing `environment == "production"` is the obvious way to add the next
+production-only behaviour, and it is how the v0.10.6 incident happened: the
+production worker crash-looped on missing encryption secrets while the staging
+rehearsal built to catch that booted clean, because staging's name is not
+"production". This test makes the obvious wrong thing fail the merge gate.
+
+Scope is Python and Terraform, because the rule has already been duplicated
+across both. Shell is deliberately excluded: the container entrypoint MUST
+compare environment names — that IS the mirrored rule — so gating it would mean
+allowlisting the very line the gate exists to permit. That copy is covered by
+tests/unit/test_entrypoint_server_choice.py, which compares behaviour rather
+than text.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Directories that make deployment decisions. Tests are excluded: they name
+# environments legitimately, and asserting on the predicate requires saying
+# "production" out loud.
+_SCANNED = [
+    ("src", "*.py"),
+    ("deploy", "*.py"),
+    ("deploy", "*.tf"),
+    ("harness", "*.py"),
+    ("scripts", "*.py"),
+]
+
+# Files permitted to compare the environment name directly. Every entry needs a
+# reason here AND a comment at the site. Empty is the goal, and currently true:
+# the derived predicate needs no literal comparison to express itself.
+_ALLOWLIST: dict[str, str] = {}
+
+# `x == "production"`, `"production" != x`, and the Terraform equivalents.
+_DIRECT_COMPARISON = re.compile(
+    r'(==|!=)\s*["\']production["\']|["\']production["\']\s*(==|!=)'
+)
+
+
+def _offenders() -> list[str]:
+    found: list[str] = []
+    for directory, pattern in _SCANNED:
+        root = _REPO_ROOT / directory
+        if not root.is_dir():
+            continue
+        for path in root.rglob(pattern):
+            if "__pycache__" in path.parts or ".terraform" in path.parts:
+                continue
+            relative = path.relative_to(_REPO_ROOT).as_posix()
+            if relative in _ALLOWLIST:
+                continue
+            for number, line in enumerate(
+                path.read_text(encoding="utf-8", errors="replace").splitlines(), 1
+            ):
+                if _DIRECT_COMPARISON.search(line):
+                    found.append(f"{relative}:{number}: {line.strip()}")
+    return found
+
+
+def test_nothing_decides_strictness_by_comparing_the_environment_name():
+    offenders = _offenders()
+
+    assert not offenders, (
+        "Environment name compared to 'production' directly:\n  "
+        + "\n  ".join(offenders)
+        + "\n\nUse src.config.schema.is_production_like() instead — the rule is "
+        "derived so an unanticipated environment name is strict, not lax. "
+        'In Terraform, mirror it as !contains(["development", "test"], var.environment). '
+        "If a comparison is genuinely correct, add the file to _ALLOWLIST with a reason."
+    )
+
+
+def test_the_detector_actually_detects(tmp_path):
+    """A gate that cannot fail is worse than no gate."""
+    sample = tmp_path / "sample.py"
+    sample.write_text('if settings.environment == "production":\n    strict()\n')
+
+    matches = [
+        line
+        for line in sample.read_text().splitlines()
+        if _DIRECT_COMPARISON.search(line)
+    ]
+    assert matches, "the detector missed a direct comparison"
+
+    # And does not fire on legitimate uses.
+    for benign in (
+        'PROTECTED_ENVIRONMENTS = {"production", "prod"}',
+        'contains(["test", "development", "production"], var.environment)',
+        "if is_production_like(settings.environment):",
+        'assert is_production_like("production") is True',
+    ):
+        assert not _DIRECT_COMPARISON.search(benign), benign
+
+
+def test_allowlist_entries_are_justified():
+    """Each exemption carries its reason, so the gate cannot rot silently."""
+    for path, reason in _ALLOWLIST.items():
+        assert (_REPO_ROOT / path).is_file(), f"stale allowlist entry: {path}"
+        assert reason.strip(), f"allowlist entry {path} has no reason"

--- a/tests/unit/test_production_like_predicate.py
+++ b/tests/unit/test_production_like_predicate.py
@@ -1,0 +1,153 @@
+"""One question — "is this a real deployment?" — asked the same way everywhere.
+
+`ENVIRONMENT` used to decide two unrelated things: which config file to load, and
+how strictly the application behaves. Only the first is a legitimate use of the
+name. These tests pin the second onto a single derived predicate, and pin the
+consequence that motivated it.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.config.schema import (
+    RELAXED_ENVIRONMENTS,
+    Settings,
+    is_production_like,
+    resolve_cors_origins,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# --- Truth table -------------------------------------------------------------
+
+
+@pytest.mark.parametrize("environment", sorted(RELAXED_ENVIRONMENTS))
+def test_known_sandboxes_are_relaxed(environment):
+    assert is_production_like(environment) is False
+
+
+@pytest.mark.parametrize(
+    "environment",
+    ["production", "staging", "demo", "preprod", "qa", "anything-else"],
+)
+def test_everything_else_is_a_real_deployment(environment):
+    """Fail CLOSED: a name nobody anticipated is strict, not lax.
+
+    An opt-in 'strict' setting would reproduce the v0.10.6 bug the first time
+    someone forgot it on a new environment.
+    """
+    assert is_production_like(environment) is True
+
+
+@pytest.mark.parametrize("environment", ["PRODUCTION", " Staging ", "Development"])
+def test_matching_ignores_case_and_surrounding_space(environment):
+    expected = environment.strip().lower() not in RELAXED_ENVIRONMENTS
+    assert is_production_like(environment) is expected
+
+
+@pytest.mark.parametrize("environment", [None, "", "   "])
+def test_missing_environment_is_treated_as_a_real_deployment(environment):
+    """Unset is the most dangerous case, so it must not be the laxest."""
+    assert is_production_like(environment) is True
+
+
+def test_settings_exposes_the_same_answer():
+    assert Settings(environment="staging").is_production_like is True
+    assert Settings(environment="test").is_production_like is False
+
+
+# --- The failure this exists to prevent --------------------------------------
+
+
+def test_staging_now_demands_the_encryption_secrets_that_broke_v0_10_6(monkeypatch):
+    """Regression: v0.10.6 crash-looped in production, staging booted clean.
+
+    The worker died at import with "LLM_ENCRYPTION_SALT and
+    LLM_ENCRYPTION_PASSWORD must be set in production". The staging rehearsal
+    built to catch exactly that ran the same image happily, because the guard
+    compared the environment to "production" and staging's was "staging".
+
+    Staging must now fail the same way production does — that is the whole point.
+    """
+    monkeypatch.setenv("ENVIRONMENT", "staging")
+    monkeypatch.delenv("LLM_ENCRYPTION_SALT", raising=False)
+    monkeypatch.delenv("LLM_ENCRYPTION_PASSWORD", raising=False)
+    monkeypatch.delenv("LLM_ENCRYPTION_KEY", raising=False)
+
+    llm_config = importlib.import_module("src.config.llm_config")
+
+    with pytest.raises(ValueError, match="LLM_ENCRYPTION"):
+        llm_config.CredentialManager()
+
+
+def test_a_sandbox_still_boots_without_encryption_secrets(monkeypatch):
+    """The relaxed environments must stay usable with no secrets at all."""
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.delenv("LLM_ENCRYPTION_SALT", raising=False)
+    monkeypatch.delenv("LLM_ENCRYPTION_PASSWORD", raising=False)
+    monkeypatch.delenv("LLM_ENCRYPTION_KEY", raising=False)
+
+    llm_config = importlib.import_module("src.config.llm_config")
+
+    llm_config.CredentialManager()  # must not raise
+
+
+# --- The other strictness checks move together -------------------------------
+
+
+def test_cors_denies_by_default_on_any_real_deployment():
+    assert resolve_cors_origins(None, "production") == []
+    assert resolve_cors_origins(None, "staging") == []
+    assert resolve_cors_origins(None, "development") == ["*"]
+    assert resolve_cors_origins(None, "test") == ["*"]
+
+
+def test_startup_validation_hard_fails_on_any_real_deployment():
+    """A misconfigured deployment must refuse to boot, not degrade quietly."""
+    from src.config.schema import enforce_startup_config
+
+    broken = Settings(
+        environment="staging",
+        storage_provider="azure_blob",
+        azure_storage_account=None,
+        azure_storage_container=None,
+        azure_storage_key=None,
+    )
+    with pytest.raises(RuntimeError):
+        enforce_startup_config(broken)
+
+    degraded = Settings(
+        environment="development",
+        storage_provider="azure_blob",
+        azure_storage_account=None,
+        azure_storage_container=None,
+        azure_storage_key=None,
+    )
+    assert enforce_startup_config(degraded)  # warns, returns problems, no raise
+
+
+@pytest.mark.parametrize(
+    "environment,expected",
+    [("production", True), ("staging", True), ("development", False), ("test", False)],
+)
+def test_write_auth_is_enforced_on_any_real_deployment(
+    monkeypatch, environment, expected
+):
+    import src.config.security_policy as security_policy
+    import src.config.settings as settings_module
+
+    # The policy reads the module-level ENVIRONMENT; patch it rather than
+    # reloading the module, which drags in storage and LLM config as a side effect.
+    monkeypatch.setattr(settings_module, "ENVIRONMENT", environment)
+
+    assert security_policy._peacetime_requires_auth_for_writes() is expected

--- a/tests/unit/test_staging_deploy.py
+++ b/tests/unit/test_staging_deploy.py
@@ -53,13 +53,21 @@ def test_staging_uses_different_redis_databases_than_production():
 # --- Staging is otherwise identical to production ----------------------------
 
 
-def test_staging_forces_the_production_server():
-    """USE_GUNICORN=auto starts `uvicorn --reload` for any non-production env.
+def test_staging_is_treated_as_a_real_deployment():
+    """A rehearsal on a laxer posture or a different server proves very little.
 
-    A rehearsal on a different process model proves very little, so staging
-    pins the production server explicitly.
+    Staging used to pin `USE_GUNICORN=true` by hand to work around the
+    entrypoint only recognising "production". Both the server choice and the
+    application's strictness are now derived from the same rule, so the
+    workaround is gone and staging must simply be production-like.
+
+    The behaviours themselves are covered by test_production_like_predicate.py
+    and test_entrypoint_server_choice.py.
     """
-    assert deploy_env_vars("staging")["USE_GUNICORN"] == "true"
+    from src.config.schema import is_production_like
+
+    assert is_production_like("staging") is True
+    assert "USE_GUNICORN" not in deploy_env_vars("staging")
 
 
 def test_staging_matches_production_worker_shape():


### PR DESCRIPTION
Closes #320, #321, #322.

`ENVIRONMENT` was deciding two unrelated things: which per-environment config file to load, and how strictly the application behaves. Only the first is a legitimate use of the name.

That conflation is what let the v0.10.6 release break. The production worker crash-looped on missing `LLM_ENCRYPTION_*`, while the staging rehearsal built to catch exactly that booted the same image cleanly — the guard read `environment == "production"` and staging's was `"staging"`. **Staging was laxer than production, so the rehearsal passed and production broke.** That direction of failure makes a rehearsal worthless.

## What changed

**One derived predicate** (#320). `is_production_like()` — anything outside `{development, test}` is a real deployment — now answers every strictness question: write-auth enforcement, CORS deny-by-default, the missing-API-keys warning, hard-fail startup validation, and both LLM encryption checks. The name still selects the config file; nothing else compares it.

Derived rather than an opt-in setting, deliberately: it **fails closed**. An opt-in "strict" flag reproduces this exact bug the first time someone forgets it on a new environment. Unset or blank is production-like for the same reason.

**The entrypoint agrees** (#321). Server selection is shell and cannot import the predicate, so it mirrors the rule — with a test that *executes* the real decision block from the script and fails if shell and Python ever diverge. `staging.toml`'s hand-cut `use_gunicorn = "true"` workaround is gone; it existed only to compensate for the bug being fixed.

**A ratchet** (#322). Any direct `== "production"` comparison in Python or Terraform now fails the merge gate. The allowlist is **empty** — the derived predicate needs no literal comparison, so nothing legitimate needs exempting. Shell is out of scope by design: the entrypoint must compare names, so gating it would mean allowlisting the very line the gate permits; the drift test covers that copy by behaviour instead of text.

## Every check was verified load-bearing

A passing test proves nothing until you watch it fail:

| Change reverted | Result |
|---|---|
| `staging` added back to the relaxed set | **6 tests fail**, including the v0.10.6 regression |
| Old shell rule restored | **7 tests fail** |
| `== "production"` reintroduced in `security_policy.py` | ratchet fails with a pointed message |

The regression test reproduces the original crash under a staging-like environment — so the incident is now encoded where it cannot be forgotten.

## One correction to my own earlier analysis

I claimed the Terraform module was a live landmine. It is not: `environment` is validated to `test|development|production`, so a staging-like name cannot currently be passed. It would bite whoever first adds a name to that list. Mirrored anyway — latent coupling is cheapest to remove before it fires.

`make ready` green on every commit; 1205 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
