### PR TITLE
Stop deploys from overwriting Key Vault references

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -47,6 +47,7 @@ Total Python files: 623
 │   │   │   │       def secret_refs_for()
 │   │   │   │       def container_app_secrets()
 │   │   │   │       def secret_env_vars()
+│   │   │   │       def write_secret_to_vault()
 │   │   │   └── redis_secrets.py
 │   │   │           class RedisConfigError
 │   │   │           def _redis_url()
@@ -489,6 +490,7 @@ Total Python files: 623
 │   │   │       def enforce_startup_config()
 │   │   │       def _secret_field_names()
 │   │   │       def deploy_env_vars()
+│   │   │       def key_vault_name()
 │   │   │       def redis_deploy_config()
 │   │   │       def worker_deploy_config()
 │   │   │       def worker_deploy_env_vars()
@@ -2688,6 +2690,9 @@ Total Python files: 623
         │       def test_the_worker_gets_the_secrets_it_actually_needs()
         │       def test_both_apps_reference_the_same_secret_for_a_shared_value()
         │       def test_key_vault_names_are_valid()
+        │       def _worker_deploy()
+        │       def test_the_worker_deploy_writes_references_never_values()
+        │       def test_the_worker_deploy_no_longer_copies_secrets_from_the_api_app()
         ├── test_layer_cascade.py
         ├── test_llm_auth_gate.py
         │       def _availability()
@@ -3162,7 +3167,8 @@ Total Python files: 623
         │       def test_staging_holds_no_secrets()
         │       def _run_backend_deploy()
         │       def _app_command()
-        │       def test_production_deploy_is_unchanged_without_the_mirror_flag()
+        │       def test_production_deploy_writes_references_never_values()
+        │       def test_production_deploy_mints_redis_urls_into_the_vault_not_onto_the_app()
         │       def test_mirroring_wires_both_the_values_and_the_env_refs()
         │       def test_mirroring_reads_from_the_named_source_app()
         │       def _run_teardown()
@@ -6024,7 +6030,7 @@ This module provides the Azure Container Apps deplo...
 - `DeploymentError` (inherits: Exception)
   - Raised when deployment operations fail....
 - `AzureContainerAppsDeployer` (inherits: BaseDeployer)
-  - Methods: fetch_redis_access_key, read_secret, set_secrets, setup, deploy
+  - Methods: fetch_redis_access_key, read_secret, write_vault_secret, set_secrets, setup
   - Azure Container Apps deployer implementation....
 
 ### `deploy/providers/azure/key_vault.py`
@@ -6092,7 +6098,7 @@ This script uses the Azure deployer to update th...
 - `main()`
   - Deploy to Azure Container Apps....
 
-**Internal Dependencies:** 2 imports
+**Internal Dependencies:** 3 imports
 
 ### `deploy/scripts/deploy_azure_frontend.py`
 > Deploy the OHM **frontend** container to Azure Container Apps.
@@ -6118,7 +6124,7 @@ The worker runs the SAME image ...
 - `main()`
   - Deploy the Celery worker to Azure Container Apps....
 
-**Internal Dependencies:** 3 imports
+**Internal Dependencies:** 4 imports
 
 ### `deploy/scripts/deploy_gcp.py`
 > Manual deployment script for GCP Cloud Run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Deploys no longer overwrite Key Vault references with inline values.** After
+  the migration, both deploy scripts still minted Redis URLs and mirrored shared
+  secrets as *values*, and setting a secret by name replaces a Key Vault
+  reference — so the next release would have succeeded, kept working, and
+  silently undone the migration on an inline copy. Where an environment declares
+  `key_vault_name`, the deploys now write references only, mint the Redis URLs
+  *into the vault*, and stop copying secrets between apps entirely. Environments
+  without a vault are unchanged.
+
+
 ### Security
 
 - **LLM generation requires authentication once a provider is configured.**

--- a/config/environments/production.toml
+++ b/config/environments/production.toml
@@ -38,6 +38,11 @@ jobs_enabled = true
 gunicorn_workers = "1"
 gunicorn_timeout = "300"
 
+# Key Vault holding this environment's secrets. Each value lives here once and
+# both container apps hold a reference resolved through their managed identity,
+# so the deploy never writes a secret VALUE onto an app.
+key_vault_name = "ohm-prod-kv"
+
 # Azure Cache for Redis backing BOTH the catalogue cache and the Celery broker,
 # split by database (0=cache, 1=broker, 2=results) — the same split
 # docker-compose.yml uses.

--- a/deploy/providers/azure/container_apps.py
+++ b/deploy/providers/azure/container_apps.py
@@ -193,6 +193,19 @@ class AzureContainerAppsDeployer(BaseDeployer):
             )
         return stdout.strip()
 
