### PR TITLE
Point secrets-check at what Key Vault made important

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -87,8 +87,7 @@ Total Python files: 622
 │       │       def test_deployment_command_building()
 │       │       def main()
 │       └── verify_app_secrets.py
-│               def _digest()
-│               def _read_secret()
+│               def _secrets()
 │               def main()
 ├── harness/
 │   ├── __init__.py
@@ -2419,14 +2418,15 @@ Total Python files: 622
         │       def test_create_command_is_logged_with_secret_values_redacted()
         │       def _load_verifier()
         │       def _run_verifier()
-        │       def _all_agreeing()
-        │       def test_secret_check_passes_when_both_apps_agree()
-        │       def test_secret_check_detects_a_differing_value()
-        │       def test_secret_check_detects_a_missing_secret_on_the_worker()
+        │       def _all_vault_backed()
+        │       def test_passes_when_both_apps_reference_the_same_vault_secrets()
+        │       def test_detects_apps_pointed_at_different_vault_secrets()
+        │       def test_detects_a_secret_left_inline_on_one_app()
+        │       def test_detects_a_shared_secret_missing_from_the_worker()
+        │       def test_a_value_inline_on_both_apps_is_not_treated_as_agreement()
         │       def test_api_only_secret_is_not_reported_as_drift()
         │       def test_missing_api_only_secret_on_the_api_is_a_problem()
-        │       def test_shared_set_covers_the_broker_url()
-        │       def test_digest_never_reveals_the_value()
+        │       def test_the_checked_set_comes_from_what_the_deploys_actually_wire()
         ├── test_bindings.py
         │       class _InMemoryManager (__init__)
         │       class _FakeStorageService (__init__)
@@ -6188,9 +6188,9 @@ This script allows testing the GCP deployer locally before ...
   - Test service status checking....
 
 ### `deploy/scripts/verify_app_secrets.py`
-> Verify the API and worker container apps agree on their shared secrets.
+> Verify the API and worker agree about the secrets they share.
 
-The deploys mirror these se...
+Secrets now live once in Key Vault; e...
 
 **Exports:** main
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`make secrets-check` now checks what Key Vault made important.** It compared
+  resolved secret *values*, which proves little once there is only one copy — and
+  it read a separate list, so after the migration it verified a renamed-away
+  secret while never inspecting the live one. It now derives its scope from the
+  same mapping the deploys wire, and asserts both apps reference the **same vault
+  secret**, flagging any value left inline. It reads no secret values at all.
+
 ### Added
 
 - **Container App secrets can be backed by Key Vault.** Each shared value lives

--- a/deploy/scripts/verify_app_secrets.py
+++ b/deploy/scripts/verify_app_secrets.py
@@ -1,29 +1,33 @@
 #!/usr/bin/env python3
-"""Verify the API and worker container apps agree on their shared secrets.
+"""Verify the API and worker agree about the secrets they share.
 
-The deploys mirror these secrets from the API app on every run, so they cannot
-drift across a deploy. This confirms that actually took effect, and catches the
-two cases mirroring cannot: a half-completed deploy, and someone editing a
-secret directly in the portal afterwards.
+Secrets now live once in Key Vault; each app holds a *reference* resolved
+through its managed identity. So the question worth asking changed. Comparing
+resolved values proves little when there is only one copy — but two apps can
+still be pointed at **different vault secrets**, or one can be left holding an
+inline value while the other reads the vault. That is what this checks.
 
-Compares **digests**, never values, so the output is safe to paste anywhere.
+It also reports secrets that are still inline. Those are not automatically
+wrong — the platform manages the registry credential itself, and the migration
+deliberately leaves pre-rename secrets behind rather than deleting during a
+cutover — but an inline copy of a value that should come from the vault is
+drift waiting to happen.
 
-The sharp one is the broker URL. An API and worker pointed at different Redis
-databases means jobs are accepted and never consumed — no error in either app,
-a progress bar at 0%, and nothing that looks wrong until you compare the two.
+No secret value is read at all — only the vault URI each app points at — so the
+output is safe to paste anywhere.
 
 Not part of ``make ready``: it needs live cloud credentials, and the merge gate
 must stay runnable offline.
 
 Usage:
