### PR TITLE
Declare the LLM provider on the config surface, and make ollama usable

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -1240,6 +1240,8 @@ Total Python files: 618
 │       │   ├── availability.py
 │       │   │       class LLMUnavailableReason
 │       │   │       class LLMAvailability (unavailable)
+│       │   │       def _configured_ollama_url()
+│       │   │       def _ollama_base_url()
 │       │   │       def _env_key()
 │       │   ├── chunking.py
 │       │   │       class TokenEstimator (__call__)
@@ -1277,7 +1279,6 @@ Total Python files: 618
 │       │   │       class LLMProviderSelector (__init__, select_provider, invalidate_availability_cache...)
 │       │   │       def get_provider_selector()
 │       │   │       def default_model_for()
-│       │   │       def select_llm_provider()
 │       │   ├── providers/
 │       │   │   ├── __init__.py
 │       │   │   ├── anthropic.py
@@ -8467,7 +8468,7 @@ T...
 
 This module provides an LLM provider ...
 
-**Exports:** ProviderSelectionStrategy, LLMProviderSelector, get_provider_selector, default_model_for, select_llm_provider
+**Exports:** ProviderSelectionStrategy, LLMProviderSelector, get_provider_selector, default_model_for
 
 **Classes:**
 - `ProviderSelectionStrategy` (inherits: Enum)
@@ -8484,11 +8485,6 @@ Selection pri...
 - `default_model_for(provider_name)`
   - Return the default model for a provider name string.
 Centralized helper to avoid...
-- `select_llm_provider(cli_provider, cli_model, verbose)`
-  - Select the best available LLM provider.
-
-Args:
-    cli_provider: Provider specif...
 
 ### `src/core/llm/providers/__init__.py`
 > LLM Provider implementations for the Open Hardware Manager.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The LLM provider is declared on the config surface, and ollama is usable.**
+  `LLM_DEFAULT_PROVIDER` is now a schema setting, deployable per environment like
+  everything else. An explicit choice is tried **alone** — falling back would
+  silently serve a provider nobody asked for. Unset, a documented preference
+  order applies and the winner is logged. Ollama needs no credential, so naming
+  it (or setting `OLLAMA_BASE_URL`) is the opt-in; it joins auto-selection only
+  when that URL is set, and is never inferred from its client's localhost
+  default, which every node would otherwise appear to satisfy. Its hand-written
+  duplicate in `env.template` is gone — a later assignment there would have
+  silently overridden the schema-owned one.
+
+
 - **`make secrets-check`** confirms the API and worker container apps agree on
   every secret they share — storage key, both git tokens, and all three Redis
   URLs — by comparing digests, never values. The deploys mirror these on every

--- a/env.template
+++ b/env.template
@@ -48,6 +48,9 @@ GENERATE_FROM_URL_MAX_QUEUED=20
 # Per-IP rate limit for generate-from-url job submission.
 GENERATE_FROM_URL_RATE_LIMIT_PER_MINUTE=10
 
+# Which LLM provider generation should use: anthropic | openai | azure_openai | local (ollama). Unset means auto-select the one that is configured; with several configured, a documented preference order applies and the choice is logged. Naming 'local' is also how you opt into ollama, which has no credential to detect.
+# LLM_DEFAULT_PROVIDER=
+
 # Master switch for LLM use. A kill switch, not an enable switch: configuring a provider credential is what turns the LLM on, and this turns it off without deleting credentials (e.g. during a cost spike). False means no LLM regardless of stored keys.
 LLM_ENABLED=True
 
@@ -175,9 +178,10 @@ GOOGLE_CLOUD_STORAGE_BUCKET=your-gcs-bucket
 # credential (here, or via Settings → LLM providers) is what turns the LLM on.
 # Do not re-declare it here; a later assignment would silently override it.
 
-# LLM Provider: openai, anthropic, google, azure, local
-LLM_DEFAULT_PROVIDER=anthropic  # Used in code
-LLM_PROVIDER=anthropic  # Alternative name
+# LLM_DEFAULT_PROVIDER is schema-owned — see the generated block above. Leave it
+# unset to auto-select whichever provider is configured; set it to pick between
+# several, or to `local` to opt into ollama (which has no credential to detect).
+# Do not re-declare it here; a later assignment would silently override it.
 LLM_DEFAULT_MODEL=claude-3-sonnet-20240229  # Used in code
 LLM_MODEL=claude-3-sonnet-20240229  # Alternative name
 

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -233,6 +233,16 @@ class Settings(BaseSettings):
         default=10,
         description="Per-IP rate limit for generate-from-url job submission.",
     )
