### PR TITLE
Gate LLM auth on actual spend, and arm the flag

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 622
+Total Python files: 623
 
 ├── deploy/
 │   ├── __init__.py
@@ -812,7 +812,6 @@ Total Python files: 622
 │       │       │       def _matches_filters()
 │       │       ├── okh.py
 │       │       │       def _okh_success_response()
-│       │       │       def _enforce_llm_auth_if_required()
 │       │       │       def _enforce_generate_rate_limit()
 │       │       ├── okw.py
 │       │       ├── package.py
@@ -2690,6 +2689,11 @@ Total Python files: 622
         │       def test_both_apps_reference_the_same_secret_for_a_shared_value()
         │       def test_key_vault_names_are_valid()
         ├── test_layer_cascade.py
+        ├── test_llm_auth_gate.py
+        │       def _availability()
+        │       def _flag()
+        │       def test_production_arms_the_flag()
+        │       def _app()
         ├── test_llm_availability.py
         │       def _no_ambient_keys()
         │       def _stored()
@@ -3204,7 +3208,7 @@ Total Python files: 622
 
 ## Overview
 
-Total files analyzed: 622
+Total files analyzed: 623
 
 ## Entry Points
 
@@ -11140,6 +11144,20 @@ it cann...
 > Unit tests for evaluate_layers and evaluate_layers_supply_tree....
 
 **Internal Dependencies:** 2 imports
+
+### `tests/unit/test_llm_auth_gate.py`
+> Authentication is required only when a request would genuinely spend.
+
+The gate used to key off the ...
+
+**Exports:** test_production_arms_the_flag
+
+**Functions:**
+- `test_production_arms_the_flag()`
+  - Inert until a provider exists, protective the moment one does — which
+removes th...
+
+**Internal Dependencies:** 6 imports
 
 ### `tests/unit/test_llm_availability.py`
 > A key stored via Settings must actually reach generation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **LLM generation requires authentication once a provider is configured.**
+  `GENERATE_FROM_URL_REQUIRE_AUTH_FOR_LLM` gated on the request's *intent* — the
+  `no_llm` flag — rather than on whether an LLM was actually available. Since the
+  web UI always requests LLM-enabled generation, switching it on would have
+  rejected every generation to guard a cost that could not occur, which is why it
+  stayed off and the spend path stayed unguarded. It now fires only when a
+  request would genuinely invoke an LLM, on both the synchronous and async
+  endpoints, and is **armed in production** — inert while no provider is
+  configured, protective the moment an admin adds a credential, with no step to
+  remember at the moment it would be easiest to forget.
+
+
 ### Changed
 
 - **`make secrets-check` now checks what Key Vault made important.** It compared

--- a/config/environments/production.toml
+++ b/config/environments/production.toml
@@ -17,6 +17,16 @@ azure_storage_container = "production"
 # back to memory. See CACHE_BACKEND / CACHE_REDIS_URL in env.template.
 cache_backend = "redis"
 
+# Require authentication for generation that would actually invoke an LLM.
+#
+# Safe to have on before any provider is configured: the gate fires only when a
+# request would genuinely spend, so with no provider it is inert and anonymous
+# heuristic generation keeps working exactly as it does today. The moment an
+# admin adds a credential in Settings, the spend path is already guarded — which
+# removes the "remember to turn this on" step at precisely the moment it would
+# be easiest to forget.
+generate_from_url_require_auth_for_llm = true
+
 # Async generate-from-url, served by the Celery worker container app. Requires
 # JOB_BROKER_URL (minted as a secret by the deploy) and a running worker —
 # jobs_available() is the AND of the two. Rehearsed in staging first; see

--- a/src/core/api/routes/okh.py
+++ b/src/core/api/routes/okh.py
@@ -1107,24 +1107,45 @@ async def get_okh_from_storage(
         )
 
 
