### PR TITLE
Resolve LLM availability once, so a stored key reaches generation

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 616
+Total Python files: 618
 
 ├── deploy/
 │   ├── __init__.py
@@ -1237,6 +1237,10 @@ Total Python files: 616
 │       │           def generate_from_url_task()
 │       ├── llm/
 │       │   ├── __init__.py
+│       │   ├── availability.py
+│       │   │       class LLMUnavailableReason
+│       │   │       class LLMAvailability (unavailable)
+│       │   │       def _env_key()
 │       │   ├── chunking.py
 │       │   │       class TokenEstimator (__call__)
 │       │   │       class TokenBudget
@@ -2660,6 +2664,15 @@ Total Python files: 616
         │       def _manifest_with_components()
         ├── test_inline_okw_facilities.py
         ├── test_layer_cascade.py
+        ├── test_llm_availability.py
+        │       def _no_ambient_keys()
+        │       def _stored()
+        │       def _nothing_stored()
+        │       def test_the_schema_default_is_a_kill_switch_not_an_enable_switch()
+        │       def test_the_generation_layer_builds_a_service_for_the_resolved_provider()
+        │       def test_an_unknown_resolved_provider_falls_back_rather_than_crashing()
+        │       def test_an_unresolved_config_runs_without_an_llm()
+        │       def test_the_gate_and_the_enabled_layer_stack_agree()
         ├── test_llm_credential_hot_swap.py
         │       class _InMemoryManager (__init__)
         │       class _FakeStorageService (__init__)
@@ -3151,7 +3164,7 @@ Total Python files: 616
 
 ## Overview
 
-Total files analyzed: 616
+Total files analyzed: 618
 
 ## Entry Points
 
@@ -6940,7 +6953,7 @@ Generates a complete, empty OKH manifest ...
 
 Prompts for required fields, then optiona...
 
-**Internal Dependencies:** 2 imports
+**Internal Dependencies:** 3 imports
 
 ### `src/cli/okw.py`
 > OKW (OpenKnowWhere) commands for OHM CLI
@@ -8398,6 +8411,22 @@ This module provides URL validation, platform detect...
 > LLM Provider System for the Open Hardware Manager.
 
 This module provides a LLM provider abstraction ...
+
+### `src/core/llm/availability.py`
+> Resolve, once per run, whether an LLM is actually usable.
+
+Generation used to answer this question t...
+
+**Exports:** LLMUnavailableReason, LLMAvailability
+
+**Classes:**
+- `LLMUnavailableReason`
+  - Why no LLM will run. Surfaced to users by #315....
+- `LLMAvailability`
+  - Methods: unavailable
+  - The single answer to "will an LLM run, and which one?"....
+
+**Internal Dependencies:** 3 imports
 
 ### `src/core/llm/chunking.py`
 > Core chunking primitives for long-context LLM workflows....
@@ -11004,6 +11033,26 @@ Verifies that:
 > Unit tests for evaluate_layers and evaluate_layers_supply_tree....
 
 **Internal Dependencies:** 2 imports
