### PR TITLE
Report whether the LLM actually ran

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 618
+Total Python files: 619
 
 ├── deploy/
 │   ├── __init__.py
@@ -1181,6 +1181,9 @@ Total Python files: 618
 │       │   ├── quality.py
 │       │   │       class ValidationResult (__post_init__)
 │       │   │       class QualityAssessor (__init__, assess_field_confidence, validate_required_fields...)
+│       │   │       class LLMUsageStatus
+│       │   │       def summarize_llm_usage()
+│       │   │       def llm_usage_recommendation()
 │       │   ├── repair_doc_extractor.py
 │       │   │       class RepairExtractionResult (to_patch)
 │       │   │       class RepairDocExtractor (extract, _extract_text, _extract_pdf...)
@@ -2681,6 +2684,20 @@ Total Python files: 618
         │       class _InMemoryManager (__init__)
         │       class _FakeStorageService (__init__)
         │       def store()
+        ├── test_llm_usage_reporting.py
+        │       def _available()
+        │       def _unavailable()
+        │       def test_a_run_that_used_the_llm_says_so_and_names_the_provider()
+        │       def test_no_provider_configured_is_reported_as_such()
+        │       def test_the_kill_switch_is_distinguished_from_a_missing_credential()
+        │       def test_opting_out_is_not_reported_as_a_problem()
+        │       def test_a_configured_provider_that_failed_is_distinguished_from_one_never_reached()
+        │       def test_the_provider_is_not_claimed_for_a_run_that_did_not_use_it()
+        │       def test_a_degraded_run_explains_itself_in_plain_language()
+        │       def test_a_failed_provider_is_told_to_check_the_credential_not_to_add_one()
+        │       def test_a_successful_run_says_nothing()
+        │       def test_deliberate_choices_are_not_nagged_about()
+        │       def test_the_kill_switch_gets_its_own_explanation()
         ├── test_match_coverage.py
         │       class TestCoverageURIVsPlainText (test_laser_cutting_uri_matches_plain_text_requirement, test_cnc_machining_uri_matches_plain_text_requirement, test_assembly_uri_matches_plain_text_requirement...)
         │       class TestCoverageDuplicateRequirements (test_duplicate_process_names_deduplicated, test_duplicate_uri_processes_deduplicated)
@@ -3164,7 +3181,7 @@ Total Python files: 618
 
 ## Overview
 
-Total files analyzed: 618
+Total files analyzed: 619
 
 ## Entry Points
 
@@ -8313,7 +8330,7 @@ Fractions are start-of-stage cumulatives so ...
 
 This module provides functionality to assess the qu...
 
-**Exports:** ValidationResult, QualityAssessor
+**Exports:** ValidationResult, QualityAssessor, LLMUsageStatus, summarize_llm_usage, llm_usage_recommendation
 
 **Classes:**
 - `ValidationResult`
@@ -8321,6 +8338,19 @@ This module provides functionality to assess the qu...
 - `QualityAssessor`
   - Methods: assess_field_confidence, validate_required_fields, generate_quality_report
   - Assesses the quality of generated manifest fields...
+- `LLMUsageStatus`
+  - Why the LLM did or did not contribute to a run....
+
+**Functions:**
+- `summarize_llm_usage(config, layer_usage_counts, layer_error_counts)`
+  - Report whether the LLM contributed, and why not when it did not.
+
+Args:
+    conf...
+- `llm_usage_recommendation(summary)`
+  - A plain-language line for a run that had no LLM, or None.
+
+Rendered by the exist...
 
 ### `src/core/generation/repair_doc_extractor.py`
 > Repair document extractor: two-pass extraction of repair-specific OKH fields.
@@ -11079,6 +11109,26 @@ the gat...
 - `store()`
 
 **Internal Dependencies:** 3 imports