+    def write_vault_secret(self, vault_name: str, name: str, value: str) -> None:
+        """Store a value in Key Vault. Logs the NAME only, never the value."""
+        from .key_vault import write_secret_to_vault
+
+        logger.info("Writing %s to Key Vault %s", name, vault_name)
+        exit_code, _, stderr = self._run_az_command(
+            write_secret_to_vault(vault_name, name, value), check=False
+        )
+        if exit_code != 0:
+            raise DeploymentError(
+                f"Failed to write {name!r} to Key Vault {vault_name!r}: {stderr}"
+            )
+
     def set_secrets(self, secrets: Dict[str, str]) -> None:
         """Set Container App secrets, logging their NAMES only, never values.
 

--- a/deploy/providers/azure/key_vault.py
+++ b/deploy/providers/azure/key_vault.py
@@ -108,3 +108,19 @@ def secret_env_vars(*, worker: bool = False) -> Dict[str, str]:
         env_var: f"secretref:{name}"
         for env_var, name in secret_refs_for(worker=worker).items()
     }
+
+
+def write_secret_to_vault(vault_name: str, secret_name: str, value: str) -> list:
+    """``az`` argv that stores one value in the vault. Never log it."""
+    return [
+        "az",
+        "keyvault",
+        "secret",
+        "set",
+        "--vault-name",
+        vault_name,
+        "--name",
+        secret_name,
+        "--value",
+        value,
+    ]

--- a/deploy/scripts/deploy_azure.py
+++ b/deploy/scripts/deploy_azure.py
@@ -29,11 +29,15 @@ from deploy.providers.azure.app_secrets import (
     mirrored_secret_env_vars,
     mirrored_secret_names,
 )
+from deploy.providers.azure.key_vault import (
+    container_app_secrets,
+    secret_env_vars as vault_secret_env_vars,
+)
 from deploy.providers.azure.redis_secrets import (
     build_redis_secret_values,
     redis_secret_env_vars,
 )
-from src.config.schema import deploy_env_vars, redis_deploy_config
+from src.config.schema import deploy_env_vars, key_vault_name, redis_deploy_config
 
 logging.basicConfig(
     level=logging.INFO,
@@ -166,9 +170,13 @@ def main():
     if redis_config:
         environment_vars.update(redis_secret_env_vars())
 
-    # Standing up a new environment: the target app has no secrets yet, so it
-    # needs both the values (mirrored below) and the env vars pointing at them.
-    if args.mirror_secrets_from:
+    # With a vault, every secret env var points at a reference and the deploy
+    # never handles a value. Without one, standing up a new environment still
+    # needs the values mirrored from an established app.
+    vault = key_vault_name(args.environment)
+    if vault:
+        environment_vars.update(vault_secret_env_vars())
+    elif args.mirror_secrets_from:
         environment_vars.update(mirrored_secret_env_vars(include_api_keys=True))
 
     print("=" * 80)
@@ -223,7 +231,12 @@ def main():
         # them — a secretRef to a secret that does not exist yet fails.
         secrets = {}
 
-        if args.mirror_secrets_from:
+        if vault:
+            # References, not values. Setting a value here would REPLACE the
+            # Key Vault reference on the app and silently undo the migration —
+            # the deploy would succeed and the app would work, on a copy.
+            secrets.update(container_app_secrets(vault))
+        elif args.mirror_secrets_from:
             print(f"\n🔑 Mirroring shared secrets from {args.mirror_secrets_from!r}")
             secrets.update(
                 {
@@ -239,7 +252,13 @@ def main():
                 f"{redis_config['broker_db']}, results db {redis_config['results_db']})"
             )
             access_key = deployer.fetch_redis_access_key(redis_config["resource_name"])
-            secrets.update(build_redis_secret_values(redis_config, access_key))
+            minted = build_redis_secret_values(redis_config, access_key)
+            if vault:
+                # The value belongs in the vault; the app already references it.
+                for name, url in minted.items():
+                    deployer.write_vault_secret(vault, name, url)
+            else:
+                secrets.update(minted)
         else:
             print(
                 f"\nℹ️  No [redis] table for environment {args.environment!r}; "

--- a/deploy/scripts/deploy_azure_worker.py
+++ b/deploy/scripts/deploy_azure_worker.py
@@ -40,11 +40,16 @@ from deploy.providers.azure.app_secrets import (
     mirrored_secret_env_vars,
     mirrored_secret_names,
 )
+from deploy.providers.azure.key_vault import (
+    container_app_secrets,
+    secret_env_vars as vault_secret_env_vars,
+)
 from deploy.providers.azure.redis_secrets import (
     build_redis_secret_values,
     redis_secret_env_vars,
 )
 from src.config.schema import (
+    key_vault_name,
     redis_deploy_config,
     worker_deploy_config,
     worker_deploy_env_vars,
@@ -160,10 +165,17 @@ def main():
     # VALUE is ever applied as an env var.
     environment_vars = worker_deploy_env_vars(args.environment)
     environment_vars["ENVIRONMENT"] = args.environment
-    environment_vars.update(mirrored_secret_env_vars())
+
+    # With a vault, the worker references the same secrets the API does — one
+    # value, two pointers — so there is nothing to mirror and no value to hold.
+    vault = key_vault_name(args.environment)
+    if vault:
+        environment_vars.update(vault_secret_env_vars(worker=True))
+    else:
+        environment_vars.update(mirrored_secret_env_vars())
 
     redis_config = redis_deploy_config(args.environment)
-    if redis_config:
+    if redis_config and not vault:
         environment_vars.update(redis_secret_env_vars())
 
     print("=" * 80)
@@ -184,7 +196,11 @@ def main():
         # Resolve secret VALUES before building the config: the deployer sets
         # them ahead of an update, or passes them inline when creating the app
         # (which cannot have secrets set on it before it exists).
-        print(f"\n🔑 Mirroring shared secrets from {args.api_container_app_name!r}")
+        if not vault:
+            print(
+                f"\n🔑 Mirroring shared secrets from "
+                f"{args.api_container_app_name!r}"
+            )
         probe = AzureContainerAppsDeployer(
             AzureDeploymentConfig.from_dict(
                 {
@@ -201,11 +217,17 @@ def main():
                 }
             )
         )
-        secrets = {
-            name: probe.read_secret(name, app_name=args.api_container_app_name)
-            for name in mirrored_secret_names()
-        }
-        if redis_config:
+        if vault:
+            # References only. Mirroring a VALUE here would replace the app's
+            # Key Vault reference and quietly recreate the duplicate copies the
+            # vault exists to remove.
+            secrets = container_app_secrets(vault, worker=True)
+        else:
+            secrets = {
+                name: probe.read_secret(name, app_name=args.api_container_app_name)
+                for name in mirrored_secret_names()
+            }
+        if redis_config and not vault:
             print(f"🔑 Minting Redis secrets from {redis_config['resource_name']!r}")
             access_key = probe.fetch_redis_access_key(redis_config["resource_name"])
             secrets.update(build_redis_secret_values(redis_config, access_key))

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -422,6 +422,20 @@ def deploy_env_vars(environment: str) -> Dict[str, str]:
     return env_vars
 
 
+def key_vault_name(environment: str) -> Optional[str]:
+    """Key Vault holding ``<environment>``'s secrets, or None if it has none.
+
+    When set, the deploy writes secret REFERENCES rather than values: each value
+    lives once in the vault and both apps resolve it through their managed
+    identity. Without this the deploy would set inline values and silently undo
+    that.
+    """
+    path = _CONFIG_ENV_DIR / f"{environment}.toml"
+    if not path.is_file():
+        return None
+    return tomllib.loads(path.read_text(encoding="utf-8")).get("key_vault_name")
+
+
 def redis_deploy_config(environment: str) -> Dict[str, Any]:
     """Non-secret Redis coordinates for ``<environment>``'s deploy.
 

