### PR TITLE
Rename the misspelt gihub-token secret

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -2688,6 +2688,7 @@ Total Python files: 623
         │       def test_the_worker_gets_the_secrets_it_actually_needs()
         │       def test_both_apps_reference_the_same_secret_for_a_shared_value()
         │       def test_key_vault_names_are_valid()
+        │       def test_the_github_secret_name_is_spelled_correctly()
         ├── test_layer_cascade.py
         ├── test_llm_auth_gate.py
         │       def _availability()

--- a/deploy/providers/azure/app_secrets.py
+++ b/deploy/providers/azure/app_secrets.py
@@ -16,12 +16,10 @@ from typing import Dict
 
 # Container env var -> the Container App secret holding its value. The same
 # names are used on both apps so the two are comparable secret-for-secret.
-#
-# NB `gihub-token` is missing a 't'. That is the real name of the live secret;
-# correcting it is a separate change that must rename on both apps at once.
+
 MIRRORED_SECRET_ENV_REFS: Dict[str, str] = {
     "AZURE_STORAGE_KEY": "azure-storage-key",
-    "GITHUB_ACCESS_TOKEN": "gihub-token",
+    "GITHUB_ACCESS_TOKEN": "github-token",
     "GITLAB_ACCESS_TOKEN": "gitlab-token",
     # Required by ANY app that imports src.config with ENVIRONMENT=production —
     # settings.py builds LLMConfigManager at import time, and CredentialManager

--- a/deploy/providers/azure/key_vault.py
+++ b/deploy/providers/azure/key_vault.py
@@ -30,15 +30,13 @@ MAX_SECRET_NAME_LENGTH = 20
 # Env var -> Key Vault secret name. These are the values both apps need, each
 # stored once. Key Vault secret names allow only alphanumerics and dashes.
 #
-# NB two names carry history:
-#   * `gihub-token` is missing a 't' — the real name of the live secret. It is
-#     renamed by a separate change, deliberately not bundled here.
+# NB one name carries history:
 #   * `llm-encrypt-password` was `llm-encryption-password` (23 chars), which
 #     exceeds the limit above. The ENV VAR name is unchanged; only the secret's
 #     name moves, so nothing in the application sees a difference.
 KEY_VAULT_SECRET_REFS: Dict[str, str] = {
     "AZURE_STORAGE_KEY": "azure-storage-key",
-    "GITHUB_ACCESS_TOKEN": "gihub-token",
+    "GITHUB_ACCESS_TOKEN": "github-token",
     "GITLAB_ACCESS_TOKEN": "gitlab-token",
     "LLM_ENCRYPTION_SALT": "llm-encryption-salt",
     "LLM_ENCRYPTION_PASSWORD": "llm-encrypt-password",

--- a/docs/ops/async-generation.md
+++ b/docs/ops/async-generation.md
@@ -210,6 +210,21 @@ keeps its name reserved for 90 days, so a delete without a purge silently blocks
 the next rebuild of that environment with a name collision. Purging is
 irreversible, which is why it is opt-in.
 
+### Renaming a secret
+
+Do it additively, in this order, because an app that resolves the wrong name
+does not fail loudly — a missing GitHub token just means anonymous cloning, and
+anonymous rate limits look like intermittent 429s during generation.
+
+1. Create the new secret in the vault with the same value; confirm the digests
+   match before going further.
+2. Change the name in the deploy constants.
+3. Deploy. Both apps gain a reference to the new name and their env vars follow.
+4. Verify, then delete the old vault secret and the leftover app secrets.
+
+The old secret stays resolvable throughout, so there is no window where an app
+is pointed at something that does not exist.
+
 ### Leftovers
 
 The migration replaces secrets by name and touches nothing else, so a

--- a/tests/unit/test_azure_worker_deploy.py
+++ b/tests/unit/test_azure_worker_deploy.py
@@ -94,10 +94,13 @@ def test_worker_carries_storage_key_and_both_git_tokens():
 
 
 def test_mirrored_names_match_the_live_secret_names():
-    """`gihub-token` is missing a 't' in the live app; renaming is separate work."""
+    """The GitHub secret was `gihub-token` — missing a 't' — until it was
+    renamed. Getting this wrong drops the worker to anonymous GitHub rate
+    limits, which surfaces as confusing 429s during generation rather than as
+    an obvious failure."""
     assert mirrored_secret_names() == [
         "azure-storage-key",
-        "gihub-token",
+        "github-token",
         "gitlab-token",
         "llm-encryption-password",
         "llm-encryption-salt",
@@ -194,7 +197,7 @@ def test_worker_creates_with_secrets_inline_because_the_app_does_not_exist_yet()
         for token in command[command.index("--secrets") + 1 :]
         if "=" in token and not token.startswith("--")
     }
-    assert {"azure-storage-key", "gihub-token", "gitlab-token"} <= secret_names
+    assert {"azure-storage-key", "github-token", "gitlab-token"} <= secret_names
     assert {"job-broker-url", "job-result-backend"} <= secret_names
 
 
@@ -328,7 +331,7 @@ def test_detects_a_secret_left_inline_on_one_app():
 
 def test_detects_a_shared_secret_missing_from_the_worker():
     secrets = _all_vault_backed()
-    del secrets["openhardwaremanager-worker"]["gihub-token"]
+    del secrets["openhardwaremanager-worker"]["github-token"]
 
     code, _ = _run_verifier(secrets)
     assert code == 1

--- a/tests/unit/test_key_vault_secrets.py
+++ b/tests/unit/test_key_vault_secrets.py
@@ -144,3 +144,14 @@ def test_key_vault_names_are_valid():
 
     for name in KEY_VAULT_SECRET_REFS.values():
         assert re.fullmatch(r"[A-Za-z0-9-]+", name), name
+
+
+def test_the_github_secret_name_is_spelled_correctly():
+    """It was `gihub-token` — missing a 't' — in the vault and on both apps.
+
+    Pinned because the failure mode is quiet: a wrong name means the worker
+    clones anonymously, and anonymous GitHub rate limits surface as intermittent
+    429s during generation rather than as an obvious misconfiguration.
+    """
+    assert KEY_VAULT_SECRET_REFS["GITHUB_ACCESS_TOKEN"] == "github-token"
+    assert "gihub-token" not in KEY_VAULT_SECRET_REFS.values()


### PR DESCRIPTION
Closes #319. **Merge after #335** — that PR is what makes deploys write references from these constants.

The GitHub token secret was `gihub-token`, missing a 't'. Cosmetic, but it had spread: the vault, both container apps, two deploy constants, and several tests. Every future reader had to work out whether it was a typo or a real name.

## Done additively, because the failure is quiet

An app resolving the wrong secret name does not crash. It clones GitHub **anonymously**, and anonymous rate limits surface as intermittent 429s during generation — a misconfiguration that looks like someone else's outage.

So nothing is ever pointed at a name that does not exist:

1. **Done** — the vault now holds `github-token` with the same value, alongside the old name. Verified by comparing digests rather than assuming the copy worked:
   ```
   gihub-token   86342eabb673
   github-token  86342eabb673   → identical
   ```
2. **This PR** — the deploy constants name the new secret.
3. **Next deploy** — both apps gain a reference to `github-token` and their env vars follow, automatically.
4. **Later** — delete `gihub-token` from the vault and the leftover app secrets.

Step 4 is deliberately **not** in this PR. The old name has to stay resolvable until the deploy that switches over has actually run; deleting it now would create exactly the window this ordering avoids.

## Also

A test pins the correct spelling, with the reason — a name that looks like a typo invites someone to "fix" it back.

The ops guide gains the rename ordering, since the next one will hit the same trap.

`make ready` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