-def _enforce_llm_auth_if_required(
+async def _enforce_llm_auth_if_required(
     *,
     no_llm: bool,
     user: Optional[AuthenticatedUser],
 ) -> None:
-    """When configured, LLM-enabled generation requires a valid API key."""
+    """Require authentication only when a request would genuinely invoke an LLM.
+
+    This used to gate on the request's *intent* — the `no_llm` flag — rather than
+    on whether an LLM was actually available. The web UI always requests
+    LLM-enabled generation, so switching the setting on would have rejected every
+    generation in order to guard a cost that could not occur. That is why it
+    stayed off, and why the spend path stayed unguarded.
+
+    Availability is resolved here rather than reused from the generation call:
+    on the async path this runs in the API process while generation happens in
+    the worker, so there is nothing to reuse.
+    """
     from src.config.schema import get_settings
+
+    from ...llm.availability import resolve_llm_availability
 
     if no_llm or not get_settings().generate_from_url_require_auth_for_llm:
         return
-    if user is None:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=(
-                "LLM-enabled generation requires authentication. "
-                "Pass Authorization: Bearer <token>, or set no_llm=true."
-            ),
-        )
+    if user is not None:
+        return
+
+    availability = await resolve_llm_availability(requested=True)
+    if not availability.available:
+        # No provider, so no spend to protect. Refusing here would deny an
+        # anonymous user heuristic generation they are entitled to.
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail=(
+            "LLM-enabled generation requires authentication. "
+            "Pass Authorization: Bearer <token>, or set no_llm=true."
+        ),
+    )
 
 
 def _enforce_generate_rate_limit(http_request: Request) -> None:
