### PR TITLE
Back Container App secrets with Key Vault references (code half)

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 619
+Total Python files: 622
 
 ├── deploy/
 │   ├── __init__.py
@@ -40,6 +40,13 @@ Total Python files: 619
 │   │   │   │       class DeploymentError
 │   │   │   │       class AzureContainerAppsDeployer (__init__, _run_az_command, _convert_memory_to_gb...)
 │   │   │   │       def _redact_secret_args()
+│   │   │   ├── key_vault.py
+│   │   │   │       class SecretNameTooLongError
+│   │   │   │       def secret_uri()
+│   │   │   │       def key_vault_reference()
+│   │   │   │       def secret_refs_for()
+│   │   │   │       def container_app_secrets()
+│   │   │   │       def secret_env_vars()
 │   │   │   └── redis_secrets.py
 │   │   │           class RedisConfigError
 │   │   │           def _redis_url()
@@ -60,6 +67,9 @@ Total Python files: 619
 │       ├── deploy_azure_worker.py
 │       │       def main()
 │       ├── deploy_gcp.py
+│       │       def main()
+│       ├── migrate_secrets_to_key_vault.py
+│       │       def _run()
 │       │       def main()
 │       ├── teardown_azure_environment.py
 │       │       def _run()
@@ -2667,6 +2677,18 @@ Total Python files: 619
         │       class _Result
         │       def _manifest_with_components()
         ├── test_inline_okw_facilities.py
+        ├── test_key_vault_secrets.py
+        │       def test_every_secret_name_fits_the_platform_limit()
+        │       def test_a_too_long_name_fails_loudly_and_says_which()
+        │       def test_the_renamed_secret_kept_its_environment_variable()
+        │       def test_a_reference_names_the_vault_the_secret_and_the_identity()
+        │       def test_the_uri_points_at_the_secret_not_a_version()
+        │       def test_container_app_secrets_carry_pointers_never_values()
+        │       def test_env_vars_carry_pointers_never_values()
+        │       def test_the_worker_does_not_get_the_api_keys()
+        │       def test_the_worker_gets_the_secrets_it_actually_needs()
+        │       def test_both_apps_reference_the_same_secret_for_a_shared_value()
+        │       def test_key_vault_names_are_valid()
         ├── test_layer_cascade.py
         ├── test_llm_availability.py
         │       def _no_ambient_keys()
@@ -3182,7 +3204,7 @@ Total Python files: 619
 
 ## Overview
 
-Total files analyzed: 619
+Total files analyzed: 622
 
 ## Entry Points
 
@@ -5998,6 +6020,35 @@ This module provides the Azure Container Apps deplo...
   - Methods: fetch_redis_access_key, read_secret, set_secrets, setup, deploy
   - Azure Container Apps deployer implementation....
 
+### `deploy/providers/azure/key_vault.py`
+> Container App secrets backed by Key Vault, resolved via managed identity.
+
+Container App secrets are...
+
+**Exports:** SecretNameTooLongError, secret_uri, key_vault_reference, secret_refs_for, container_app_secrets
+
+**Classes:**
+- `SecretNameTooLongError` (inherits: ValueError)
+  - Raised when a secret name cannot carry a Key Vault reference....
+
+**Functions:**
+- `secret_uri(vault_name, secret_name)`
+  - The Key Vault URI a Container App secret points at....
+- `key_vault_reference(vault_name, secret_name)`
+  - The ``keyvaultref:`` value for one secret, resolved by system identity.
+
+Raises:...
+- `secret_refs_for()`
+  - Env var -> Key Vault secret name for one app's share of the secrets....
+- `container_app_secrets(vault_name)`
+  - Secret name -> ``keyvaultref:`` value, for ``az containerapp secret set``.
+
+Carr...
+- `secret_env_vars()`
+  - Env var -> ``secretref:`` pointer, unchanged in shape from before.
+
+The applicat...
+
 ### `deploy/providers/azure/redis_secrets.py`
 > Mint Redis connection URLs as Azure Container App secrets.
 