+
+### `tests/unit/test_llm_availability.py`
+> A key stored via Settings must actually reach generation.
+
+Generation used to answer "is an LLM conf...
+
+**Exports:** test_the_schema_default_is_a_kill_switch_not_an_enable_switch, test_the_generation_layer_builds_a_service_for_the_resolved_provider, test_an_unknown_resolved_provider_falls_back_rather_than_crashing, test_an_unresolved_config_runs_without_an_llm, test_the_gate_and_the_enabled_layer_stack_agree
+
+**Functions:**
+- `test_the_schema_default_is_a_kill_switch_not_an_enable_switch()`
+- `test_the_generation_layer_builds_a_service_for_the_resolved_provider()`
+  - It hardcoded Anthropic, so a configured OpenAI key was ignored even once
+the gat...
+- `test_an_unknown_resolved_provider_falls_back_rather_than_crashing()`
+- `test_an_unresolved_config_runs_without_an_llm()`
+  - Fail closed: a caller that never resolved must not silently get an LLM....
+- `test_the_gate_and_the_enabled_layer_stack_agree()`
+  - Progress stages are built from the same answer the engine acts on....
+
+**Internal Dependencies:** 8 imports
 
 ### `tests/unit/test_llm_credential_hot_swap.py`
 > Stored credentials can be hot-swapped into a running LLMService....

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A stored LLM credential now actually reaches generation.** The gate deciding
+  whether the LLM layer joins the stack read process environment variables only,
+  while the service that would have run it reads the encrypted credential store
+  first — so a key set through **Settings → LLM providers** caused the layer to
+  be dropped *before* that service was ever constructed. The store worked;
+  nothing reached it. Availability is now resolved **once**, asynchronously, at
+  the generation entry point and carried as plain values the synchronous gate
+  reads, so the gate, the progress stages and the layer stack cannot disagree.
+  Environment keys keep working unchanged; the store simply wins when both exist.
+- **The generation layer no longer hardcodes Anthropic.** It built its LLM
+  service with a fixed provider and then looked for an *Anthropic* credential
+  specifically, so a configured OpenAI key was ignored even once the gate let the
+  layer run. It now uses the resolved provider.
+- **`LLM_ENABLED` means something.** It previously gated only a startup log line.
+  It is now a schema setting and a genuine **kill switch** — false disables the
+  LLM regardless of stored credentials, so an operator can stop spend without
+  deleting keys. Configuring a provider remains the enable action. Its duplicate
+  hand-written entry in `env.template` is gone; a later assignment there would
+  have silently overridden the schema-owned one.
+
 ### Changed
 
 - **One predicate decides whether a deployment is "real".** `ENVIRONMENT` was

--- a/env.template
+++ b/env.template
@@ -48,6 +48,9 @@ GENERATE_FROM_URL_MAX_QUEUED=20
 # Per-IP rate limit for generate-from-url job submission.
 GENERATE_FROM_URL_RATE_LIMIT_PER_MINUTE=10
 
+# Master switch for LLM use. A kill switch, not an enable switch: configuring a provider credential is what turns the LLM on, and this turns it off without deleting credentials (e.g. during a cost spike). False means no LLM regardless of stored keys.
+LLM_ENABLED=True
+
 # When true, LLM-enabled generation (sync or async) requires a valid API key. Heuristic-only runs (no_llm=true) stay public.
 GENERATE_FROM_URL_REQUIRE_AUTH_FOR_LLM=False
 
@@ -167,8 +170,10 @@ GOOGLE_CLOUD_STORAGE_BUCKET=your-gcs-bucket
 # =============================================================================
 # LLM Configuration
 # =============================================================================
-# Enable/disable LLM integration
-LLM_ENABLED=false
+# LLM_ENABLED is schema-owned — see the generated block near the top of this
+# file. It is a kill switch, not an enable switch: configuring a provider
+# credential (here, or via Settings → LLM providers) is what turns the LLM on.
+# Do not re-declare it here; a later assignment would silently override it.
 
 # LLM Provider: openai, anthropic, google, azure, local
 LLM_DEFAULT_PROVIDER=anthropic  # Used in code

--- a/src/cli/llm.py
+++ b/src/cli/llm.py
@@ -149,6 +149,8 @@ async def _generate_okh_manifest(
 ) -> dict:
     """Generate OKH manifest using LLM."""
     # Create generation engine with LLM enabled
