### PR TITLE
Make LLM tests independent of the machine's credentials

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -1942,6 +1942,7 @@ Total Python files: 623
     │   │       def _get_app()
     │   ├── test_okh_generate_jobs.py
     │   │       def _get_app()
+    │   │       def _llm_available()
     │   ├── test_okw_create_route.py
     │   │       def _get_app()
     │   ├── test_package_build_response.py
@@ -1995,6 +1996,7 @@ Total Python files: 623
     ├── conftest.py
     │       def _lane_for_path()
     │       def pytest_collection_modifyitems()
+    │       def _no_ambient_llm_credentials()
     │       def _block_external_network()
     │       def pytest_runtest_makereport()
     ├── data/
@@ -9683,7 +9685,7 @@ Regression: OKHResponse s...
 ### `tests/api/test_okh_generate_jobs.py`
 > Contract tests for async generate-from-url jobs....
 
-**Internal Dependencies:** 2 imports
+**Internal Dependencies:** 4 imports
 
 ### `tests/api/test_okw_create_route.py`
 > Contract test for POST /api/okw/create.

--- a/tests/api/test_okh_generate_jobs.py
+++ b/tests/api/test_okh_generate_jobs.py
@@ -153,23 +153,77 @@ async def test_submit_jobs_rate_limited(monkeypatch):
     assert second.status_code == 429, second.text
 
 
+def _llm_available(available: bool):
+    """Control whether an LLM would run, instead of inheriting the machine's."""
+    from src.core.llm.availability import LLMAvailability, LLMUnavailableReason
+
+    value = (
+        LLMAvailability(available=True, provider="anthropic", source="credential_store")
+        if available
+        else LLMAvailability.unavailable(LLMUnavailableReason.NOT_CONFIGURED)
+    )
+    from unittest.mock import AsyncMock
+
+    return patch(
+        "src.core.llm.availability.resolve_llm_availability",
+        AsyncMock(return_value=value),
+    )
+
+
 @pytest.mark.asyncio
 @pytest.mark.contract
-async def test_llm_generation_requires_auth_when_flag_set(monkeypatch):
+async def test_llm_generation_requires_auth_when_a_provider_is_configured(monkeypatch):
+    """The gate fires on actual spend, not on the request asking for an LLM."""
     monkeypatch.setenv("GENERATE_FROM_URL_REQUIRE_AUTH_FOR_LLM", "true")
     monkeypatch.setenv("JOBS_ENABLED", "true")
     monkeypatch.setenv("JOB_BROKER_URL", "redis://redis:6379/1")
 
     app, _ = _get_app()
     transport = httpx.ASGITransport(app=app)
-    async with httpx.AsyncClient(
-        transport=transport, base_url="http://testserver"
-    ) as client:
-        resp = await client.post(
-            "/v1/api/okh/generate-from-url/jobs",
-            json={"urls": ["https://github.com/a/one"], "no_llm": False},
-        )
+    with _llm_available(True):
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as client:
+            resp = await client.post(
+                "/v1/api/okh/generate-from-url/jobs",
+                json={"urls": ["https://github.com/a/one"], "no_llm": False},
+            )
     assert resp.status_code == 401, resp.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_llm_generation_is_not_gated_without_a_provider(monkeypatch):