+
+### `tests/unit/test_llm_usage_reporting.py`
+> A run must say whether an LLM contributed, and why not when it did not.
+
+Generation degrades to dire...
+
+**Exports:** test_a_run_that_used_the_llm_says_so_and_names_the_provider, test_no_provider_configured_is_reported_as_such, test_the_kill_switch_is_distinguished_from_a_missing_credential, test_opting_out_is_not_reported_as_a_problem, test_a_configured_provider_that_failed_is_distinguished_from_one_never_reached
+
+**Functions:**
+- `test_a_run_that_used_the_llm_says_so_and_names_the_provider()`
+- `test_no_provider_configured_is_reported_as_such()`
+- `test_the_kill_switch_is_distinguished_from_a_missing_credential()`
+  - 'Disabled' and 'not configured' need different fixes....
+- `test_opting_out_is_not_reported_as_a_problem()`
+- `test_a_configured_provider_that_failed_is_distinguished_from_one_never_reached()`
+  - Neither leaves a usage count, so the engine's error count separates them.
+
+A sto...
+
+**Internal Dependencies:** 8 imports
 
 ### `tests/unit/test_match_coverage.py`
 > Tests for match coverage computation correctness.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Runs report whether the LLM actually contributed.** The quality report now
+  carries `llm_used`, `llm_status` and the provider, and a degraded run adds a
+  plain-language recommendation explaining why — rendered by the existing banner
+  with no frontend change. Degradation was previously invisible outside the logs,
+  so a reviewer could not tell a thin manifest from a missing provider. Status
+  distinguishes the cases that need different fixes: `not_configured` (add a
+  credential), `disabled` (the kill switch is on), `failed` (the provider could
+  not be reached), `skipped` (confidence was met before it ran) and
+  `not_requested`. To tell *failed* from *never reached* the engine now records
+  per-layer failures — neither leaves a usage count otherwise. The production
+  probe gained `expect_llm`, which fails a release if a node with a configured
+  provider silently drops to heuristic-only.
+
 ### Fixed
 
 - **A stored LLM credential now actually reaches generation.** The gate deciding

--- a/frontend/src/features/generate/qualityBanner.ts
+++ b/frontend/src/features/generate/qualityBanner.ts
@@ -1,10 +1,15 @@
 /**
  * Quality-report presentation mapper (pure, unit-tested).
  *
- * The banner WARNS and never blocks. Generation is heuristic-only in
- * production, so an imperfect manifest is the expected outcome, not an error —
- * the human review step is what compensates. The only hard gate is that the six
- * required OKH fields are valid before saving (see manifestTiers.ts).
+ * The banner WARNS and never blocks. An imperfect manifest is the expected
+ * outcome, not an error — the human review step is what compensates. The only
+ * hard gate is that the six required OKH fields are valid before saving (see
+ * manifestTiers.ts).
+ *
+ * Whether an LLM contributed varies per run and per deployment: the backend
+ * reports it as `llm_used` / `llm_status`, and adds a plain-language
+ * recommendation when a run degraded to heuristic-only. Recommendations are
+ * rendered verbatim, so that line reaches the reviewer with no work here.
  */
 
 import type { OkhQualityReport } from "../../api/ohm/okh";

--- a/harness.config.json
+++ b/harness.config.json
@@ -93,7 +93,8 @@
         "timeout_seconds": 300,
         "poll_seconds": 5,
         "no_llm": true,
-        "note": "Health signal for the Celery worker: a job accepted but never consumed sits in PENDING forever with no error, and only an end-to-end submit-and-poll sees it."
+        "expect_llm": false,
+        "note": "Set expect_llm=true once a provider credential is configured, to catch a silent regression to heuristic-only. Health signal for the Celery worker: a job accepted but never consumed sits in PENDING forever with no error, and only an end-to-end submit-and-poll sees it."
       }
     }
   }

--- a/harness/modules/probe_async_generation.py
+++ b/harness/modules/probe_async_generation.py
@@ -49,6 +49,7 @@ class ProbeAsyncGenerationLoop(ProbeModule):
                 "repo_url": opts.get("repo_url", DEFAULT_REPO_URL),
                 "timeout_seconds": opts.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS),
                 "no_llm": opts.get("no_llm", True),