@@ -6072,6 +6123,16 @@ This script uses the GCP deployer to deploy the service...
 **Functions:**
 - `main()`
   - Deploy to GCP Cloud Run....
+
+### `deploy/scripts/migrate_secrets_to_key_vault.py`
+> Move an environment's Container App secrets into Key Vault, once.
+
+Container App secrets are per-app...
+
+**Exports:** main
+
+**Functions:**
+- `main()`
 
 ### `deploy/scripts/teardown_azure_environment.py`
 > Delete a non-production environment's Container Apps (and optionally its blobs).
@@ -11054,6 +11115,26 @@ Verifies that:
 > Regression: match API must honor MatchRequest.okw_facilities (avoid blocking storage list)....
 
 **Internal Dependencies:** 9 imports
+
+### `tests/unit/test_key_vault_secrets.py`
+> Container App secrets backed by Key Vault rather than duplicated per app.
+
+The properties worth pinn...
+
+**Exports:** test_every_secret_name_fits_the_platform_limit, test_a_too_long_name_fails_loudly_and_says_which, test_the_renamed_secret_kept_its_environment_variable, test_a_reference_names_the_vault_the_secret_and_the_identity, test_the_uri_points_at_the_secret_not_a_version
+
+**Functions:**
+- `test_every_secret_name_fits_the_platform_limit()`
+  - A Key Vault reference is rejected above 20 characters.
+
+`llm-encryption-password...
+- `test_a_too_long_name_fails_loudly_and_says_which()`
+- `test_the_renamed_secret_kept_its_environment_variable()`
+  - Only the secret's NAME moved. The application reads the same env var, so
+it cann...
+- `test_a_reference_names_the_vault_the_secret_and_the_identity()`
+- `test_the_uri_points_at_the_secret_not_a_version()`
+  - Pinning a version would freeze rotation, defeating the point....
 
 ### `tests/unit/test_layer_cascade.py`
 > Unit tests for evaluate_layers and evaluate_layers_supply_tree....

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Container App secrets can be backed by Key Vault.** Each shared value lives
+  once in a vault; both apps hold a reference resolved through their
+  system-assigned managed identity, so rotation is one edit rather than an edit
+  plus a redeploy of everything downstream.
+  `deploy/scripts/migrate_secrets_to_key_vault.py` performs the migration in the
+  order that keeps apps startable — identities and access first, values second,
+  repointing last — and is idempotent, dry-runnable, and rehearsed on staging
+  before production. Two platform facts it encodes: a secret name carrying a
+  Key Vault reference cannot exceed 20 characters (so
+  `llm-encryption-password` becomes `llm-encrypt-password`, env var unchanged),
+  and an RBAC-authorised vault grants subscription Owners **no** data-plane
+  access, so the operator is granted Secrets Officer before any write.
+
+
+### Added
+
 - **Runs report whether the LLM actually contributed.** The quality report now
   carries `llm_used`, `llm_status` and the provider, and a degraded run adds a
   plain-language recommendation explaining why — rendered by the existing banner

--- a/deploy/providers/azure/key_vault.py
+++ b/deploy/providers/azure/key_vault.py
@@ -1,0 +1,110 @@
+"""Container App secrets backed by Key Vault, resolved via managed identity.
+
+Container App secrets are per-app, so every value two apps share exists twice.
+The deploys mirror them so the copies cannot drift, but the API app is still the
+origin: rotating a credential means editing it there and redeploying everything
+downstream.
+
+A Key Vault reference removes the copies entirely. Each secret exists once; both
+apps hold a *pointer* to it, resolved at runtime through their managed identity.
+Rotation becomes one edit with no deploy, and the mirroring — plus the drift
+check that watched it — can retire.
+
+Two constraints the platform imposes, both learned from its CLI rather than
+assumed:
+
+* A secret name carrying a Key Vault reference **cannot exceed 20 characters**.
+  ``llm-encryption-password`` is 23, hence the rename recorded below.
+* The reference is ``keyvaultref:<secret-uri>,identityref:<system|resource-id>``
+  and the identity must already hold read access, or the app cannot start.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+# Longest permitted Container App secret name when it holds a Key Vault
+# reference. Enforced by the platform; a longer name is rejected at deploy time.
+MAX_SECRET_NAME_LENGTH = 20
+
+# Env var -> Key Vault secret name. These are the values both apps need, each
+# stored once. Key Vault secret names allow only alphanumerics and dashes.
+#
+# NB two names carry history:
+#   * `gihub-token` is missing a 't' — the real name of the live secret. It is
+#     renamed by a separate change, deliberately not bundled here.
+#   * `llm-encrypt-password` was `llm-encryption-password` (23 chars), which
+#     exceeds the limit above. The ENV VAR name is unchanged; only the secret's
+#     name moves, so nothing in the application sees a difference.
+KEY_VAULT_SECRET_REFS: Dict[str, str] = {
+    "AZURE_STORAGE_KEY": "azure-storage-key",
+    "GITHUB_ACCESS_TOKEN": "gihub-token",
+    "GITLAB_ACCESS_TOKEN": "gitlab-token",
+    "LLM_ENCRYPTION_SALT": "llm-encryption-salt",
+    "LLM_ENCRYPTION_PASSWORD": "llm-encrypt-password",
+    "API_KEYS": "api-key",
+    "CACHE_REDIS_URL": "cache-redis-url",
+    "JOB_BROKER_URL": "job-broker-url",
+    "JOB_RESULT_BACKEND": "job-result-backend",
+}
+
+# The worker authenticates no callers, so it has no use for the API keys.
+WORKER_EXCLUDED_SECRETS = {"API_KEYS"}
+
+
+class SecretNameTooLongError(ValueError):
+    """Raised when a secret name cannot carry a Key Vault reference."""
+
+
+def secret_uri(vault_name: str, secret_name: str) -> str:
+    """The Key Vault URI a Container App secret points at."""
+    return f"https://{vault_name}.vault.azure.net/secrets/{secret_name}"
+
+
+def key_vault_reference(vault_name: str, secret_name: str) -> str:
+    """The ``keyvaultref:`` value for one secret, resolved by system identity.
+
+    Raises:
+        SecretNameTooLongError: if the name exceeds the platform limit. Failing
+            here beats failing at deploy time with a platform error that does
+            not say which name was at fault.
+    """
+    if len(secret_name) > MAX_SECRET_NAME_LENGTH:
+        raise SecretNameTooLongError(
+            f"Container App secret name {secret_name!r} is "
+            f"{len(secret_name)} characters; Key Vault references allow at most "
+            f"{MAX_SECRET_NAME_LENGTH}. Rename it in KEY_VAULT_SECRET_REFS."
+        )
+    return f"keyvaultref:{secret_uri(vault_name, secret_name)},identityref:system"
+
+
+def secret_refs_for(*, worker: bool = False) -> Dict[str, str]:
+    """Env var -> Key Vault secret name for one app's share of the secrets."""
+    return {
+        env_var: name
+        for env_var, name in KEY_VAULT_SECRET_REFS.items()
+        if not (worker and env_var in WORKER_EXCLUDED_SECRETS)
+    }
+
+
+def container_app_secrets(vault_name: str, *, worker: bool = False) -> Dict[str, str]:
+    """Secret name -> ``keyvaultref:`` value, for ``az containerapp secret set``.
+
+    Carries no secret values: every entry is a pointer, so this is safe to log.
+    """
+    return {
+        name: key_vault_reference(vault_name, name)
+        for name in secret_refs_for(worker=worker).values()
+    }
+
+
+def secret_env_vars(*, worker: bool = False) -> Dict[str, str]:
+    """Env var -> ``secretref:`` pointer, unchanged in shape from before.
+
+    The application sees no difference: it still reads an env var backed by a
+    Container App secret. Only where that secret's *value* comes from changed.
+    """
+    return {
+        env_var: f"secretref:{name}"
+        for env_var, name in secret_refs_for(worker=worker).items()
+    }

--- a/deploy/scripts/migrate_secrets_to_key_vault.py
+++ b/deploy/scripts/migrate_secrets_to_key_vault.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Move an environment's Container App secrets into Key Vault, once.
+
+Container App secrets are per-app, so every shared value exists twice. This
+replaces the copies with references: the value lives once in Key Vault, and both
+apps hold a pointer resolved at runtime through their managed identity. Rotation
+then means one edit and no deploy.
+
+**The order matters, because an app that cannot resolve a secret does not
+start.** Each step is safe to stop after:
+
+1. Create the vault (idempotent).
+2. Enable a system-assigned identity on each app.
+3. Grant each identity read access, and the deploy principal write access.
+4. Copy the current values from the apps into the vault.
+5. Repoint each app's secrets at the vault.
+6. Verify the apps still run.
+
+The original inline secrets are **left in place** — a Container App secret is
+replaced by name, so repointing overwrites them anyway, and anything this script
+does not touch stays untouched. Removing leftovers is a separate, later step
+once the references have been trusted for a while.
+
+Run with --dry-run first. Rehearse on staging before production: an app that
+fails to resolve a secret fails to start, and that is a live outage in prod.
+
+Usage:
+    uv run python deploy/scripts/migrate_secrets_to_key_vault.py \\
+        --environment staging --vault-name ohm-staging-kv \\
+        --container-app-name openhardwaremanager-staging \\
+        --worker-app-name openhardwaremanager-stg-worker --dry-run
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from deploy.providers.azure.key_vault import (  # noqa: E402
+    container_app_secrets,
+    secret_env_vars,
+    secret_refs_for,
+)
+
+# Where each Key Vault secret's current value comes from: the API app holds the
+# authoritative copy today, so it is the source for every one of them.
+SOURCE_APP_ROLE = "api"
+
+
+def _run(command: list[str], *, dry_run: bool = False, redact: bool = False) -> str:
+    """Run an az command, returning stdout. Never echoes a secret value."""
+    shown = command if not redact else [*command[:6], "…(values redacted)"]
+    if dry_run:
+        print(f"   would run: {' '.join(shown)}")
+        return ""
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(f"{' '.join(shown)}\n{result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Migrate app secrets into Key Vault")
+    parser.add_argument("--environment", required=True)
+    parser.add_argument("--vault-name", required=True)
+    parser.add_argument("--resource-group", default="project_data_rg")
+    parser.add_argument("--container-app-name", required=True, help="the API app")
+    parser.add_argument("--worker-app-name", required=True)
+    parser.add_argument("--location", default="westus3")
+    parser.add_argument(
+        "--deploy-principal-id",
+        default=None,
+        help="Object id of the CI principal that mints Redis URLs; granted write access",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    api, worker, vault = args.container_app_name, args.worker_app_name, args.vault_name
+    dry = args.dry_run
+
+    print("=" * 78)
+    print(f"Key Vault migration — {args.environment}")
+    print(f"  vault:  {vault}")
+    print(f"  apps:   {api}, {worker}")
+    print(f"  mode:   {'DRY RUN' if dry else 'APPLY'}")
+    print("=" * 78)
+
+    subscription = _run(["az", "account", "show", "--query", "id", "-o", "tsv"])
+    vault_scope = (
+        f"/subscriptions/{subscription}/resourceGroups/{args.resource_group}"
+        f"/providers/Microsoft.KeyVault/vaults/{vault}"
+    )
+
+    print("\n[1/6] Vault")
+    exists = _run(
+        ["az", "keyvault", "list", "--query", f"[?name=='{vault}'].name", "-o", "tsv"]
+    )
+    if exists:
+        print(f"   exists: {vault}")
+    else:
+        _run(
+            [
+                "az",
+                "keyvault",
+                "create",
+                "--name",
+                vault,
+                "--resource-group",
+                args.resource_group,
+                "--location",
+                args.location,
+                "--enable-rbac-authorization",
+                "true",
+            ],
+            dry_run=dry,
+        )
+        print(f"   created: {vault}")
+
+    print("\n[2/6] Managed identities")
+    principals = {}
+    for app in (api, worker):
+        principal = _run(
+            [
+                "az",
+                "containerapp",
+                "identity",
+                "assign",
+                "--system-assigned",
+                "--name",
+                app,
+                "--resource-group",
+                args.resource_group,
+                "--query",
+                "principalId",
+                "-o",
+                "tsv",
+            ],
+            dry_run=dry,
+        )
+        principals[app] = principal
+        print(f"   {app}: {principal or '(dry run)'}")
+
+    print("\n[3/6] Access")
+    for app, principal in principals.items():
+        if principal:
+            _run(
+                [
+                    "az",
+                    "role",
+                    "assignment",
+                    "create",
+                    "--assignee-object-id",
+                    principal,
+                    "--assignee-principal-type",
+                    "ServicePrincipal",
+                    "--role",
+                    "Key Vault Secrets User",
+                    "--scope",
+                    vault_scope,
+                ],
+                dry_run=dry,
+            )
+        print(f"   {app}: Key Vault Secrets User")
+    # Whoever runs this must WRITE secrets, and an RBAC-enabled vault grants no
+    # data-plane access to subscription Owners — management-plane rights are not
+    # enough. Without this the copy step fails with a bare 403.
+    operator = _run(
+        ["az", "ad", "signed-in-user", "show", "--query", "id", "-o", "tsv"]
+    )
+    if operator:
+        _run(
+            [
+                "az",
+                "role",
+                "assignment",
+                "create",
+                "--assignee-object-id",
+                operator,
+                "--assignee-principal-type",
+                "User",
+                "--role",
+                "Key Vault Secrets Officer",
+                "--scope",
+                vault_scope,
+            ],
+            dry_run=dry,
+        )
+        print("   operator: Key Vault Secrets Officer")
+
+    if args.deploy_principal_id:
+        # The deploy mints the Redis URLs on every run, so it must WRITE.
+        _run(
+            [
+                "az",
+                "role",
+                "assignment",
+                "create",
+                "--assignee-object-id",
+                args.deploy_principal_id,
+                "--assignee-principal-type",
+                "ServicePrincipal",
+                "--role",
+                "Key Vault Secrets Officer",
+                "--scope",
+                vault_scope,
+            ],
+            dry_run=dry,
+        )
+        print("   deploy principal: Key Vault Secrets Officer")
+    else:
+        print(
+            "   ⚠  no --deploy-principal-id: CI cannot mint Redis URLs into the vault"
+        )
+
+    print("\n[4/6] Copy values in (from the API app, the current source of truth)")
+    for env_var, name in secret_refs_for().items():
+        # The live secret may still carry its pre-rename name.
+        legacy = {"llm-encrypt-password": "llm-encryption-password"}.get(name, name)
+        value = _run(
+            [
+                "az",
+                "containerapp",
+                "secret",
+                "show",
+                "--name",
+                api,
+                "--resource-group",
+                args.resource_group,
+                "--secret-name",
+                legacy,
+                "--query",
+                "value",
+                "-o",
+                "tsv",
+            ],
+            dry_run=dry,
+        )
+        if not dry and not value:
+            print(f"   ✗ {name}: nothing to copy (missing on {api})")
+            continue
+        _run(
+            [
+                "az",
+                "keyvault",
+                "secret",
+                "set",
+                "--vault-name",
+                vault,
+                "--name",
+                name,
+                "--value",
+                value or "placeholder",
+            ],
+            dry_run=dry,
+            redact=True,
+        )
+        print(f"   ✓ {name}" + (f"  (was {legacy})" if legacy != name else ""))
+
+    print("\n[5/6] Repoint the apps")
+    for app, is_worker in ((api, False), (worker, True)):
+        refs = container_app_secrets(vault, worker=is_worker)
+        _run(
+            [
+                "az",
+                "containerapp",
+                "secret",
+                "set",
+                "--name",
+                app,
+                "--resource-group",
+                args.resource_group,
+                "--secrets",
+                *[f"{n}={v}" for n, v in refs.items()],
+            ],
+            dry_run=dry,
+        )
+        env = secret_env_vars(worker=is_worker)
+        _run(
+            [
+                "az",
+                "containerapp",
+                "update",
+                "--name",
+                app,
+                "--resource-group",
+                args.resource_group,
+                "--set-env-vars",
+                *[f"{k}={v}" for k, v in env.items()],
+            ],
+            dry_run=dry,
+        )
+        print(f"   {app}: {len(refs)} secret(s) now reference the vault")
+
+    print("\n[6/6] Verify")
+    if dry:
+        print("   skipped (dry run)")
+    else:
+        for app in (api, worker):
+            state = _run(
+                [
+                    "az",
+                    "containerapp",
+                    "revision",
+                    "list",
+                    "--name",
+                    app,
+                    "--resource-group",
+                    args.resource_group,
+                    "--query",
+                    "[?properties.active].properties.runningState",
+                    "-o",
+                    "tsv",
+                ],
+            )
+            print(f"   {app}: {state or 'unknown'}")
+        print("\n   Revisions take a moment to roll. Re-check, then run the")
+        print("   end-to-end probe before trusting this.")
+
+    print("\n" + "=" * 78)
+    print("Done." if not dry else "Dry run complete — nothing changed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/ops/async-generation.md
+++ b/docs/ops/async-generation.md
@@ -144,3 +144,59 @@ is silent by design — the job succeeds either way — but heuristic-only outpu
 typically leaves `function` empty, and that is a required OKH field. The guided
 review in the UI asks for it before enabling download, so expect to write one
 sentence per generated manifest.
+
+## Secrets in Key Vault
+
+Container App secrets are per-app, so every value the API and worker share once
+existed twice. They are now **references**: the value lives once in Key Vault and
+both apps hold a pointer, resolved at runtime through their system-assigned
+managed identity. Rotation is one edit rather than an edit plus a redeploy of
+everything downstream.
+
+Migrating an environment:
+
+```bash
+uv run python deploy/scripts/migrate_secrets_to_key_vault.py \
+    --environment production --vault-name <vault> \
+    --container-app-name openhardwaremanager \
+    --worker-app-name openhardwaremanager-worker \
+    --deploy-principal-id <CI principal object id> --dry-run
+```
+
+Run the dry run first, and **rehearse on staging before production**: an app that
+cannot resolve a secret does not start, which in production is an outage.
+
+The order is not arbitrary — identities and access must exist before any app is
+repointed, or the repointed app cannot start:
+
+1. Create the vault (RBAC-authorised).
+2. Enable a system-assigned identity on each app.
+3. Grant each identity **Key Vault Secrets User**; grant the operator and the CI
+   deploy principal **Key Vault Secrets Officer** (both write).
+4. Copy current values in from the API app.
+5. Repoint both apps.
+6. Verify: health, worker logs, and the end-to-end job probe.
+
+!!! warning "An RBAC vault grants Owners nothing on the data plane"
+    Subscription Owner is a management-plane role. Without an explicit
+    **Secrets Officer** grant, writing secrets fails with a bare 403 partway
+    through, leaving the vault half-populated. The migration script grants the
+    operator this before it writes.
+
+### Two constraints worth knowing
+
+- A Container App secret name carrying a Key Vault reference **cannot exceed 20
+  characters**. `llm-encryption-password` was 23, so the secret is now
+  `llm-encrypt-password`. Only the secret's name changed; the environment
+  variable the application reads is unchanged.
+- Rotation needs no deploy, but is **not instant** — the platform caches
+  Key Vault-backed secret values and refreshes on its own schedule. Plan
+  rotations accordingly rather than expecting immediate effect.
+
+### Leftovers
+
+The migration replaces secrets by name and touches nothing else, so a
+pre-rename secret such as `llm-encryption-password` remains, unreferenced.
+Removing leftovers is a **separate** step once the references have been trusted
+in production — not part of the cutover, where an unnecessary deletion is one
+more way to lose a value you still need.

--- a/tests/unit/test_key_vault_secrets.py
+++ b/tests/unit/test_key_vault_secrets.py
@@ -1,0 +1,146 @@
+"""Container App secrets backed by Key Vault rather than duplicated per app.
+
+The properties worth pinning are the ones whose failure is an outage: a name the
+platform rejects, a reference an app cannot resolve, or a secret value leaking
+into something that gets logged.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from deploy.providers.azure.key_vault import (
+    KEY_VAULT_SECRET_REFS,
+    MAX_SECRET_NAME_LENGTH,
+    SecretNameTooLongError,
+    container_app_secrets,
+    key_vault_reference,
+    secret_env_vars,
+    secret_refs_for,
+    secret_uri,
+)
+
+pytestmark = pytest.mark.unit
+
+VAULT = "ohm-test-kv"
+
+
+# --- The platform limit that forced a rename ---------------------------------
+
+
+def test_every_secret_name_fits_the_platform_limit():
+    """A Key Vault reference is rejected above 20 characters.
+
+    `llm-encryption-password` was 23, which is why it is now
+    `llm-encrypt-password`. Adding a longer name would fail at deploy time with
+    a platform error that does not name the culprit.
+    """
+    too_long = {
+        name: len(name)
+        for name in KEY_VAULT_SECRET_REFS.values()
+        if len(name) > MAX_SECRET_NAME_LENGTH
+    }
+
+    assert (
+        not too_long
+    ), f"names exceed the {MAX_SECRET_NAME_LENGTH}-char limit: {too_long}"
+
+
+def test_a_too_long_name_fails_loudly_and_says_which():
+    with pytest.raises(SecretNameTooLongError, match="this-name-is-far-too-long"):
+        key_vault_reference(VAULT, "this-name-is-far-too-long")
+
+
+def test_the_renamed_secret_kept_its_environment_variable():
+    """Only the secret's NAME moved. The application reads the same env var, so
+    it cannot tell the difference — which is what makes the rename safe."""
+    assert KEY_VAULT_SECRET_REFS["LLM_ENCRYPTION_PASSWORD"] == "llm-encrypt-password"
+    assert "LLM_ENCRYPTION_PASSWORD" in secret_env_vars()
+
+
+# --- References resolve to the right place -----------------------------------
+
+
+def test_a_reference_names_the_vault_the_secret_and_the_identity():
+    reference = key_vault_reference(VAULT, "azure-storage-key")
+
+    assert reference == (
+        f"keyvaultref:https://{VAULT}.vault.azure.net/secrets/azure-storage-key"
+        ",identityref:system"
+    )
+
+
+def test_the_uri_points_at_the_secret_not_a_version():
+    """Pinning a version would freeze rotation, defeating the point."""
+    assert secret_uri(VAULT, "api-key").endswith("/secrets/api-key")
+
+
+# --- No secret value ever appears --------------------------------------------
+
+
+def test_container_app_secrets_carry_pointers_never_values():
+    """These get logged and pasted into issues; they must be safe to read."""
+    for value in container_app_secrets(VAULT).values():
+        assert value.startswith("keyvaultref:https://")
+        assert "identityref:system" in value
+
+
+def test_env_vars_carry_pointers_never_values():
+    for value in secret_env_vars().values():
+        assert value.startswith("secretref:")
+        assert (
+            "vault.azure.net" not in value
+        )  # the env var names the SECRET, not the URI
+
+
+# --- Each app gets only what it needs ----------------------------------------
+
+
+def test_the_worker_does_not_get_the_api_keys():
+    """It authenticates no callers, so granting it those is access it cannot use."""
+    assert "API_KEYS" in secret_refs_for()
+    assert "API_KEYS" not in secret_refs_for(worker=True)
+
+
+def test_the_worker_gets_the_secrets_it_actually_needs():
+    """Storage to read designs, git tokens because IT clones repositories, the
+    encryption secrets because importing config in production demands them, and
+    the broker URLs to consume jobs."""
+    worker = secret_refs_for(worker=True)
+
+    for required in (
+        "AZURE_STORAGE_KEY",
+        "GITHUB_ACCESS_TOKEN",
+        "GITLAB_ACCESS_TOKEN",
+        "LLM_ENCRYPTION_SALT",
+        "LLM_ENCRYPTION_PASSWORD",
+        "JOB_BROKER_URL",
+        "JOB_RESULT_BACKEND",
+    ):
+        assert required in worker, required
+
+
+def test_both_apps_reference_the_same_secret_for_a_shared_value():
+    """The whole point: one value, two pointers, no copies to drift."""
+    api = secret_refs_for()
+    worker = secret_refs_for(worker=True)
+
+    shared = set(api) & set(worker)
+    assert shared, "expected shared secrets"
+    for env_var in shared:
+        assert api[env_var] == worker[env_var]
+
+
+def test_key_vault_names_are_valid():
+    """Key Vault accepts alphanumerics and dashes only."""
+    import re
+
+    for name in KEY_VAULT_SECRET_REFS.values():
+        assert re.fullmatch(r"[A-Za-z0-9-]+", name), name


### PR DESCRIPTION
Refs #317 — the **code half**. No production infrastructure is touched by merging this. The live migration is a separate, authorised step.

Container App secrets are per-app, so every value the API and worker share exists twice. The deploys mirror them so the copies cannot drift, but the API app remains the origin: rotating a credential means editing it there and redeploying everything downstream. A Key Vault reference removes the copies — each value lives once, and both apps hold a pointer resolved through their system-assigned managed identity.

## Rehearsed on staging, and the rehearsal paid for itself

Staging was rebuilt, a green baseline established, then migrated end to end:

```
[1/6] vault created        ohm-staging-kv (RBAC-authorised)
[2/6] identities assigned  both apps, system-assigned
[3/6] access granted       apps → Secrets User; operator + CI → Secrets Officer
[4/6] 9 secrets copied     incl. llm-encrypt-password (was llm-encryption-password)
[5/6] apps repointed       API 9 refs, worker 8 (no api-key)
[6/6] verified             API healthy 276 OKH · worker celery ready · probe clean
```

**It caught a blocker that reading the code would not have.** An RBAC-authorised vault grants subscription Owners **no** data-plane access — management-plane rights are not enough — so the copy step dies on a bare 403 partway through, leaving the vault half-populated. The script now grants the operator `Secrets Officer` before it writes anything.

Azure confirms the secrets carry `keyVaultUrl` + `identity: system` rather than inline values, and the worker booted cleanly — notable because it needs `LLM_ENCRYPTION_*` at *import* time, and those now resolve from the vault.

## Two platform facts, encoded rather than rediscovered

**A secret name carrying a Key Vault reference cannot exceed 20 characters.** `llm-encryption-password` is 23. It becomes `llm-encrypt-password`; only the secret's name moves, so the environment variable the application reads is unchanged and the rename is invisible to it. A test fails if any future name exceeds the limit, because the platform's own error does not say which name was at fault.

**Rotation needs no deploy, but is not instant.** The platform caches Key Vault-backed values and refreshes on its own schedule. I verified a new version can be written without a deploy; I did **not** verify the running app picks it up, and I have not claimed otherwise in the docs.

## Deliberately additive

The migration replaces secrets by name and touches nothing else, so pre-rename secrets remain, unreferenced. Deleting leftovers is a separate step once the references have been trusted in production — a cutover is a bad moment to also be removing values you might still need.

`make ready` green; 1253 tests, 11 new.

## After merging

The production migration is the same script, same order, now rehearsed. It ends with health, `secrets-check` and the probe, and stops short of deleting anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