--- a/tests/unit/test_key_vault_secrets.py
+++ b/tests/unit/test_key_vault_secrets.py
@@ -144,3 +144,66 @@ def test_key_vault_names_are_valid():
 
     for name in KEY_VAULT_SECRET_REFS.values():
         assert re.fullmatch(r"[A-Za-z0-9-]+", name), name
+
+
+# --- The deploy must not undo the migration ----------------------------------
+#
+# The failure this guards is silent: setting a secret VALUE replaces the app's
+# Key Vault reference, the deploy succeeds, the app keeps working on an inline
+# copy, and the duplicated secrets the vault removed quietly come back.
+
+
+def _worker_deploy(record):
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "_worker_deploy_kv",
+        _REPO_ROOT / "deploy" / "scripts" / "deploy_azure_worker.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    from unittest.mock import MagicMock, patch
+
+    def _run(command, capture_output, text, check):
+        record.append(command)
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = "value-or-key"
+        result.stderr = ""
+        return result
+
+    argv = [
+        "deploy_azure_worker.py",
+        "--image",
+        "img@sha256:abc",
+        "--subscription-id",
+        "sub",
+        "--environment",
+        "production",
+    ]
+    with (
+        patch.object(sys, "argv", argv),
+        patch("deploy.providers.azure.container_apps.subprocess.run", side_effect=_run),
+    ):
+        return module.main()
+
+
+def test_the_worker_deploy_writes_references_never_values():
+    calls = []
+    assert _worker_deploy(calls) == 0
+
+    for command in calls:
+        if command[:4] == ["az", "containerapp", "secret", "set"]:
+            for token in command[command.index("--secrets") + 1 :]:
+                assert "keyvaultref:" in token, token
+
+
+def test_the_worker_deploy_no_longer_copies_secrets_from_the_api_app():
+    """One value with two references has nothing to mirror."""
+    calls = []
+    assert _worker_deploy(calls) == 0
+
+    assert not any(
+        c[:4] == ["az", "containerapp", "secret", "show"] for c in calls
+    ), "the worker deploy should not read the API app's secret values"