+    llm_default_provider: Optional[str] = Field(
+        default=None,
+        description=(
+            "Which LLM provider generation should use: anthropic | openai | "
+            "azure_openai | local (ollama). Unset means auto-select the one "
+            "that is configured; with several configured, a documented "
+            "preference order applies and the choice is logged. Naming 'local' "
+            "is also how you opt into ollama, which has no credential to detect."
+        ),
+    )
     llm_enabled: bool = Field(
         default=True,
         description=(

--- a/src/core/llm/availability.py
+++ b/src/core/llm/availability.py
@@ -29,11 +29,17 @@ from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 
-# Tried in order when nothing is explicitly configured. Deliberately excludes
-# LOCAL/ollama: it needs a base URL rather than a key and defaults to
-# localhost, so presence-based detection would make every node believe a local
-# model is available. Opting into it explicitly is #314.
+# Tried in order when no provider is named. Deliberately excludes LOCAL/ollama:
+# it has no credential to detect and its client falls back to localhost, so
+# including it here would make every node believe a local model is available.
+# Ollama is opt-in only — see OLLAMA_BASE_URL below.
 PROVIDER_PREFERENCE: List[str] = ["anthropic", "openai", "azure_openai"]
+
+# Ollama authenticates with nothing, so "is a key present" cannot answer whether
+# it is usable. It counts only when explicitly named as the default provider, or
+# when its base URL is set — never inferred from the client's localhost default.
+OLLAMA_PROVIDER = "local"
+OLLAMA_BASE_URL_ENV = "OLLAMA_BASE_URL"
 
 # Environment variable holding each provider's key, checked when the credential
 # store has nothing. Keeps the local `.env` workflow working unchanged.
@@ -84,12 +90,29 @@ async def _stored_key(provider: str) -> Optional[str]:
         return None
 
 
+def _configured_ollama_url() -> Optional[str]:
+    """An explicitly configured ollama endpoint, or None."""
+    value = os.getenv(OLLAMA_BASE_URL_ENV, "").strip()
+    return value or None
+
+
+def _ollama_base_url(*, explicitly_chosen: bool) -> Optional[str]:
+    """Where ollama is, or None if it was not opted into.
+
+    Two ways in, both deliberate: setting the base URL, or naming ollama as the
+    provider (which falls back to its client's localhost default). Never
+    inferred from that default alone — a node that merely has the library
+    installed would otherwise claim a local model it does not have.
+    """
+    return _configured_ollama_url() or (
+        "http://localhost:11434" if explicitly_chosen else None
+    )
+
+
 def _env_key(provider: str) -> Optional[str]:
     name = PROVIDER_ENV_KEYS.get(provider)
-    if not name:
-        return None
-    value = os.getenv(name)
-    return value.strip() if value and value.strip() else None
+    value = os.getenv(name, "").strip() if name else ""
+    return value or None
 
 
 async def resolve_llm_availability(
@@ -113,15 +136,34 @@ async def resolve_llm_availability(
 
     from src.config.schema import get_settings
 
-    if not get_settings().llm_enabled:
+    settings = get_settings()
+    if not settings.llm_enabled:
         logger.info("LLM disabled by configuration (LLM_ENABLED=false)")
         return LLMAvailability.unavailable(LLMUnavailableReason.DISABLED)
 
-    candidates = [preferred_provider] if preferred_provider else PROVIDER_PREFERENCE
+    chosen = preferred_provider or settings.llm_default_provider
+    if chosen:
+        # An explicit choice is tried ALONE. Falling back would silently serve a
+        # different provider than the one asked for, which is worse than failing.
+        candidates = [chosen]
+    else:
+        # Ollama joins auto-selection only when its base URL is set, which is a
+        # deliberate act. It is never reached via its client's localhost
+        # default, which every node would otherwise appear to satisfy.
+        candidates = list(PROVIDER_PREFERENCE)
+        if _configured_ollama_url():
+            candidates.append(OLLAMA_PROVIDER)
 
     for provider in candidates:
-        if not provider:
+        if provider == OLLAMA_PROVIDER:
+            base_url = _ollama_base_url(explicitly_chosen=bool(chosen))
+            if base_url:
+                logger.info("LLM available: ollama at %s", base_url)
+                return LLMAvailability(
+                    available=True, provider=provider, source="ollama"
+                )
             continue
+
         if await _stored_key(provider):
             logger.info("LLM available: %s (stored credential)", provider)
             return LLMAvailability(
@@ -135,6 +177,6 @@ async def resolve_llm_availability(
 
     logger.info(
         "No LLM provider configured (tried: %s); generation will run without one",
-        ", ".join(p for p in candidates if p),
+        ", ".join(candidates),
     )
     return LLMAvailability.unavailable(LLMUnavailableReason.NOT_CONFIGURED)

--- a/src/core/llm/provider_selection.py
+++ b/src/core/llm/provider_selection.py
@@ -325,15 +325,15 @@ class LLMProviderSelector:
                 except:
                     return False
 
-            # Run the async check
             loop = asyncio.get_event_loop()
             if loop.is_running():
-                # If we're already in an async context, we can't use asyncio.run
-                # For now, assume Ollama is available if we can't check
-                return True
-            else:
-                return asyncio.run(check_ollama())
-        except:
+                # Cannot block on the probe from inside a running loop. Report
+                # unavailable rather than assuming: claiming a local model that
+                # is not there sends every request to a dead endpoint.
+                logger.debug("Cannot probe Ollama from a running event loop")
+                return False
+            return asyncio.run(check_ollama())
+        except Exception:
             return False
 
     def _auto_detect_best_provider(
@@ -458,27 +458,6 @@ def default_model_for(provider_name: Optional[str]) -> Optional[str]:
         return None
     selector = get_provider_selector()
     return selector.DEFAULT_MODELS.get(provider_type)
-
-
-def select_llm_provider(
-    cli_provider: Optional[str] = None,
-    cli_model: Optional[str] = None,
-    verbose: bool = True,
-) -> Dict[str, Any]:
-    """
-    Select the best available LLM provider.
-
-    Args:
-        cli_provider: Provider specified via command line flag
-        cli_model: Model specified via command line flag
-        verbose: Whether to log selection details
-
-    Returns:
-        Selection result dictionary
-    """
-    return get_provider_selector().select_provider(
-        cli_provider=cli_provider, cli_model=cli_model, verbose=verbose
-    )
 
 
 async def create_llm_service_with_selection(

--- a/tests/unit/test_llm_availability.py
+++ b/tests/unit/test_llm_availability.py
@@ -36,7 +36,12 @@ pytestmark = pytest.mark.unit
 @pytest.fixture(autouse=True)
 def _no_ambient_keys(monkeypatch):
     """Tests must not depend on the developer's real .env."""
+    # LLM_DEFAULT_PROVIDER especially: a developer's .env commonly sets it, and
+    # an explicit choice is tried ALONE, so leaving it set would silently change
+    # what every test in this file is exercising.
     for name in (
+        "LLM_DEFAULT_PROVIDER",
+        "OLLAMA_BASE_URL",
         "ANTHROPIC_API_KEY",
         "OPENAI_API_KEY",
         "AZURE_OPENAI_API_KEY",
@@ -250,3 +255,113 @@ def test_the_gate_and_the_enabled_layer_stack_agree():
 
     assert unavailable.is_llm_configured() is False
     assert GenerationLayer.LLM not in unavailable.get_enabled_layers()
+
+
+# --- Declaring the provider on the config surface ----------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_configured_default_provider_wins_over_preference_order(monkeypatch):
+    monkeypatch.setenv("LLM_DEFAULT_PROVIDER", "openai")
+
+    with _stored({"anthropic": "sk-anthropic", "openai": "sk-openai"}):
+        availability = await resolve_llm_availability()
+
+    assert availability.provider == "openai"
+
+
+@pytest.mark.asyncio
+async def test_a_configured_default_is_tried_alone(monkeypatch):
+    """Falling back would silently serve a provider the operator did not choose."""
+    monkeypatch.setenv("LLM_DEFAULT_PROVIDER", "openai")
+
+    with _stored({"anthropic": "sk-anthropic"}):
+        availability = await resolve_llm_availability()
+
+    assert availability.available is False
+    assert availability.reason == LLMUnavailableReason.NOT_CONFIGURED
+
+
+@pytest.mark.asyncio
+async def test_a_call_site_choice_beats_the_configured_default(monkeypatch):
+    """`ohm llm --provider ...` must win over the deployment's default."""
+    monkeypatch.setenv("LLM_DEFAULT_PROVIDER", "anthropic")
+
+    with _stored({"openai": "sk-openai"}):
+        availability = await resolve_llm_availability(preferred_provider="openai")
+
+    assert availability.provider == "openai"
+
+
+# --- Ollama is opt-in, never assumed -----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ollama_is_usable_when_named_as_the_default(monkeypatch):
+    """It has no credential to detect, so naming it IS the opt-in."""
+    monkeypatch.setenv("LLM_DEFAULT_PROVIDER", "local")
+
+    with _nothing_stored():
+        availability = await resolve_llm_availability()
+
+    assert availability.available is True
+    assert availability.provider == "local"
+    assert availability.source == "ollama"
+
+
+@pytest.mark.asyncio
+async def test_ollama_is_usable_when_its_base_url_is_set(monkeypatch):
+    monkeypatch.setenv("LLM_DEFAULT_PROVIDER", "local")
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://gpu-box.local:11434")
+
+    with _nothing_stored():
+        availability = await resolve_llm_availability()
+
+    assert availability.available is True
+
+
+@pytest.mark.asyncio
+async def test_ollama_needs_no_api_key(monkeypatch):
+    """The whole point of the local path: run a model with no cloud key anywhere."""
+    monkeypatch.setenv("LLM_DEFAULT_PROVIDER", "local")
+
+    with _nothing_stored():
+        availability = await resolve_llm_availability()
+
+    assert availability.available is True
+
+
+@pytest.mark.asyncio
+async def test_ollama_is_never_reached_by_preference_order():
+    """Its client falls back to localhost, so auto-selecting it would make every
+    node claim a local model and send every request to a dead endpoint."""
+    with _nothing_stored():
+        availability = await resolve_llm_availability()
+
+    assert availability.available is False
+    assert availability.reason == LLMUnavailableReason.NOT_CONFIGURED
+
+
+@pytest.mark.asyncio
+async def test_setting_the_base_url_alone_opts_you_in(monkeypatch):
+    """Setting it is itself a deliberate act, so it counts as opting in — but
+    only the SET value ever does; the client's localhost default never has."""
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://gpu-box.local:11434")
+
+    with _nothing_stored():
+        availability = await resolve_llm_availability()
+
+    assert availability.available is True
+    assert availability.provider == "local"
+
+
+@pytest.mark.asyncio
+async def test_a_cloud_credential_still_wins_over_an_available_ollama(monkeypatch):
+    """Ollama joins the end of preference order, so it is the fallback, not the
+    default — a node with both keeps using its configured cloud provider."""
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://gpu-box.local:11434")
+
+    with _stored({"anthropic": "sk-anthropic"}):
+        availability = await resolve_llm_availability()
+
+    assert availability.provider == "anthropic"


### PR DESCRIPTION
Closes #314. Completes the BYO-provider story: a self-hoster can run a local model with no cloud key anywhere, configured the same way locally and remotely.

## Provider choice moves onto the config surface

`LLM_DEFAULT_PROVIDER` becomes a schema setting, deployable per environment like the storage target or the cache backend. It was previously read by a legacy config path that generation ignored entirely.

- An **explicit choice is tried alone.** Falling back would silently serve a provider nobody asked for — worse than failing.
- **Unset**, a documented preference order applies and the winner is **logged**, so the decision is never invisible.

## Ollama, without pretending

Ollama authenticates with nothing, so "is a key present" cannot answer whether it is usable. Naming it is the opt-in; setting `OLLAMA_BASE_URL` also counts, since that is a deliberate act. It is **never** inferred from its client's localhost default, which every node appears to satisfy. It sits at the **end** of preference order, so a node with both a cloud key and a local model keeps using the cloud one.

## Two defects found while implementing

**The old selector's ollama probe returned `True` when it could not check** — the comment says *"assume Ollama is available if we can't check"* — and it cannot check from inside a running event loop, which is exactly where generation runs. The admin provider listing therefore claimed a local model on every node. Now fails closed.

**`env.template` had a second `LLM_DEFAULT_PROVIDER`**, hand-written *after* the schema-owned one. In a `.env` the later assignment wins, so it would have silently overridden the schema default. Same trap as `LLM_ENABLED` in #313; removed with a comment saying why it must not come back.

## Correcting the issue's premise

`LLMProviderSelector` is **not dead**. `select_provider` is reachable from `ohm llm` via `create_llm_service_with_selection`. Only the module-level `select_llm_provider` wrapper had zero callers; that is deleted.

That leaves two provider-selection mechanisms — the new resolver for generation, the old selector for the CLI. Unifying them is a real refactor, so it is **filed separately** rather than smuggled in here.

## Written with a backward pass

The backward pass caught more than style. `_ollama_base_url`'s `explicitly_chosen` parameter was always `True`, and chasing *why* revealed the implementation was **stricter than the locked decision**: a set base URL alone did not opt you in. A test asserted that wrong behaviour — green, and confirming the implementation rather than the requirement. Both corrected.

Also removed: a dead guard (`if not provider` — every candidate is a non-empty literal by construction), the matching impossible-empty filter in the log line, and 21 lines of uncalled wrapper.

`make ready` green; 1230 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