+    """With nothing to spend, an anonymous caller keeps its heuristic-only run.
+
+    This is the case the previous version of this test got wrong: it asserted
+    401 whenever the flag was set, which passed on a machine that happened to
+    have an API key and failed in CI, which has none.
+    """
+    monkeypatch.setenv("GENERATE_FROM_URL_REQUIRE_AUTH_FOR_LLM", "true")
+    monkeypatch.setenv("JOBS_ENABLED", "true")
+    monkeypatch.setenv("JOB_BROKER_URL", "redis://redis:6379/1")
+
+    enqueued = MagicMock()
+    enqueued.id = "job-222"
+
+    app, _ = _get_app()
+    transport = httpx.ASGITransport(app=app)
+    with (
+        _llm_available(False),
+        patch(
+            "src.core.jobs.generation_jobs.generate_from_url_task.delay",
+            return_value=enqueued,
+        ),
+    ):
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as client:
+            resp = await client.post(
+                "/v1/api/okh/generate-from-url/jobs",
+                json={"urls": ["https://github.com/a/one"], "no_llm": False},
+            )
+    assert resp.status_code != 401, resp.text
 
 
 @pytest.mark.asyncio

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,50 @@ def pytest_collection_modifyitems(
             item.add_marker(getattr(pytest.mark, lane))
 
 
+# Provider credentials a developer commonly has in .env, and which must not
+# change what a test asserts. `load_dotenv` repopulates these from the project
+# .env whatever the shell says, so clearing them here is the only reliable way.
+_AMBIENT_LLM_CREDENTIALS = (
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "AWS_BEDROCK_API_KEY",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "LLM_DEFAULT_PROVIDER",
+    "OLLAMA_BASE_URL",
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_llm_credentials(
+    request: pytest.Request, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Make LLM behaviour independent of whether the machine has an API key.
+
+    Whether an LLM is available changes real behaviour — which layers run, and
+    whether the auth gate fires — so a test that reads ambient credentials
+    asserts something different on a laptop with a key than in CI without one.
+
+    That is not hypothetical: a contract test asserting generation returns 401
+    passed locally and failed in CI for exactly this reason. It was green
+    because the developer had a key, not because the code was right.
+
+    Set to empty rather than deleted, deliberately: `load_dotenv` is called at
+    module import, imports happen lazily inside tests, and it repopulates any
+    variable that is ABSENT — so deleting them is undone the first time a test
+    imports a config module. It leaves a variable that already exists alone,
+    even an empty one, and the code treats empty as unset.
+
+    Tests that want a credential set one themselves; monkeypatch runs after this
+    fixture, so setting one still works. Tests marked ``llm`` deliberately use a
+    real provider and are left alone.
+    """
+    if request.node.get_closest_marker("llm"):
+        return
+    for name in _AMBIENT_LLM_CREDENTIALS:
+        monkeypatch.setenv(name, "")
+
+
 @pytest.fixture(autouse=True)
 def _block_external_network(
     request: pytest.Request, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Fixes the CI failure on #335. **`main` is red too** — this is not specific to that branch, and it should merge first.

## What broke

A contract test asserted generation returns **401 whenever** `GENERATE_FROM_URL_REQUIRE_AUTH_FOR_LLM` is set. That was the behaviour before #316, which deliberately changed the gate to fire only when a request would *genuinely* invoke an LLM.

## Why it passed locally and failed in CI

This is the part worth reading.

It was green on my machine **because I have an API key in `.env`**. The gate found a provider, so it returned 401 and the assertion held. CI has no key, so the gate correctly allowed the request through to job submission — which then failed trying to reach a Celery broker:

```
RuntimeError: Retry limit exceeded while trying to reconnect to the Celery result store backend.
```

`make ready` ran that test and it passed. For the wrong reason.

## Two fixes

**The test now asserts the real contract** — 401 when a provider is configured, and *not* 401 when none is — with availability controlled explicitly rather than inherited from whatever the machine happens to have.

**An autouse fixture neutralises ambient LLM credentials for the whole suite**, so no future test can quietly depend on them. Whether an LLM is available changes real behaviour — which layers run, whether the gate fires — so a test that reads ambient credentials asserts something different on a laptop than in CI.

### One detail that took a while to find

The fixture sets those variables **empty rather than deleting them**.

Deleting looks correct and does not work. `load_dotenv` runs at module import, imports happen lazily *inside* tests, and it repopulates any variable that is **absent** — so a deletion is undone the moment a test first imports a config module. That is exactly what happened on my first attempt: the fixture ran, cleared the key, and the test then imported `resolve_llm_availability`, which pulled in `src.config.schema`, which put the key straight back.

`load_dotenv` leaves an *existing* variable alone, even an empty one, and the code already treats empty as unset.

Tests marked `llm` deliberately use a real provider and keep theirs.

## Verification

All three CI lanes, run **with** and **without** `.env` present:

```
unit         1173 passed      (identical both ways)
contract       80 passed      (identical both ways)
integration     7 passed      (identical both ways)
```

Before this, those two runs differed. That they now agree is the property that was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