-    uv run python deploy/scripts/verify_app_secrets.py
+    make secrets-check
     uv run python deploy/scripts/verify_app_secrets.py --environment staging \\
         --container-app-name openhardwaremanager-staging \\
         --worker-app-name openhardwaremanager-stg-worker
 """
 
 import argparse
-import hashlib
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -31,76 +35,67 @@ from pathlib import Path
 project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
 
-from deploy.providers.azure.app_secrets import (  # noqa: E402
-    API_ONLY_SECRET_ENV_REFS,
-    mirrored_secret_names,
-)
-from deploy.providers.azure.redis_secrets import (  # noqa: E402
-    SECRET_CACHE_URL,
-    SECRET_JOB_BROKER_URL,
-    SECRET_JOB_RESULT_BACKEND,
+from deploy.providers.azure.key_vault import (  # noqa: E402
+    WORKER_EXCLUDED_SECRETS,
+    secret_refs_for,
 )
 
-# Secrets both apps must hold identically. The Redis URLs are included because a
-# broker mismatch is invisible in either app on its own.
-SHARED_SECRETS = sorted(
-    set(mirrored_secret_names())
-    | {SECRET_CACHE_URL, SECRET_JOB_BROKER_URL, SECRET_JOB_RESULT_BACKEND}
+# Secrets both apps must resolve identically. Sourced from the Key Vault mapping
+# so this cannot drift from what the deploys actually wire — reading a separate
+# list is how the previous version came to check a renamed-away secret while
+# missing the live one.
+SHARED_SECRETS = sorted(set(secret_refs_for(worker=True).values()))
+
+# Expected on the API alone: a worker authenticates no callers.
+API_ONLY_SECRETS = sorted(
+    {
+        name
+        for env_var, name in secret_refs_for().items()
+        if env_var in WORKER_EXCLUDED_SECRETS
+    }
 )
 
-# Expected on the API only — a worker authenticates no callers. Absence from the
-# worker is correct, not drift.
-API_ONLY_SECRETS = sorted(set(API_ONLY_SECRET_ENV_REFS.values()))
 
-
-def _digest(value: str) -> str:
-    """Short, stable fingerprint. Never reveals the secret."""
-    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]
-
-
-def _read_secret(app: str, resource_group: str, name: str) -> str | None:
+def _secrets(app: str, resource_group: str) -> dict:
+    """Secret name -> its Key Vault URI, or None when the value is inline."""
     result = subprocess.run(
         [
             "az",
             "containerapp",
-            "secret",
             "show",
             "--name",
             app,
             "--resource-group",
             resource_group,
-            "--secret-name",
-            name,
             "--query",
-            "value",
+            "properties.configuration.secrets",
             "--output",
-            "tsv",
+            "json",
         ],
         capture_output=True,
         text=True,
         check=False,
     )
     if result.returncode != 0:
-        return None
-    value = result.stdout.strip()
-    return value or None
+        raise RuntimeError(
+            f"could not read secrets from {app}: {result.stderr.strip()}"
+        )
+    return {s["name"]: s.get("keyVaultUrl") for s in json.loads(result.stdout or "[]")}
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Verify the API and worker agree on their shared secrets"
+        description="Verify the API and worker agree about their shared secrets"
     )
     parser.add_argument("--resource-group", default="project_data_rg")
     parser.add_argument("--container-app-name", default="openhardwaremanager")
     parser.add_argument("--worker-app-name", default="openhardwaremanager-worker")
-    parser.add_argument(
-        "--environment",
-        default="production",
-        help="Labels the report only; secret names are the same across environments",
-    )
+    parser.add_argument("--environment", default="production", help="labels the report")
     args = parser.parse_args()
 
     api, worker = args.container_app_name, args.worker_app_name
+    api_secrets = _secrets(api, args.resource_group)
+    worker_secrets = _secrets(worker, args.resource_group)
 
     print("=" * 78)
     print(f"Shared secret check — {args.environment}")
@@ -111,47 +106,59 @@ def main() -> int:
     problems: list[str] = []
 
     for name in SHARED_SECRETS:
-        api_value = _read_secret(api, args.resource_group, name)
-        worker_value = _read_secret(worker, args.resource_group, name)
-
-        if api_value is None and worker_value is None:
-            problems.append(f"{name}: missing from BOTH apps")
-            print(f"  ✗ {name:24} missing from both")
-            continue
-        if api_value is None:
+        if name not in api_secrets:
             problems.append(f"{name}: missing from {api}")
             print(f"  ✗ {name:24} missing from api")
             continue
-        if worker_value is None:
+        if name not in worker_secrets:
             problems.append(f"{name}: missing from {worker}")
             print(f"  ✗ {name:24} missing from worker")
             continue
 
-        api_digest, worker_digest = _digest(api_value), _digest(worker_value)
-        if api_digest != worker_digest:
-            problems.append(
-                f"{name}: differs (api {api_digest} != worker {worker_digest})"
-            )
-            print(f"  ✗ {name:24} DIFFERS  api={api_digest} worker={worker_digest}")
+        api_uri, worker_uri = api_secrets[name], worker_secrets[name]
+        if api_uri != worker_uri:
+            problems.append(f"{name}: apps reference different sources")
+            print(f"  ✗ {name:24} DIFFERENT sources")
+            print(f"      api    → {api_uri or 'inline value'}")
+            print(f"      worker → {worker_uri or 'inline value'}")
+        elif api_uri:
+            print(f"  ✓ {name:24} same vault secret")
         else:
-            print(f"  ✓ {name:24} agree    {api_digest}")
+            # Both inline and therefore equal only by luck; nothing keeps them so.
+            problems.append(f"{name}: still an inline copy on both apps")
+            print(f"  ✗ {name:24} inline on both — not vault-backed")
 
     for name in API_ONLY_SECRETS:
-        if _read_secret(api, args.resource_group, name) is None:
+        if name not in api_secrets:
             problems.append(f"{name}: missing from {api}")
             print(f"  ✗ {name:24} missing from api (API-only secret)")
         else:
             print(f"  · {name:24} api only (expected)")
 
+    leftovers = {
+        app_name: sorted(
+            name
+            for name, uri in secrets.items()
+            if uri is None and name not in API_ONLY_SECRETS
+        )
+        for app_name, secrets in ((api, api_secrets), (worker, worker_secrets))
+    }
+    if any(leftovers.values()):
+        print("\n  Inline secrets (not vault-backed):")
+        for app_name, names in leftovers.items():
+            for name in names:
+                note = " ← platform-managed" if "registry" in name else ""
+                print(f"    {app_name}: {name}{note}")
+        print("  Expected during a migration; remove once references are trusted.")
+
     print("=" * 78)
     if problems:
-        print("❌ Secret drift detected:")
+        print("❌ Problems:")
         for problem in problems:
             print(f"   - {problem}")
-        print("\nRe-run the deploys to re-mirror, or fix the source app's secret.")
         return 1
 
-    print("✅ The API and worker agree on every shared secret.")
+    print("✅ Both apps reference the same vault secret for every shared value.")
     return 0
 
 

--- a/tests/unit/test_azure_worker_deploy.py
+++ b/tests/unit/test_azure_worker_deploy.py
@@ -6,6 +6,7 @@ config surface, it runs worker mode with no ingress, it carries the secrets it
 needs, and it does not by itself switch async jobs on.
 """
 
