### PR TITLE
Teach the teardown script about Key Vaults

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3165,6 +3165,9 @@ Total Python files: 622
         │       def test_teardown_refuses_production()
         │       def test_teardown_refuses_the_live_app_names_even_under_another_environment()
         │       def test_teardown_without_yes_deletes_nothing()
+        │       def test_teardown_refuses_the_production_vault()
+        │       def test_teardown_keeps_the_vault_unless_explicitly_asked()
+        │       def test_teardown_purges_the_vault_it_deletes()
         │       def test_teardown_keeps_blobs_unless_explicitly_asked()
         │       def test_created_app_targets_the_port_the_image_actually_binds()
         ├── test_storage_config_env_parsing.py

--- a/deploy/scripts/teardown_azure_environment.py
+++ b/deploy/scripts/teardown_azure_environment.py
@@ -42,6 +42,10 @@ PROTECTED_APPS = {
     "openhardwaremanager-worker",
 }
 
+# Vaults that must never be deleted by this script. Deleting one takes every
+# secret both live apps resolve at runtime, so they stop starting.
+PROTECTED_VAULTS = {"ohm-prod-kv"}
+
 
 def _run(command: list[str]) -> tuple[int, str, str]:
     result = subprocess.run(command, capture_output=True, text=True, check=False)