+    from ..core.llm.availability import resolve_llm_availability
+
     config = LayerConfig(
         use_llm=True,
         llm_config={
@@ -158,6 +160,13 @@ async def _generate_okh_manifest(
             "temperature": temperature,
             "timeout": timeout,
         },
+    )
+
+    # The user named a provider on the command line; resolve THAT one rather
+    # than falling back to preference order, so an explicit choice is never
+    # silently swapped for another provider.
+    config.with_llm_availability(
+        await resolve_llm_availability(preferred_provider=provider)
     )
 
     engine = GenerationEngine(config)

--- a/src/cli/okh.py
+++ b/src/cli/okh.py
@@ -1396,10 +1396,17 @@ async def generate_from_url(
                     project_data = await generator.extract_project(url)
 
             # Generate manifest from project data (LLM + chunking preferred; see LayerConfig)
-            config = LayerConfig.for_generate_from_url(no_llm=no_llm)
+            from src.core.llm.availability import resolve_llm_availability
+
+            config = LayerConfig.for_generate_from_url(
+                no_llm=no_llm
+            ).with_llm_availability(
+                await resolve_llm_availability(requested=not no_llm)
+            )
             if config.use_llm and not config.is_llm_configured():
                 cli_ctx.log(
-                    "LLM preferred but not configured; using 3-layer generation.",
+                    f"LLM preferred but unavailable "
+                    f"({config.llm_unavailable_reason}); using 3-layer generation.",
                     "warning",
                 )
             engine = GenerationEngine(config=config)

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -233,6 +233,15 @@ class Settings(BaseSettings):
         default=10,
         description="Per-IP rate limit for generate-from-url job submission.",
     )
+    llm_enabled: bool = Field(
+        default=True,
+        description=(
+            "Master switch for LLM use. A kill switch, not an enable switch: "
+            "configuring a provider credential is what turns the LLM on, and "
+            "this turns it off without deleting credentials (e.g. during a cost "
+            "spike). False means no LLM regardless of stored keys."
+        ),
+    )
     generate_from_url_require_auth_for_llm: bool = Field(
         default=False,
         description=(

--- a/src/core/generation/dataset_generation.py
+++ b/src/core/generation/dataset_generation.py
@@ -114,7 +114,11 @@ async def generate_manifest_for_repository(
                 raise ValueError(f"Unsupported platform: {platform}")
             project_data = await generator.extract_project(url)
 
-    config = LayerConfig.for_generate_from_url(no_llm=not use_llm)
+    from ..llm.availability import resolve_llm_availability
+
+    config = LayerConfig.for_generate_from_url(
+        no_llm=not use_llm
+    ).with_llm_availability(await resolve_llm_availability(requested=use_llm))
     config.use_bom_normalization = use_bom_normalization
     if use_llm and not llm_chunked_mode_enabled:
         config.llm_config["chunked_mode_enabled"] = False

--- a/src/core/generation/layers/llm.py
+++ b/src/core/generation/layers/llm.py
@@ -112,9 +112,26 @@ class LLMGenerationLayer(BaseGenerationLayer):
         """Create LLM service (initialization will be done in process method)"""
         try:
             # Create LLM service configuration (uses centralized default model)
+            # Use the provider resolved at the entry point. This was hardcoded
+            # to Anthropic, so a credential configured for any other provider
+            # was ignored even once the gate let this layer run — the service
+            # then looked for an ANTHROPIC credential specifically and found
+            # nothing.
+            resolved = getattr(self.layer_config, "llm_provider", None)
+            try:
+                provider = (
+                    LLMProviderType(resolved) if resolved else LLMProviderType.ANTHROPIC
+                )
+            except ValueError:
+                logger.warning(
+                    "Unknown resolved LLM provider %r; falling back to anthropic",
+                    resolved,
+                )
+                provider = LLMProviderType.ANTHROPIC
+
             service_config = LLMServiceConfig(
                 name="LLMGenerationLayer",
-                default_provider=LLMProviderType.ANTHROPIC,
+                default_provider=provider,
                 default_model=None,  # Use centralized config
                 max_retries=3,
                 retry_delay=1.0,

--- a/src/core/generation/models.py
+++ b/src/core/generation/models.py
@@ -2011,6 +2011,16 @@ class LayerConfig:
     llm_config: Dict[str, Any] = field(default_factory=dict)
     file_categorization_config: Dict[str, Any] = field(default_factory=dict)
 
+    # Resolved ONCE at the generation entry point (see
+    # src.core.llm.availability.resolve_llm_availability) and carried here as
+    # plain values, because the gate below is synchronous while reading the
+    # credential store is not. Nothing re-derives it: the gate, the progress
+    # stages and the layer stack therefore cannot disagree, and the answer
+    # cannot change midway through a run.
+    llm_available: bool = False
+    llm_provider: Optional[str] = None
+    llm_unavailable_reason: Optional[str] = None
+
     def __post_init__(self):
         """Validate configuration after initialization"""
         self._validate_config()
@@ -2159,7 +2169,12 @@ class LayerConfig:
         return self.llm_config.get("model", "gpt-3.5-turbo")
 
     def get_llm_api_key(self) -> Optional[str]:
-        """Get the LLM API key (from config or environment)"""
+        """Get the LLM API key (from config or environment).
+
+        NOTE: availability is decided by :meth:`is_llm_configured`, which reads
+        the pre-resolved answer. This remains only for callers that construct a
+        provider client directly from an explicit config.
+        """
         api_key = self.llm_config.get("api_key")
         if api_key:
             return api_key
@@ -2176,12 +2191,25 @@ class LayerConfig:
             return os.getenv(f"{provider.upper()}_API_KEY")
 
     def is_llm_configured(self) -> bool:
-        """Check if LLM layer is properly configured"""
-        if not self.use_llm:
-            return False
+        """Whether the LLM layer will run.
 
-        api_key = self.get_llm_api_key()
-        return api_key is not None and len(api_key.strip()) > 0
+        Reads the availability resolved once at the entry point rather than
+        re-deriving it. Previously this consulted process environment variables
+        only, so a credential stored via Settings → LLM providers caused the
+        layer to be dropped before the service that *would* have found it was
+        ever constructed.
+        """
+        return bool(self.use_llm and self.llm_available)
+
+    def with_llm_availability(self, availability) -> "LayerConfig":
+        """Apply a resolved :class:`LLMAvailability` to this config (in place).
+
+        Returns ``self`` so entry points can resolve-and-apply in one line.
+        """
+        self.llm_available = bool(availability.available)
+        self.llm_provider = availability.provider
+        self.llm_unavailable_reason = availability.reason
+        return self
 
     @classmethod
     def for_generate_from_url(cls, *, no_llm: bool = False) -> "LayerConfig":
@@ -2191,8 +2219,10 @@ class LayerConfig:
         default ``llm_config`` includes chunked map-reduce for quality on large
         repositories.
 
-        If API keys are missing, :meth:`is_llm_configured` is false and the
-        engine runs without the LLM matcher (direct + heuristic + NLP only).
+        The returned config has ``llm_available`` False until an entry point
+        applies a resolved availability via :meth:`with_llm_availability`; until
+        then :meth:`is_llm_configured` is false and the engine runs without the
+        LLM matcher (direct + heuristic + NLP only).
         """
         return cls(
             use_llm=not no_llm,

--- a/src/core/llm/availability.py
+++ b/src/core/llm/availability.py
@@ -1,0 +1,140 @@
+"""Resolve, once per run, whether an LLM is actually usable.
+
+Generation used to answer this question twice, differently. The gate that
+decides whether the LLM layer joins the stack looked only at process
+environment variables, while the service that would have run it reads the
+encrypted credential store first. The gate wins, so a key configured through
+**Settings → LLM providers** caused the layer to be dropped *before* the
+service was ever constructed — the store worked, but nothing reached it.
+
+There is one answer now, produced here. It is resolved **asynchronously at the
+entry point** (reading the store awaits storage) and then carried as plain
+values on ``LayerConfig``, which the synchronous gate reads. That kills both the
+duplicate resolution and the sync/async mismatch that caused it, and it means
+the answer cannot change midway through a run — so the progress stages and the
+enabled-layer stack always agree.
+
+Availability here means **declared configuration**: a key present in the
+credential store or the process environment. Whether the key is *valid* is not
+knowable without spending money, so a run that fails at call time degrades and
+is reported as such.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Tried in order when nothing is explicitly configured. Deliberately excludes
+# LOCAL/ollama: it needs a base URL rather than a key and defaults to
+# localhost, so presence-based detection would make every node believe a local
+# model is available. Opting into it explicitly is #314.
+PROVIDER_PREFERENCE: List[str] = ["anthropic", "openai", "azure_openai"]
+
+# Environment variable holding each provider's key, checked when the credential
+# store has nothing. Keeps the local `.env` workflow working unchanged.
+PROVIDER_ENV_KEYS = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "azure_openai": "AZURE_OPENAI_API_KEY",
+    "aws_bedrock": "AWS_BEDROCK_API_KEY",
+    "google": "GOOGLE_APPLICATION_CREDENTIALS",
+}
+
+
+class LLMUnavailableReason:
+    """Why no LLM will run. Surfaced to users by #315."""
+
+    NOT_REQUESTED = "not_requested"
+    DISABLED = "disabled"
+    NOT_CONFIGURED = "not_configured"
+
+
+@dataclass(frozen=True)
+class LLMAvailability:
+    """The single answer to "will an LLM run, and which one?"."""
+
+    available: bool
+    provider: Optional[str] = None
+    source: Optional[str] = None  # "credential_store" | "environment"
+    reason: Optional[str] = None  # set when unavailable
+
+    @classmethod
+    def unavailable(cls, reason: str) -> "LLMAvailability":
+        return cls(available=False, reason=reason)
+
+
+async def _stored_key(provider: str) -> Optional[str]:
+    """Key from the encrypted credential store, or None if absent/unreadable."""
+    try:
+        from src.config.llm_config import CredentialManager, LLMProvider
+
+        from ..services.storage_service import StorageService
+        from ..storage.llm_credential_store import LLMCredentialStore
+
+        storage = await StorageService.get_instance()
+        store = LLMCredentialStore(storage, CredentialManager())
+        return await store.load(LLMProvider(provider))
+    except Exception as exc:  # storage down, provider unknown, undecryptable
+        logger.debug("No stored credential for %s: %s", provider, exc)
+        return None
+
+
+def _env_key(provider: str) -> Optional[str]:
+    name = PROVIDER_ENV_KEYS.get(provider)
+    if not name:
+        return None
+    value = os.getenv(name)
+    return value.strip() if value and value.strip() else None
+
+
+async def resolve_llm_availability(
+    *,
+    requested: bool = True,
+    preferred_provider: Optional[str] = None,
+) -> LLMAvailability:
+    """Decide whether an LLM will run for this generation, and which provider.
+
+    Args:
+        requested: False when the caller explicitly opted out (``no_llm``).
+        preferred_provider: An explicitly chosen provider; tried alone rather
+            than falling back, so an explicit choice never silently becomes a
+            different provider.
+
+    Resolution order per provider: the credential store first (what the Settings
+    UI writes), then the process environment (what a local ``.env`` provides).
+    """
+    if not requested:
+        return LLMAvailability.unavailable(LLMUnavailableReason.NOT_REQUESTED)
+
+    from src.config.schema import get_settings
+
+    if not get_settings().llm_enabled:
+        logger.info("LLM disabled by configuration (LLM_ENABLED=false)")
+        return LLMAvailability.unavailable(LLMUnavailableReason.DISABLED)
+
+    candidates = [preferred_provider] if preferred_provider else PROVIDER_PREFERENCE
+
+    for provider in candidates:
+        if not provider:
+            continue
+        if await _stored_key(provider):
+            logger.info("LLM available: %s (stored credential)", provider)
+            return LLMAvailability(
+                available=True, provider=provider, source="credential_store"
+            )
+        if _env_key(provider):
+            logger.info("LLM available: %s (environment)", provider)
+            return LLMAvailability(
+                available=True, provider=provider, source="environment"
+            )
+
+    logger.info(
+        "No LLM provider configured (tried: %s); generation will run without one",
+        ", ".join(p for p in candidates if p),
+    )
+    return LLMAvailability.unavailable(LLMUnavailableReason.NOT_CONFIGURED)

--- a/src/core/services/okh_service.py
+++ b/src/core/services/okh_service.py
@@ -904,8 +904,17 @@ class OKHService(BaseService["OKHService"]):
             # Clone/extract is outside the engine; share one weighted stage plan with
             # the engine so UI fractions stay aligned across the process boundary.
             job_emitter: Optional[ProgressEmitter] = None
+            # Resolve LLM availability ONCE for this run. Both the progress
+            # plan and the engine below read this same answer, so the advertised
+            # stages and the layers that actually run cannot disagree.
+            from ..llm.availability import resolve_llm_availability
+
+            availability = await resolve_llm_availability(requested=not no_llm)
+
             if progress is not None:
-                config_preview = LayerConfig.for_generate_from_url(no_llm=no_llm)
+                config_preview = LayerConfig.for_generate_from_url(
+                    no_llm=no_llm
+                ).with_llm_availability(availability)
                 use_llm = bool(
                     config_preview.use_llm and config_preview.is_llm_configured()
                 )
@@ -953,11 +962,14 @@ class OKHService(BaseService["OKHService"]):
             # no API keys — see LayerConfig.for_generate_from_url / is_llm_configured).
             from ..generation.engine import GenerationEngine
 
-            config = LayerConfig.for_generate_from_url(no_llm=no_llm)
+            config = LayerConfig.for_generate_from_url(
+                no_llm=no_llm
+            ).with_llm_availability(availability)
             if config.use_llm and not config.is_llm_configured():
                 self.logger.info(
-                    "OKH generate-from-url: LLM preferred but not configured; "
-                    "using 3-layer generation (direct/heuristic/NLP)."
+                    "OKH generate-from-url: LLM preferred but unavailable (%s); "
+                    "using 3-layer generation (direct/heuristic/NLP).",
+                    config.llm_unavailable_reason,
                 )
 
             engine_progress = None

--- a/tests/unit/test_llm_availability.py
+++ b/tests/unit/test_llm_availability.py
@@ -1,0 +1,252 @@
+"""A key stored via Settings must actually reach generation.
+
+Generation used to answer "is an LLM configured?" twice, differently: the gate
+that admits the LLM layer read process environment variables only, while the
+service that would have run it reads the encrypted credential store first. The
+gate wins, so a credential set through Settings → LLM providers caused the layer
+to be dropped BEFORE the service was ever constructed. The store worked;
+nothing reached it.
+
+These tests pin the single resolved answer, and the two independent bugs found
+alongside it.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.core.generation.models import LayerConfig
+from src.core.llm.availability import (
+    LLMAvailability,
+    LLMUnavailableReason,
+    resolve_llm_availability,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_keys(monkeypatch):
+    """Tests must not depend on the developer's real .env."""
+    for name in (
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "AZURE_OPENAI_API_KEY",
+        "AWS_BEDROCK_API_KEY",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("LLM_ENABLED", "true")
+
+
+def _stored(mapping):
+    """Patch the credential store to return keys from `mapping`."""
+    return patch(
+        "src.core.llm.availability._stored_key",
+        AsyncMock(side_effect=lambda provider: mapping.get(provider)),
+    )
+
+
+def _nothing_stored():
+    return _stored({})
+
+
+# --- The bug this issue exists to fix ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_credential_stored_via_settings_makes_the_llm_available():
+    """THE regression. Previously the gate never consulted the store at all."""
+    with _stored({"anthropic": "sk-from-the-settings-ui"}):
+        availability = await resolve_llm_availability()
+
+    assert availability.available is True
+    assert availability.provider == "anthropic"
+    assert availability.source == "credential_store"
+
+
+@pytest.mark.asyncio
+async def test_a_stored_credential_reaches_the_generation_gate():
+    """End to end through the object generation actually consults."""
+    with _stored({"anthropic": "sk-stored"}):
+        availability = await resolve_llm_availability()
+
+    config = LayerConfig.for_generate_from_url().with_llm_availability(availability)
+
+    assert config.is_llm_configured() is True
+    assert config.llm_provider == "anthropic"
+
+
+@pytest.mark.asyncio
+async def test_an_environment_key_still_works_unchanged(monkeypatch):
+    """The local `.env` workflow must not regress — Settings ALSO works now."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-from-env")
+
+    with _nothing_stored():
+        availability = await resolve_llm_availability()
+
+    assert availability.available is True
+    assert availability.source == "environment"
+
+
+@pytest.mark.asyncio
+async def test_the_store_wins_over_the_environment(monkeypatch):
+    """An admin rotating a key through Settings should take effect."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-stale-env")
+
+    with _stored({"anthropic": "sk-current"}):
+        availability = await resolve_llm_availability()
+
+    assert availability.source == "credential_store"
+
+
+# --- Nothing configured ------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_credential_anywhere_means_no_llm():
+    with _nothing_stored():
+        availability = await resolve_llm_availability()
+
+    assert availability.available is False
+    assert availability.reason == LLMUnavailableReason.NOT_CONFIGURED
+
+
+@pytest.mark.asyncio
+async def test_opting_out_short_circuits_before_touching_the_store():
+    """`no_llm=true` must not pay for a storage read it cannot use."""
+    store = AsyncMock()
+    with patch("src.core.llm.availability._stored_key", store):
+        availability = await resolve_llm_availability(requested=False)
+
+    assert availability.available is False
+    assert availability.reason == LLMUnavailableReason.NOT_REQUESTED
+    store.assert_not_awaited()
+
+
+# --- The master switch -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_llm_enabled_false_overrides_a_stored_credential(monkeypatch):
+    """A kill switch: turn the LLM off without deleting credentials."""
+    monkeypatch.setenv("LLM_ENABLED", "false")
+
+    with _stored({"anthropic": "sk-still-there"}):
+        availability = await resolve_llm_availability()
+
+    assert availability.available is False
+    assert availability.reason == LLMUnavailableReason.DISABLED
+
+
+@pytest.mark.asyncio
+async def test_llm_is_on_by_default_when_a_credential_exists(monkeypatch):
+    """Configuring a provider is the enable action; the flag only disables."""
+    monkeypatch.delenv("LLM_ENABLED", raising=False)
+
+    with _stored({"anthropic": "sk-configured"}):
+        availability = await resolve_llm_availability()
+
+    assert availability.available is True
+
+
+def test_the_schema_default_is_a_kill_switch_not_an_enable_switch():
+    from src.config.schema import Settings
+
+    assert Settings().llm_enabled is True
+
+
+# --- Provider selection ------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preference_order_picks_the_configured_provider():
+    """With only OpenAI configured, generation must not insist on Anthropic."""
+    with _stored({"openai": "sk-openai"}):
+        availability = await resolve_llm_availability()
+
+    assert availability.provider == "openai"
+
+
+@pytest.mark.asyncio
+async def test_an_explicitly_chosen_provider_is_never_silently_swapped():
+    """A CLI `--provider openai` must not fall back to a stored Anthropic key."""
+    with _stored({"anthropic": "sk-anthropic", "openai": None}):
+        availability = await resolve_llm_availability(preferred_provider="openai")
+
+    assert availability.available is False
+    assert availability.reason == LLMUnavailableReason.NOT_CONFIGURED
+
+
+@pytest.mark.asyncio
+async def test_ollama_is_not_assumed_available():
+    """It defaults to localhost, so presence-based detection would claim every
+    node has a local model. Explicit opt-in is a separate change."""
+    with _nothing_stored():
+        availability = await resolve_llm_availability()
+
+    assert availability.provider != "local"
+
+
+# --- The layer uses the resolved provider ------------------------------------
+
+
+def test_the_generation_layer_builds_a_service_for_the_resolved_provider():
+    """It hardcoded Anthropic, so a configured OpenAI key was ignored even once
+    the gate let the layer run."""
+    from src.core.generation.layers.llm import LLMGenerationLayer
+
+    config = LayerConfig(use_llm=True).with_llm_availability(
+        LLMAvailability(available=True, provider="openai", source="credential_store")
+    )
+    layer = LLMGenerationLayer(layer_config=config)
+
+    assert layer.llm_service.config.default_provider.value == "openai"
+
+
+def test_an_unknown_resolved_provider_falls_back_rather_than_crashing():
+    from src.core.generation.layers.llm import LLMGenerationLayer
+
+    config = LayerConfig(use_llm=True).with_llm_availability(
+        LLMAvailability(available=True, provider="not-a-provider")
+    )
+    layer = LLMGenerationLayer(layer_config=config)
+
+    assert layer.llm_service.config.default_provider.value == "anthropic"
+
+
+# --- The stack cannot disagree with itself -----------------------------------
+
+
+def test_an_unresolved_config_runs_without_an_llm():
+    """Fail closed: a caller that never resolved must not silently get an LLM."""
+    config = LayerConfig.for_generate_from_url()
+
+    assert config.llm_available is False
+    assert config.is_llm_configured() is False
+
+
+def test_the_gate_and_the_enabled_layer_stack_agree():
+    """Progress stages are built from the same answer the engine acts on."""
+    from src.core.generation.models import GenerationLayer
+
+    available = LayerConfig.for_generate_from_url().with_llm_availability(
+        LLMAvailability(available=True, provider="anthropic")
+    )
+    unavailable = LayerConfig.for_generate_from_url().with_llm_availability(
+        LLMAvailability.unavailable(LLMUnavailableReason.NOT_CONFIGURED)
+    )
+
+    assert available.is_llm_configured() is True
+    assert GenerationLayer.LLM in available.get_enabled_layers()
+
+    assert unavailable.is_llm_configured() is False
+    assert GenerationLayer.LLM not in unavailable.get_enabled_layers()


### PR DESCRIPTION
Closes #313.

A key configured through **Settings → LLM providers** had no effect on generation. This makes it work — and it is a smaller fix than the original diagnosis suggested, because the bridge already existed.

## The actual defect

Generation answered *"is an LLM configured?"* **twice, differently**:

- The **gate** that admits the LLM layer to the stack read process environment variables only.
- `LLMService`, which would have run it, reads the encrypted credential store first, then env.

The gate wins. So a stored credential caused the layer to be dropped **before the service that would have found it was ever constructed**. The store worked; nothing reached it.

The reason the two diverged is structural: the gate is **synchronous** and reading the store is **async**, so the gate could not simply consult the store.

## The fix

Availability is resolved **once**, asynchronously, at the generation entry point, and carried on `LayerConfig` as plain values the sync gate reads. Nothing re-derives it, so the gate, the progress stages and the enabled-layer stack cannot disagree — and the answer cannot change midway through a run.

All four construction sites resolve: the OKH service (which covers the **sync endpoint and the Celery worker**, since they share it), dataset generation, and both CLI paths. A config that was never resolved **fails closed** — no LLM.

Environment keys keep working exactly as before. The store simply wins when both exist, which is what makes key rotation through the UI take effect.

## Two independent bugs found alongside

Both were invisible while the gate blocked everything:

**The layer hardcoded Anthropic.** It built its service with a fixed provider and then resolved an *Anthropic* credential specifically — so a configured OpenAI key was ignored even once the gate let it through. It now uses the resolved provider, with a safe fallback for an unrecognised one.

**`LLM_ENABLED` gated only a startup log line.** It is now a schema setting and a genuine kill switch: false disables the LLM regardless of stored credentials, so spend can be stopped without deleting keys. Configuring a provider stays the enable action, hence the default is on — per the "kill switch, not enable switch" decision. Its hand-written duplicate in `env.template` is removed; a later assignment there would have silently overridden the schema-owned one.

## Verification

Restoring the old env-only gate fails the two tests asserting a stored credential reaches the engine — so they catch the original bug rather than passing incidentally.

Also pinned: an explicitly chosen provider is resolved **alone**, never falling back through preference order, so `--provider openai` cannot be quietly served by a stored Anthropic key. And ollama is deliberately not assumed available — it defaults to localhost, so presence-based detection would claim every node has a local model. Explicit opt-in is #314.

`make ready` green; 1221 tests.

## Note for reviewers

Generation still runs heuristic-only in production until an admin stores a credential — this PR makes that action *work*, it does not configure one. Reporting which happened is #315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