+import json
 import logging
 import sys
 from pathlib import Path
@@ -244,9 +245,10 @@ def test_create_command_is_logged_with_secret_values_redacted(caplog):
 
 # --- Shared-secret verification ----------------------------------------------
 #
-# The deploys mirror these on every run, so this confirms mirroring took effect
-# and catches what mirroring cannot: a half-completed deploy, or a secret edited
-# by hand in the portal afterwards.
+# Secrets live once in Key Vault now, so comparing resolved VALUES proves little
+# — there is only one copy. What can still go wrong is the two apps being
+# pointed at different sources, or one being left holding an inline value while
+# the other reads the vault. That is what these pin.
 
 
 def _load_verifier():
@@ -261,17 +263,23 @@ def _load_verifier():
     return module
 
 
-def _run_verifier(values_by_app):
-    """values_by_app: {app_name: {secret_name: value or None}}"""
+VAULT = "https://ohm-kv.vault.azure.net/secrets"
+
+
+def _run_verifier(secrets_by_app):
+    """secrets_by_app: {app: {secret_name: key_vault_uri or None}}"""
     module = _load_verifier()
 
     def _run(command, capture_output, text, check):
         app = command[command.index("--name") + 1]
-        secret = command[command.index("--secret-name") + 1]
-        value = values_by_app.get(app, {}).get(secret)
         result = MagicMock()