+                "expect_llm": opts.get("expect_llm", False),
                 "api_base_url": self.config.api_base_url,
             },
             notes=[
@@ -126,6 +127,7 @@ class ProbeAsyncGenerationLoop(ProbeModule):
             time.sleep(poll_seconds)
 
         elapsed = time.monotonic() - started
+        quality = status_body.get("quality_report") or {}
         data.update(
             {
                 "state": state,
@@ -135,6 +137,8 @@ class ProbeAsyncGenerationLoop(ProbeModule):
                 "timed_out": state not in TERMINAL_STATES,
                 "has_manifest": bool(status_body.get("manifest")),
                 "job_error": status_body.get("error"),
+                "llm_used": quality.get("llm_used"),
+                "llm_status": quality.get("llm_status"),
             }
         )
 
@@ -265,6 +269,29 @@ class ProbeAsyncGenerationLoop(ProbeModule):
                     severity=Severity.ERROR,
                     title="Generation job was revoked unexpectedly",
                     evidence={"job_id": data.get("job_id")},
+                    suggested_state="needs-triage",
+                )
+            )
+        elif (
+            state == "SUCCESS"
+            and self._options().get("expect_llm")
+            and not data.get("llm_used")
+        ):
+            findings.append(
+                Finding(
+                    module=self.name,
+                    kind=FindingKind.BUG,
+                    severity=Severity.ERROR,
+                    title="Generation succeeded but ran without an LLM",
+                    evidence={
+                        "llm_status": data.get("llm_status"),
+                        "recommendation": (
+                            "This node is expected to have an LLM provider "
+                            "configured. 'not_configured' means the credential is "
+                            "missing; 'disabled' means LLM_ENABLED is false; "
+                            "'failed' means the provider could not be reached."
+                        ),
+                    },
                     suggested_state="needs-triage",
                 )
             )

--- a/src/core/generation/engine.py
+++ b/src/core/generation/engine.py
@@ -856,6 +856,12 @@ class GenerationEngine:
 
             except Exception as e:
                 logger.warning(f"Layer {layer.value} failed: {e}")
+                # Record it: a layer that raised leaves no usage count, so
+                # without this a failed layer is indistinguishable from one that
+                # was never reached (see quality.summarize_llm_usage).
+                self._metrics.error_counts[layer.value] = (
+                    self._metrics.error_counts.get(layer.value, 0) + 1
+                )
                 # Continue with other layers
                 continue
 