--- a/tests/unit/test_staging_deploy.py
+++ b/tests/unit/test_staging_deploy.py
@@ -139,17 +139,54 @@ def _app_command(calls):
     )
 
 
-def test_production_deploy_is_unchanged_without_the_mirror_flag():
-    """The established app is its own source of truth; never re-write its secrets."""
+def test_production_deploy_writes_references_never_values():
+    """Production has a vault, so the deploy must never handle a secret VALUE.
+
+    Writing one would REPLACE the app's Key Vault reference — the deploy would
+    succeed, the app would keep working on an inline copy, and the migration
+    would be silently undone.
+    """
     calls = []
     assert _run_backend_deploy(calls, ["--environment", "production"]) == 0
 
     command = _app_command(calls)
     env_tokens = command[command.index("--set-env-vars") + 1 :]
 
+    # Env vars name secrets; they never carry one.
+    for token in env_tokens:
+        if token.startswith(
+            ("API_KEYS=", "AZURE_STORAGE_KEY=", "GITHUB_ACCESS_TOKEN=")
+        ):
+            assert token.split("=", 1)[1].startswith("secretref:"), token
+
+    # And the secrets set on the app are vault references.
+    secrets_index = command.index("--secrets") if "--secrets" in command else None
+    if secrets_index is not None:
+        for token in command[secrets_index + 1 :]:
+            if token.startswith("--"):
+                break
+            assert "keyvaultref:" in token, token
+
+    # Nothing reads another app's secret value to copy it.
     assert not any(c[:4] == ["az", "containerapp", "secret", "show"] for c in calls)
-    assert not any(token.startswith("API_KEYS=") for token in env_tokens)
-    assert not any(token.startswith("AZURE_STORAGE_KEY=") for token in env_tokens)
+
+
+def test_production_deploy_mints_redis_urls_into_the_vault_not_onto_the_app():
+    """The generator still runs every deploy; its output goes to the vault."""
+    calls = []
+    assert _run_backend_deploy(calls, ["--environment", "production"]) == 0
+
+    vault_writes = [c for c in calls if c[:4] == ["az", "keyvault", "secret", "set"]]
+    written = {c[c.index("--name") + 1] for c in vault_writes}
+
+    assert {"job-broker-url", "job-result-backend", "cache-redis-url"} <= written
+
+    # The URL itself must never be set as an app secret.
+    app_secret_sets = [
+        c for c in calls if c[:4] == ["az", "containerapp", "secret", "set"]
+    ]
+    for command in app_secret_sets:
+        assert not any("rediss://" in token for token in command), command
 
 
 def test_mirroring_wires_both_the_values_and_the_env_refs():


### PR DESCRIPTION
Refs #317. **Merge before the next release** — without it, that release silently undoes the Key Vault migration.

## The problem

#317 moved production's secrets into Key Vault, but left both deploy scripts writing secret **values**: `deploy_azure.py` minted the Redis URLs and mirrored the shared secrets onto the apps.

`az containerapp secret set name=value` **replaces** a Key Vault reference with an inline value. So the next deploy would have:

- succeeded,
- left both apps working,
- and put production back on duplicated inline copies.

No error, no outage, nothing to notice — except `make secrets-check`, which would have reported `inline on both — not vault-backed`. That is the only thing that would have caught it, and only if someone ran it.

## The fix

Where an environment declares `key_vault_name`, the deploys now:

- set secret **references** on the apps, never values;
- mint the Redis URLs **into the vault**, where the app already points;
- stop mirroring between apps entirely — one value with two references has nothing to copy.

Environments without a vault are unchanged, so standing up a fresh self-host environment still works the old way.

The vault name sits on the config surface beside the storage target and Redis coordinates, so it is declared per environment rather than passed at a call site and forgotten.

## About one changed test

`test_production_deploy_is_unchanged_without_the_mirror_flag` asserted the production deploy applies no `API_KEYS` env var. It now applies one — as `secretref:api-key`, a pointer.

Its intent was *"the established app is its own source of truth; never re-write its secret values"*, and that intent still holds. So it was rewritten to assert it directly — env vars carry `secretref:`, app secrets carry `keyvaultref:`, and nothing reads another app's secret value — rather than deleted for being inconvenient.

## Verification

Restoring the value-writing behaviour fails the test asserting Redis URLs are minted into the vault. Two further tests cover the worker side: it writes references only, and no longer reads the API app's secrets at all.

`make ready` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