-        result.returncode = 0 if value is not None else 1
-        result.stdout = value or ""
+        result.returncode = 0
+        result.stdout = json.dumps(
+            [
+                {"name": name, "keyVaultUrl": uri}
+                for name, uri in secrets_by_app.get(app, {}).items()
+            ]
+        )
         result.stderr = ""
         return result
 
@@ -282,71 +290,88 @@ def _run_verifier(values_by_app):
         return module.main(), module
 
 
-def _all_agreeing():
+def _all_vault_backed():
     module = _load_verifier()
-    shared = {name: f"value-for-{name}" for name in module.SHARED_SECRETS}
+    shared = {name: f"{VAULT}/{name}" for name in module.SHARED_SECRETS}
+    api_only = {name: f"{VAULT}/{name}" for name in module.API_ONLY_SECRETS}
     return {
-        "openhardwaremanager": {**shared, "api-key": "the-api-key"},
+        "openhardwaremanager": {**shared, **api_only},
         "openhardwaremanager-worker": dict(shared),
     }
 
 
-def test_secret_check_passes_when_both_apps_agree():
-    code, _ = _run_verifier(_all_agreeing())
+def test_passes_when_both_apps_reference_the_same_vault_secrets():
+    code, _ = _run_verifier(_all_vault_backed())
     assert code == 0
 
 
-def test_secret_check_detects_a_differing_value():
-    values = _all_agreeing()
-    values["openhardwaremanager-worker"]["job-broker-url"] = "pointing-somewhere-else"
+def test_detects_apps_pointed_at_different_vault_secrets():
+    """The failure Key Vault does not prevent: one value, two pointers, and the
+    pointers disagree."""
+    secrets = _all_vault_backed()
+    secrets["openhardwaremanager-worker"][
+        "job-broker-url"
+    ] = "https://other-kv.vault.azure.net/secrets/job-broker-url"
 
-    code, _ = _run_verifier(values)
+    code, _ = _run_verifier(secrets)
     assert code == 1
 
 
-def test_secret_check_detects_a_missing_secret_on_the_worker():
-    values = _all_agreeing()
-    values["openhardwaremanager-worker"]["azure-storage-key"] = None
+def test_detects_a_secret_left_inline_on_one_app():
+    """A stale inline copy silently shadows the vault for that app."""
+    secrets = _all_vault_backed()
+    secrets["openhardwaremanager-worker"]["azure-storage-key"] = None
 
-    code, _ = _run_verifier(values)
+    code, _ = _run_verifier(secrets)
+    assert code == 1
+
+
+def test_detects_a_shared_secret_missing_from_the_worker():
+    secrets = _all_vault_backed()
+    del secrets["openhardwaremanager-worker"]["gihub-token"]
+
+    code, _ = _run_verifier(secrets)
+    assert code == 1
+
+
+def test_a_value_inline_on_both_apps_is_not_treated_as_agreement():
+    """Equal only by luck, with nothing keeping them so — that is the drift this
+    migration removed, not a passing state."""
+    secrets = _all_vault_backed()
+    for app in secrets:
+        secrets[app]["cache-redis-url"] = None
+
+    code, _ = _run_verifier(secrets)
     assert code == 1
 
 
 def test_api_only_secret_is_not_reported_as_drift():
     """A worker authenticates no callers, so api-key is correctly absent."""
-    values = _all_agreeing()
-    assert "api-key" not in values["openhardwaremanager-worker"]
+    module = _load_verifier()
+    secrets = _all_vault_backed()
 
-    code, _ = _run_verifier(values)
+    assert not set(module.API_ONLY_SECRETS) & set(secrets["openhardwaremanager-worker"])
+    code, _ = _run_verifier(secrets)
     assert code == 0
 
 
 def test_missing_api_only_secret_on_the_api_is_a_problem():