--- a/src/core/generation/quality.py
+++ b/src/core/generation/quality.py
@@ -6,7 +6,7 @@ validate required fields, and generate quality reports with recommendations.
 """
 
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from .models import FieldGeneration, QualityReport
 
@@ -255,3 +255,105 @@ class QualityAssessor:
             recommendations.append("Enhance the project description with more detail")
 
         return recommendations
+
+
+# --- Did the LLM actually run? -----------------------------------------------
+#
+# Generation degrades to direct + heuristic + NLP whenever no LLM is usable, and
+# that degradation used to be invisible outside the logs: a reviewer could not
+# tell whether a thin manifest reflected a thin repository or a missing
+# provider. Declared availability is not proof either — a stored key can be
+# expired, and a named local model can be down — so this reports what HAPPENED,
+# not what was configured.
+
+
+class LLMUsageStatus:
+    """Why the LLM did or did not contribute to a run."""
+
+    USED = "used"
+    NOT_REQUESTED = "not_requested"  # caller passed no_llm
+    DISABLED = "disabled"  # LLM_ENABLED=false
+    NOT_CONFIGURED = "not_configured"  # no credential for any provider
+    FAILED = "failed"  # available and attempted, but errored
+    SKIPPED = "skipped"  # enough confidence reached before it ran
+
+
+# Reasons that mean "nothing is wrong, this is what you asked for".
+_DELIBERATE = {LLMUsageStatus.NOT_REQUESTED, LLMUsageStatus.DISABLED}
+
+_RECOMMENDATIONS = {
+    LLMUsageStatus.NOT_CONFIGURED: (
+        "Generated without an LLM — no provider is configured, so descriptive "
+        "fields such as 'function' were not inferred. Add a provider credential "
+        "in Settings to improve extraction."
+    ),
+    LLMUsageStatus.FAILED: (
+        "Generated without an LLM — the configured provider could not be reached, "
+        "so descriptive fields such as 'function' were not inferred. Check the "
+        "credential is valid and the provider is reachable."
+    ),
+    LLMUsageStatus.DISABLED: (
+        "Generated without an LLM — it is switched off (LLM_ENABLED=false), so "
+        "descriptive fields such as 'function' were not inferred."
+    ),
+}
+
+
+def summarize_llm_usage(
+    config, layer_usage_counts=None, layer_error_counts=None
+) -> Dict[str, Any]:
+    """Report whether the LLM contributed, and why not when it did not.
+
+    Args:
+        config: the :class:`LayerConfig` the run used, carrying the availability
+            resolved at the entry point.
+        layer_usage_counts: the engine's per-layer execution counts. A layer that
+            raised never increments its count.
+        layer_error_counts: the engine's per-layer failure counts. This is what
+            separates "attempted and failed" from "never reached" — without it
+            the two are indistinguishable, since neither leaves a usage count.
+
+    Returns a dict merged into the quality report. ``llm_used`` is what tests and
+    the production probe assert on; ``llm_status`` says why.
+    """
+    counts = layer_usage_counts or {}
+    errors = layer_error_counts or {}
+    ran = counts.get("llm", 0) > 0
+
+    if ran:
+        status = LLMUsageStatus.USED
+    elif not getattr(config, "use_llm", False):
+        status = LLMUsageStatus.NOT_REQUESTED
+    elif not getattr(config, "llm_available", False):
+        # The entry point already decided why; reuse its word for it so the
+        # report and the logs agree.
+        status = getattr(config, "llm_unavailable_reason", None) or (
+            LLMUsageStatus.NOT_CONFIGURED
+        )
+    elif errors.get("llm", 0) > 0:
+        status = LLMUsageStatus.FAILED
+    else:
+        # Enabled, available, no attempt recorded: progressive enhancement met
+        # its confidence threshold before reaching it.
+        status = LLMUsageStatus.SKIPPED
+
+    return {
+        "llm_used": ran,
+        "llm_status": status,
+        "llm_provider": getattr(config, "llm_provider", None) if ran else None,
+    }
+
+
+def llm_usage_recommendation(summary: Dict[str, Any]) -> Optional[str]:
+    """A plain-language line for a run that had no LLM, or None.
+
+    Rendered by the existing quality banner without any frontend change. Silent
+    for deliberate choices — telling someone who passed ``no_llm`` that they got
+    no LLM is noise.
+    """
+    if summary.get("llm_used"):
+        return None
+    # _RECOMMENDATIONS omits NOT_REQUESTED and SKIPPED: telling someone who
+    # passed no_llm that they got no LLM is noise, and stopping early because
+    # confidence was already high is a success, not a degradation.
+    return _RECOMMENDATIONS.get(summary.get("llm_status"))

--- a/src/core/services/okh_service.py
+++ b/src/core/services/okh_service.py
@@ -992,6 +992,24 @@ class OKHService(BaseService["OKHService"]):
             # Convert to response format - use to_okh_manifest() to get full OKH structure
             manifest_dict = result.to_okh_manifest(include_field_confidence=verbose)
 
+            # Report whether the LLM actually contributed. Degradation to
+            # heuristic-only is otherwise invisible outside the logs, so a
+            # reviewer cannot tell a thin manifest from a missing provider.
+            from ..generation.quality import (
+                llm_usage_recommendation,
+                summarize_llm_usage,
+            )
+
+            metrics = engine.get_metrics()
+            llm_usage = summarize_llm_usage(
+                config, metrics.layer_usage_counts, metrics.error_counts
+            )
+            recommendations = list(result.quality_report.recommendations or [])
+            note = llm_usage_recommendation(llm_usage)
+            if note:
+                # Prepended: it explains the gaps the other recommendations list.
+                recommendations.insert(0, note)
+
             return {
                 "success": True,
                 "message": "Manifest generated successfully",
@@ -1000,7 +1018,8 @@ class OKHService(BaseService["OKHService"]):
                     "overall_quality": result.quality_report.overall_quality,
                     "required_fields_complete": result.quality_report.required_fields_complete,
                     "missing_required_fields": result.quality_report.missing_required_fields,
-                    "recommendations": result.quality_report.recommendations,
+                    "recommendations": recommendations,
+                    **llm_usage,
                 },
             }
 

--- a/tests/unit/test_llm_usage_reporting.py
+++ b/tests/unit/test_llm_usage_reporting.py
@@ -1,0 +1,180 @@
+"""A run must say whether an LLM contributed, and why not when it did not.
+
+Generation degrades to direct + heuristic + NLP whenever no LLM is usable, and
+that was invisible outside the logs — a reviewer could not tell a thin manifest
+from a missing provider. Declared availability is not proof either: a stored key
+can be expired, a named local model can be down. So this reports what HAPPENED.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.core.generation.models import LayerConfig
+from src.core.generation.quality import (
+    LLMUsageStatus,
+    llm_usage_recommendation,
+    summarize_llm_usage,
+)
+from src.core.llm.availability import LLMAvailability, LLMUnavailableReason
+
+pytestmark = pytest.mark.unit
+
+
+def _available(provider="anthropic"):
+    return LayerConfig.for_generate_from_url().with_llm_availability(
+        LLMAvailability(available=True, provider=provider)
+    )
+
+
+def _unavailable(reason):
+    return LayerConfig.for_generate_from_url().with_llm_availability(
+        LLMAvailability.unavailable(reason)
+    )
+
+
+# --- What actually happened --------------------------------------------------
+
+
+def test_a_run_that_used_the_llm_says_so_and_names_the_provider():
+    summary = summarize_llm_usage(_available("openai"), {"llm": 1}, {})
+
+    assert summary["llm_used"] is True
+    assert summary["llm_status"] == LLMUsageStatus.USED
+    assert summary["llm_provider"] == "openai"
+
+
+def test_no_provider_configured_is_reported_as_such():
+    summary = summarize_llm_usage(
+        _unavailable(LLMUnavailableReason.NOT_CONFIGURED), {"direct": 1}, {}
+    )
+
+    assert summary["llm_used"] is False
+    assert summary["llm_status"] == LLMUsageStatus.NOT_CONFIGURED
+
+
+def test_the_kill_switch_is_distinguished_from_a_missing_credential():
+    """'Disabled' and 'not configured' need different fixes."""
+    summary = summarize_llm_usage(
+        _unavailable(LLMUnavailableReason.DISABLED), {"direct": 1}, {}
+    )
+
+    assert summary["llm_status"] == LLMUsageStatus.DISABLED
+
+
+def test_opting_out_is_not_reported_as_a_problem():
+    summary = summarize_llm_usage(
+        LayerConfig.for_generate_from_url(no_llm=True), {"direct": 1}, {}
+    )
+
+    assert summary["llm_status"] == LLMUsageStatus.NOT_REQUESTED
+
+
+def test_a_configured_provider_that_failed_is_distinguished_from_one_never_reached():
+    """Neither leaves a usage count, so the engine's error count separates them.
+
+    A stored key can be expired and a local model can be down; reporting that as
+    'not configured' would send someone to fix the wrong thing.
+    """
+    failed = summarize_llm_usage(_available(), {"direct": 1}, {"llm": 1})
+    skipped = summarize_llm_usage(_available(), {"direct": 1}, {})
+
+    assert failed["llm_status"] == LLMUsageStatus.FAILED
+    assert skipped["llm_status"] == LLMUsageStatus.SKIPPED
+    assert failed["llm_used"] is False and skipped["llm_used"] is False
+
+
+def test_the_provider_is_not_claimed_for_a_run_that_did_not_use_it():
+    summary = summarize_llm_usage(_available("anthropic"), {"direct": 1}, {"llm": 1})
+
+    assert summary["llm_provider"] is None
+
+
+# --- What the reviewer sees --------------------------------------------------
+
+
+def test_a_degraded_run_explains_itself_in_plain_language():
+    summary = summarize_llm_usage(
+        _unavailable(LLMUnavailableReason.NOT_CONFIGURED), {"direct": 1}, {}
+    )
+    note = llm_usage_recommendation(summary)
+
+    assert note is not None
+    assert "without an LLM" in note
+    assert "function" in note  # the field this actually costs the user
+
+
+def test_a_failed_provider_is_told_to_check_the_credential_not_to_add_one():
+    note = llm_usage_recommendation(
+        summarize_llm_usage(_available(), {"direct": 1}, {"llm": 1})
+    )
+
+    assert note is not None and "could not be reached" in note
+
+
+def test_a_successful_run_says_nothing():
+    assert (
+        llm_usage_recommendation(summarize_llm_usage(_available(), {"llm": 1}, {}))
+        is None
+    )
+
+
+def test_deliberate_choices_are_not_nagged_about():
+    """Telling someone who passed no_llm that they got no LLM is noise; so is
+    reporting progressive enhancement stopping early, which is a success."""
+    opted_out = summarize_llm_usage(
+        LayerConfig.for_generate_from_url(no_llm=True), {"direct": 1}, {}
+    )
+    stopped_early = summarize_llm_usage(_available(), {"direct": 1}, {})
+
+    assert llm_usage_recommendation(opted_out) is None
+    assert llm_usage_recommendation(stopped_early) is None
+
+
+def test_the_kill_switch_gets_its_own_explanation():
+    note = llm_usage_recommendation(
+        summarize_llm_usage(
+            _unavailable(LLMUnavailableReason.DISABLED), {"direct": 1}, {}
+        )
+    )
+
+    assert note is not None and "LLM_ENABLED" in note
+
+
+# --- The engine supplies the evidence ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_engine_records_a_layer_that_raised():
+    """Without this evidence, 'failed' and 'skipped' are indistinguishable.
+
+    Exercises the real loop with a matcher that raises, rather than asserting
+    the recording code merely exists.
+    """
+    from unittest.mock import AsyncMock
+
+    from src.core.generation.engine import GenerationEngine
+    from src.core.generation.models import GenerationLayer
+
+    engine = GenerationEngine(config=_available())
+    exploding = AsyncMock(side_effect=RuntimeError("provider unreachable"))
+    engine._matchers = {GenerationLayer.LLM: AsyncMock(process=exploding)}
+
+    await engine._progressive_enhancement_async(object(), {}, {}, [])
+
+    metrics = engine.get_metrics()
+    assert metrics.error_counts.get("llm") == 1
+    assert metrics.layer_usage_counts.get("llm", 0) == 0
+
+    # And that evidence produces the FAILED status rather than SKIPPED.
+    summary = summarize_llm_usage(
+        _available(), metrics.layer_usage_counts, metrics.error_counts
+    )
+    assert summary["llm_status"] == LLMUsageStatus.FAILED