@@ -1182,7 +1203,7 @@ async def generate_from_url(
     - Optional interactive review for field validation
     """
     _enforce_generate_rate_limit(http_request)
-    _enforce_llm_auth_if_required(no_llm=request.no_llm, user=user)
+    await _enforce_llm_auth_if_required(no_llm=request.no_llm, user=user)
     try:
         # Call service to generate manifest from URL or local path
         result = await okh_service.generate_from_url(
@@ -1225,7 +1246,7 @@ async def submit_generate_from_url_jobs(
     from src.core.jobs import generation_jobs
 
     _enforce_generate_rate_limit(http_request)
-    _enforce_llm_auth_if_required(no_llm=request.no_llm, user=user)
+    await _enforce_llm_auth_if_required(no_llm=request.no_llm, user=user)
 
     if not generation_jobs.jobs_available():
         raise HTTPException(

--- a/tests/unit/test_llm_auth_gate.py
+++ b/tests/unit/test_llm_auth_gate.py
@@ -1,0 +1,232 @@
+"""Authentication is required only when a request would genuinely spend.
+
+The gate used to key off the request's *intent* — the `no_llm` flag — rather
+than on whether an LLM was actually available. The web UI always requests
+LLM-enabled generation, so switching the setting on would have rejected every
+generation in order to guard a cost that could not occur. That is why it stayed
+off, and why the spend path stayed unguarded.
+
+Fixing the semantics is what makes arming the flag safe, which is why both ship
+together: separated, merging one without the other rejects every generation.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.core.api.routes.okh import _enforce_llm_auth_if_required
+from src.core.llm.availability import LLMAvailability, LLMUnavailableReason
+
+pytestmark = pytest.mark.unit
+
+_USER = object()  # any authenticated principal
+
+
+def _availability(available: bool):
+    value = (
+        LLMAvailability(available=True, provider="anthropic", source="credential_store")
+        if available
+        else LLMAvailability.unavailable(LLMUnavailableReason.NOT_CONFIGURED)
+    )
+    return patch(
+        "src.core.llm.availability.resolve_llm_availability",
+        AsyncMock(return_value=value),
+    )
+
+
+def _flag(enabled: bool):
+    from src.config.schema import Settings
+
+    return patch(
+        "src.config.schema.get_settings",
+        return_value=Settings(generate_from_url_require_auth_for_llm=enabled),
+    )
+
+
+# --- The bug: gating on intent rather than on spend --------------------------
+
+
+@pytest.mark.asyncio
+async def test_anonymous_generation_is_allowed_when_no_provider_is_configured():
+    """THE fix. The UI always asks for LLM, so the old gate would have rejected
+    every generation to protect a cost that cannot occur."""
+    with _flag(True), _availability(False):
+        await _enforce_llm_auth_if_required(no_llm=False, user=None)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_anonymous_generation_is_refused_once_a_provider_exists():
+    with _flag(True), _availability(True):
+        with pytest.raises(HTTPException) as raised:
+            await _enforce_llm_auth_if_required(no_llm=False, user=None)
+
+    assert raised.value.status_code == 401
+    assert "no_llm=true" in str(raised.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_an_authenticated_caller_proceeds():
+    with _flag(True), _availability(True):
+        await _enforce_llm_auth_if_required(no_llm=False, user=_USER)
+
+
+# --- Things that must never be gated -----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_opting_out_of_the_llm_is_never_refused():
+    """A heuristic-only request spends nothing, whoever asks for it."""
+    with _flag(True), _availability(True):
+        await _enforce_llm_auth_if_required(no_llm=True, user=None)
+
+
+@pytest.mark.asyncio
+async def test_the_flag_off_gates_nothing():
+    with _flag(False), _availability(True):
+        await _enforce_llm_auth_if_required(no_llm=False, user=None)
+
+
+@pytest.mark.asyncio
+async def test_availability_is_not_resolved_when_it_cannot_change_the_answer():
+    """An authenticated caller, an opt-out, or the flag off all short-circuit —
+    each avoids a credential-store read on a request that cannot be refused."""
+    for no_llm, user, flag in (
+        (True, None, True),
+        (False, _USER, True),
+        (False, None, False),
+    ):
+        resolver = AsyncMock()
+        with (
+            _flag(flag),
+            patch("src.core.llm.availability.resolve_llm_availability", resolver),
+        ):
+            await _enforce_llm_auth_if_required(no_llm=no_llm, user=user)
+        resolver.assert_not_awaited()
+
+
+# --- Armed in production, and safe to be ------------------------------------
+
+
+def test_production_arms_the_flag():
+    """Inert until a provider exists, protective the moment one does — which
+    removes the step someone would otherwise have to remember at exactly the
+    wrong moment."""
+    from src.config.schema import deploy_env_vars
+
+    assert deploy_env_vars("production")["GENERATE_FROM_URL_REQUIRE_AUTH_FOR_LLM"] == (
+        "True"
+    )
+
+
+# --- Through the actual routes -----------------------------------------------
+#
+# The checks above exercise the gate directly. These drive the real endpoints,
+# because "is the gate wired into both of them" is not something a unit test of
+# the gate can answer.
+
+
+def _app():
+    from fastapi import FastAPI
+
+    from src.core.main import api_v1
+
+    app = FastAPI()
+    app.mount("/v1", api_v1)
+    return app
+
+
+async def _post(path: str, body: dict):
+    """POST a route with everything AFTER the gate stubbed out.
+
+    The gate is the subject; whether Celery can reach a broker or the extractor
+    can reach GitHub is not, and letting either run would make this a network
+    test that fails for reasons unrelated to authentication.
+    """
+    import httpx
+
+    enqueued = MagicMock()
+    enqueued.id = "job-1"
+
+    with (
+        patch(
+            "src.core.jobs.generation_jobs.generate_from_url_task.delay",
+            return_value=enqueued,
+        ),
+        patch(
+            "src.core.services.okh_service.OKHService.generate_from_url",
+            AsyncMock(
+                return_value={"success": True, "manifest": {}, "quality_report": {}}
+            ),
+        ),
+    ):
+        transport = httpx.ASGITransport(app=_app())
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as client:
+            return await client.post(path, json=body)
+
+
+_LLM_REQUEST = {"urls": ["https://github.com/octocat/Hello-World"], "no_llm": False}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/v1/api/okh/generate-from-url/jobs",
+        "/v1/api/okh/generate-from-url",
+    ],
+)
+async def test_both_routes_refuse_anonymous_llm_generation_when_a_provider_exists(
+    path, monkeypatch
+):
+    monkeypatch.setenv("GENERATE_FROM_URL_REQUIRE_AUTH_FOR_LLM", "true")
+    monkeypatch.setenv("JOBS_ENABLED", "true")
+    monkeypatch.setenv("JOB_BROKER_URL", "memory://")
+
+    body = (
+        _LLM_REQUEST
+        if "jobs" in path
+        else {**_LLM_REQUEST, "url": _LLM_REQUEST["urls"][0]}
+    )
+    with _availability(True):
+        response = await _post(path, body)
+
+    assert response.status_code == 401, response.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/v1/api/okh/generate-from-url/jobs",
+        "/v1/api/okh/generate-from-url",
+    ],
+)
+async def test_both_routes_allow_anonymous_generation_with_no_provider(
+    path, monkeypatch
+):
+    """The armed flag must be inert until a credential exists, or production
+    rejects every generation the moment this ships."""
+    monkeypatch.setenv("GENERATE_FROM_URL_REQUIRE_AUTH_FOR_LLM", "true")
+    monkeypatch.setenv("JOBS_ENABLED", "true")
+    monkeypatch.setenv("JOB_BROKER_URL", "memory://")
+
+    body = (
+        _LLM_REQUEST
+        if "jobs" in path
+        else {**_LLM_REQUEST, "url": _LLM_REQUEST["urls"][0]}
+    )
+    with _availability(False):
+        response = await _post(path, body)
+
+    assert response.status_code != 401, response.text