@@ -69,6 +73,21 @@ def main() -> int:
         help="Worker app name (default: openhardwaremanager-stg-worker for staging)",
     )
     parser.add_argument(
+        "--vault-name",
+        default=None,
+        help="Key Vault name (default: ohm-<environment>-kv)",
+    )
+    parser.add_argument(
+        "--delete-key-vault",
+        action="store_true",
+        help=(
+            "Also delete the environment's Key Vault, and PURGE it. Purging is "
+            "irreversible, and is the point: a soft-deleted vault keeps its name "
+            "reserved for 90 days, so the next rebuild of this environment would "
+            "fail on a name collision."
+        ),
+    )
+    parser.add_argument(
         "--delete-blob-container",
         action="store_true",
         help="Also delete the environment's blob container. Destroys data.",
@@ -94,6 +113,11 @@ def main() -> int:
             print(f"❌ Refusing to delete protected container app {app!r}.")
             return 1
 
+    vault = args.vault_name or f"ohm-{args.environment}-kv"
+    if args.delete_key_vault and vault in PROTECTED_VAULTS:
+        print(f"❌ Refusing to delete protected Key Vault {vault!r}.")
+        return 1
+
     env_vars = deploy_env_vars(args.environment)
     blob_container = env_vars.get("AZURE_STORAGE_CONTAINER")
     storage_account = env_vars.get("AZURE_STORAGE_ACCOUNT")
@@ -107,6 +131,10 @@ def main() -> int:
         print(f"Blob container:   {storage_account}/{blob_container}  (DATA LOSS)")
     else:
         print(f"Blob container:   {storage_account}/{blob_container}  (kept)")
+    if args.delete_key_vault:
+        print(f"Key Vault:        {vault}  (DELETED AND PURGED — irreversible)")
+    else:
+        print(f"Key Vault:        {vault}  (kept)")
     print("=" * 80)
 
     if not args.yes:
@@ -137,6 +165,50 @@ def main() -> int:
                 print(f"   ❌ {stderr.strip()}")
         else:
             print(f"   deleted: {app}")
+
+    if args.delete_key_vault:
+        print(f"\n🗑  Deleting Key Vault {vault}...")
+        code, _, stderr = _run(
+            [
+                "az",
+                "keyvault",
+                "delete",
+                "--name",
+                vault,
+                "--resource-group",
+                args.resource_group,
+            ]
+        )
+        if code != 0 and "not found" not in stderr.lower():
+            failures.append(f"key vault {vault}: {stderr.strip()}")
+            print(f"   ❌ {stderr.strip()}")
+        else:
+            # Soft-delete keeps the NAME reserved for 90 days, so without this
+            # the next rebuild of this environment fails on a name collision.
+            location = _run(
+                [
+                    "az",
+                    "group",
+                    "show",
+                    "--name",
+                    args.resource_group,
+                    "--query",
+                    "location",
+                    "--output",
+                    "tsv",
+                ]
+            )[1].strip()
+            code, _, stderr = _run(
+                ["az", "keyvault", "purge", "--name", vault, "--location", location]
+            )
+            if code != 0 and "not found" not in stderr.lower():
+                failures.append(
+                    f"key vault {vault} deleted but NOT purged — the name stays "
+                    f"reserved: {stderr.strip()}"
+                )
+                print(f"   ⚠  deleted but not purged: {stderr.strip()}")
+            else:
+                print(f"   deleted and purged: {vault}")
 
     if args.delete_blob_container and blob_container:
         print(f"\n🗑  Deleting blob container {blob_container}...")

--- a/docs/ops/async-generation.md
+++ b/docs/ops/async-generation.md
@@ -193,6 +193,23 @@ repointed, or the repointed app cannot start:
   Key Vault-backed secret values and refreshes on its own schedule. Plan
   rotations accordingly rather than expecting immediate effect.
 
+### Tearing an environment down
+
+`teardown_azure_environment.py` removes the container apps, and — when asked —
+the blob container and the Key Vault. Both destructive options are opt-in, and
+production is refused twice over: by environment name, and by the live app and
+vault names.
+
+```bash
+uv run python deploy/scripts/teardown_azure_environment.py \
+    --environment staging --yes --delete-blob-container --delete-key-vault
+```
+
+`--delete-key-vault` also **purges**. That is deliberate: a soft-deleted vault
+keeps its name reserved for 90 days, so a delete without a purge silently blocks
+the next rebuild of that environment with a name collision. Purging is
+irreversible, which is why it is opt-in.
+
 ### Leftovers
 
 The migration replaces secrets by name and touches nothing else, so a

--- a/tests/unit/test_staging_deploy.py
+++ b/tests/unit/test_staging_deploy.py
@@ -264,6 +264,43 @@ def test_teardown_without_yes_deletes_nothing():
     assert calls == []
 
 
+def test_teardown_refuses_the_production_vault():
+    """Deleting it takes every secret both live apps resolve at runtime, so they
+    stop starting. Guarded by name as well as by environment."""
+    code, calls = _run_teardown(
+        [
+            "--environment",
+            "staging",
+            "--vault-name",
+            "ohm-prod-kv",
+            "--delete-key-vault",
+            "--yes",
+        ]
+    )
+
+    assert code == 1
+    assert calls == []
+
+
+def test_teardown_keeps_the_vault_unless_explicitly_asked():
+    _, calls = _run_teardown(["--environment", "staging", "--yes"])
+
+    assert not any("keyvault" in command for command in calls)
+
+
+def test_teardown_purges_the_vault_it_deletes():
+    """A soft-deleted vault keeps its NAME reserved for 90 days, so a delete
+    without a purge silently blocks the next rebuild of this environment."""
+    _, calls = _run_teardown(
+        ["--environment", "staging", "--delete-key-vault", "--yes"]
+    )
+
+    verbs = [c[2] for c in calls if c[:2] == ["az", "keyvault"]]
+    assert "delete" in verbs, "expected the vault to be deleted"
+    assert "purge" in verbs, "a deleted-but-unpurged vault blocks the next rebuild"
+    assert verbs.index("delete") < verbs.index("purge")
+
+
 def test_teardown_keeps_blobs_unless_explicitly_asked():
     _, calls = _run_teardown(["--environment", "staging", "--yes"])
 


### PR DESCRIPTION
Closes a gap I introduced. Standing staging up for the Key Vault rehearsal added a resource the teardown did not know about, so tearing staging down **leaked the vault**. I removed that one by hand; the next person would not have known to.

## `--delete-key-vault` also purges

That is deliberate, not enthusiasm. A soft-deleted vault keeps its **name reserved for 90 days**, so deleting without purging silently blocks the next rebuild of the same environment with a name collision — the confusing kind of failure that costs an afternoon.

Purging is irreversible, so like the blob container it is opt-in, and the plan says so in those words before doing anything:

```
Blob container:   projdatablobstorage/staging  (DATA LOSS)
Key Vault:        ohm-staging-kv  (DELETED AND PURGED — irreversible)
```

## Production is now refused three ways

By environment name, by the live **app** names, and by the live **vault** name.

The vault guard matters most. Deleting an app is recoverable — it redeploys from the repo. Deleting `ohm-prod-kv` takes every secret both live apps resolve at runtime, and they stop starting.

Verified against the live subscription: the guard refuses `ohm-prod-kv`, and the production vault is still there afterwards.

## Tests

Three added, pinning the properties whose absence would bite:

- the production vault is refused, and **nothing** is executed
- the vault is kept unless explicitly asked for
- a deleted vault is **purged**, and in that order

`make ready` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