-    values = _all_agreeing()
-    values["openhardwaremanager"]["api-key"] = None
+    module = _load_verifier()
+    secrets = _all_vault_backed()
+    for name in module.API_ONLY_SECRETS:
+        del secrets["openhardwaremanager"][name]
 
-    code, _ = _run_verifier(values)
+    code, _ = _run_verifier(secrets)
     assert code == 1
 
 
-def test_shared_set_covers_the_broker_url():
-    """A broker mismatch is invisible in either app alone — jobs just never run."""
+def test_the_checked_set_comes_from_what_the_deploys_actually_wire():
+    """The previous version read a separate list, drifted from it, and ended up
+    checking a renamed-away secret while missing the live one."""
+    from deploy.providers.azure.key_vault import secret_refs_for
+
     module = _load_verifier()
 
-    assert "job-broker-url" in module.SHARED_SECRETS
-    assert "job-result-backend" in module.SHARED_SECRETS
-    assert "azure-storage-key" in module.SHARED_SECRETS
-    # API-only secrets must not be in the shared set, or every check would fail.
-    assert "api-key" not in module.SHARED_SECRETS
-
-
-def test_digest_never_reveals_the_value():
-    module = _load_verifier()
-    secret = "rediss://:super-secret-key@host:6380/1"
-
-    digest = module._digest(secret)
-
-    assert secret not in digest
-    assert "super-secret-key" not in digest
-    assert module._digest(secret) == digest
-    assert module._digest(secret + "x") != digest
+    assert set(module.SHARED_SECRETS) == set(secret_refs_for(worker=True).values())
+    assert "llm-encrypt-password" in module.SHARED_SECRETS
+    assert "llm-encryption-password" not in module.SHARED_SECRETS


### PR DESCRIPTION
Refs #317. Fixes a check that reported a **confident green about the wrong thing** immediately after the production migration.

## What it got wrong

`make secrets-check` compared resolved secret *values* between the two apps. Once each value lives once in Key Vault and both apps hold a reference, that proves very little — there is only one copy, so it cannot disagree with itself.

Worse, it read its list of names from the old mirroring module, and drifted the moment the migration renamed a secret. Run against production right after the cutover it reported success while:

- checking **`llm-encryption-password`** — the pre-rename leftover nothing references any more, and
- never inspecting **`llm-encrypt-password`** — the one both apps actually read.

It looked reassuring because `az containerapp secret show` resolves a Key Vault reference and returns the underlying value, so its digests were byte-identical to the pre-migration run.

## What it checks now

The scope is derived from the same mapping the deploys wire, so it cannot drift from them again. And it asks the question that can still go wrong once values are centralised: **do both apps reference the same vault secret?**

Two apps can be pointed at different vault secrets, or one can be left holding an inline value that silently shadows the vault. Both are now failures. Any value still held inline is reported — expected during a migration, drift waiting to happen afterwards.

It reads **no secret values at all**, only the vault URI each app points at, so the output is safe to paste anywhere.

## Against production

```
✓ azure-storage-key      same vault secret     ✓ job-broker-url        same vault secret
✓ cache-redis-url        same vault secret     ✓ job-result-backend    same vault secret
✓ gihub-token            same vault secret     ✓ llm-encrypt-password  same vault secret
✓ gitlab-token           same vault secret     ✓ llm-encryption-salt   same vault secret
· api-key                api only (expected)

Inline secrets (not vault-backed):
  openhardwaremanager: helpfulcontainerregistry… ← platform-managed
  openhardwaremanager: llm-encryption-password
  openhardwaremanager: redis-access-url
  openhardwaremanager-worker: llm-encryption-password
```

The leftovers are now visible rather than silently passed. Removing them stays a separate step, once the references have been trusted.

The tests were rewritten to match: they now pin the failures that matter — apps pointed at different vault secrets, a secret left inline on one app, and a value inline on *both* (equal only by luck, with nothing keeping it so). One asserts the checked set is derived from the deploy mapping, which is the specific mistake that caused this.

`make ready` green; 1255 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