### PR DESCRIPTION
Closes #316 — the last of the original four LLM issues.

## The bug

`GENERATE_FROM_URL_REQUIRE_AUTH_FOR_LLM` gated on the request's **intent** — the `no_llm` flag — rather than on whether an LLM was actually available.

The web UI always requests LLM-enabled generation. So switching the setting on would have rejected **every** generation, in order to guard a cost that could not occur. That is why it stayed off, and why the spend path stayed unguarded.

## The fix

It now fires only when a request would genuinely invoke an LLM, on both the synchronous endpoint and async job submission.

Availability is resolved *in the gate* rather than reused from the generation call. On the async path the gate runs in the API process while generation happens in the worker, so there is nothing to reuse. It short-circuits before that read whenever the answer cannot change — authenticated caller, explicit opt-out, or flag off — so no request pays for a credential-store read that cannot refuse it.

## Armed in production, in the same change

Deliberately together: arming the flag is only safe **because** the semantics are fixed. Separated, merging one without the other rejects every generation.

With no provider configured it is inert, and anonymous heuristic generation is untouched — which is production's state today. The moment an admin adds a credential in Settings, the spend path is already guarded. That removes the step someone would otherwise have to remember at exactly the moment it would be easiest to forget.

| State | Anonymous LLM request |
|---|---|
| No provider configured | allowed (nothing to spend) |
| Provider configured | **401**, with how to proceed |
| `no_llm=true` | always allowed |
| Flag off | always allowed |

## Verification

Restoring the old intent-based gate fails **three** tests, including both route-level ones.

Two notes on the tests. They drive the **real endpoints**, because "is the gate wired into both of them" is not a question a unit test of the gate can answer — an earlier draft counted call sites in the module source, which would have passed on a commented-out line. And they stub everything *after* the gate: without that, the allowed-path test failed on Celery's `memory://` transport rather than on anything to do with authentication, which would have been a confusing red herring for whoever hit it next.

`make ready` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