### PR DESCRIPTION
Closes #315. **Stacked on #324** (`feat/llm-availability-resolution`) — merge that first; this branch contains its commit.

Generation degrades to direct + heuristic + NLP whenever no LLM is usable, and that was invisible outside the logs. A reviewer could not tell whether a thin manifest reflected a thin repository or a missing provider.

Declared availability is not proof either: a stored key can be expired, a named local model can be down. So this reports **what happened**, not what was configured.

## What a run now says

The quality report carries `llm_used`, `llm_status` and the provider. A degraded run also gets a plain-language recommendation — and because the existing banner renders recommendations verbatim, that reaches the reviewer with **no frontend change**.

Status separates the cases that need *different fixes*:

| Status | What it means | What to do |
|---|---|---|
| `used` | the LLM contributed | — |
| `not_configured` | no credential for any provider | add one in Settings |
| `disabled` | `LLM_ENABLED=false` | flip the kill switch |
| `failed` | configured, but the provider could not be reached | check the credential is valid |
| `skipped` | confidence was met before it ran | nothing — this is a success |
| `not_requested` | the caller passed `no_llm` | nothing |

Reporting a failed credential as "not configured" would send someone to fix the wrong thing, so the distinction is load-bearing rather than cosmetic.

Deliberate outcomes stay **silent**: telling someone who passed `no_llm` that they got no LLM is noise, and progressive enhancement stopping early is a success, not a degradation.

## One thing I had to build to make this honest

Telling *failed* from *never reached* needed evidence that did not exist — neither leaves a usage count. The engine caught layer exceptions and logged them, but recorded nothing. It now populates the per-layer error counts in the metrics object it already had.

That is covered by a test which runs the **real** loop with a matcher that raises. My first draft asserted the recording code existed in the module source, which would have passed on a comment; it is replaced.

## Release protection

The production probe gained `expect_llm`. Set it once a provider is configured, and a node that silently drops to heuristic-only **fails the release** rather than quietly producing worse manifests. It ships `false`, since production has no credential yet.

## Note

`function` will keep coming back empty in production until someone stores a credential — this PR makes that state *legible*, it does not change it. The banner will now say so in as many words.

`make ready` green; 1233 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
