### PR TITLE
Unify the two LLM provider-selection mechanisms

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 623
+Total Python files: 624
 
 ├── deploy/
 │   ├── __init__.py
@@ -1288,10 +1288,10 @@ Total Python files: 623
 │       │   │           class LLMResponseMetadata
 │       │   │           class LLMResponse (__post_init__, is_success, tokens_used...)
 │       │   ├── provider_selection.py
-│       │   │       class ProviderSelectionStrategy
-│       │   │       class LLMProviderSelector (__init__, select_provider, invalidate_availability_cache...)
+│       │   │       class LLMProviderSelector (__init__, invalidate_availability_cache, _get_available_providers...)
 │       │   │       def get_provider_selector()
 │       │   │       def default_model_for()
+│       │   │       def _no_provider_message()
 │       │   ├── providers/
 │       │   │   ├── __init__.py
 │       │   │   ├── anthropic.py
@@ -3090,6 +3090,13 @@ Total Python files: 623
         ├── test_provenance_store.py
         │       class _InMemoryManager (__init__)
         │       class _FakeStorageService (__init__)
+        ├── test_provider_selection_unified.py
+        │       def _resolves_to()
+        │       def _stored()
+        │       def _no_real_service()
+        │       def test_ollama_is_not_reported_available_merely_because_it_could_be()
+        │       def test_ollama_is_available_once_opted_into()
+        │       def test_the_listing_never_opens_a_network_connection()
         ├── test_readiness_matching.py
         │       def client()
         │       def test_readiness_reports_matching_service_check()
@@ -3220,7 +3227,7 @@ Total Python files: 623
 
 ## Overview
 
-Total files analyzed: 623
+Total files analyzed: 624
 
 ## Entry Points
 
@@ -8575,13 +8582,11 @@ T...
 
 This module provides an LLM provider ...
 
-**Exports:** ProviderSelectionStrategy, LLMProviderSelector, get_provider_selector, default_model_for
+**Exports:** LLMProviderSelector, get_provider_selector, default_model_for
 
 **Classes:**
-- `ProviderSelectionStrategy` (inherits: Enum)
-  - Strategy for provider selection...
 - `LLMProviderSelector`
-  - Methods: select_provider, invalidate_availability_cache, create_llm_service, get_provider_info
+  - Methods: invalidate_availability_cache, get_provider_info
   - Handles LLM provider selection with multiple fallback strategies.
 
 Selection pri...
@@ -8592,6 +8597,8 @@ Selection pri...
 - `default_model_for(provider_name)`
   - Return the default model for a provider name string.
 Centralized helper to avoid...
+
+**Internal Dependencies:** 1 imports
 
 ### `src/core/llm/providers/__init__.py`
 > LLM Provider implementations for the Open Hardware Manager.
@@ -11794,6 +11801,23 @@ An opt-in 'strict' s...
 **Classes:**
 - `_InMemoryManager`
 - `_FakeStorageService`
+
+**Internal Dependencies:** 5 imports
+
+### `tests/unit/test_provider_selection_unified.py`
+> One mechanism decides which LLM provider is used, for every caller.
+
+Two used to. Generation read th...
+
+**Exports:** test_ollama_is_not_reported_available_merely_because_it_could_be, test_ollama_is_available_once_opted_into, test_the_listing_never_opens_a_network_connection
+
+**Functions:**
+- `test_ollama_is_not_reported_available_merely_because_it_could_be(monkeypatch)`
+  - The listing used to probe a hardcoded localhost address and, when it
+could not c...
+- `test_ollama_is_available_once_opted_into(monkeypatch)`
+- `test_the_listing_never_opens_a_network_connection(monkeypatch)`
+  - A provider listing should not depend on reaching anything....
 
 **Internal Dependencies:** 5 imports
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **One mechanism now decides which LLM provider is used.** Generation read the
+  credential store then the environment; the `ohm llm` CLI read the environment
+  only, probed ollama over the network against a hardcoded localhost address, and
+  fell through to auto-detection when an explicit choice was unavailable. So a
+  credential stored through **Settings** reached generation but was invisible to
+  the CLI. Both now use the same resolver, so `--provider` is honoured or fails
+  rather than silently running a different provider, the kill switch applies
+  everywhere, and ollama is opt-in on both paths. Provider listing no longer
+  touches the network.
+- **`ohm llm --provider` and `--model` had no effect.** The service was
+  constructed with its config passed as the service *name*, leaving the config
+  `None` and falling back to defaults — so every invocation quietly ran Anthropic
+  on the default model. Found by the tests written for the unification above.
+
+
+### Fixed
+
 - **Deploys no longer overwrite Key Vault references with inline values.** After
   the migration, both deploy scripts still minted Redis URLs and mirrored shared
   secrets as *values*, and setting a secret by name replaces a Key Vault

--- a/src/core/llm/provider_selection.py
+++ b/src/core/llm/provider_selection.py
@@ -19,15 +19,6 @@ from .service import LLMService, LLMServiceConfig
 logger = logging.getLogger(__name__)
 
 
-class ProviderSelectionStrategy(Enum):
-    """Strategy for provider selection"""
-
-    ENV_VAR = "env_var"
-    CLI_FLAG = "cli_flag"
-    DEFAULT = "default"
-    AUTO_DETECT = "auto_detect"
-
-
 class LLMProviderSelector:
     """
     Handles LLM provider selection with multiple fallback strategies.
@@ -38,13 +29,6 @@ class LLMProviderSelector:
     3. Auto-detection based on available API keys
     4. Default fallback (lowest priority)
     """
-
-    # Default provider preferences (in order of preference)
-    DEFAULT_PROVIDER_PREFERENCES = [
-        LLMProviderType.ANTHROPIC,  # Most reliable for our use case
-        LLMProviderType.OPENAI,  # Widely available
-        LLMProviderType.LOCAL,  # Free local option
-    ]
 
     # Provider-specific environment variable names
     PROVIDER_ENV_VARS = {
@@ -69,171 +53,6 @@ class LLMProviderSelector:
     def __init__(self):
         """Initialize the provider selector."""
         self._cached_available_providers: Optional[List[LLMProviderType]] = None
-
-    def select_provider(
-        self,
-        cli_provider: Optional[str] = None,
-        cli_model: Optional[str] = None,
-        env_provider: Optional[str] = None,
-        env_model: Optional[str] = None,
-        auto_detect: bool = True,
-        verbose: bool = True,
-    ) -> Dict[str, Any]:
-        """
-        Select the best available LLM provider and model.
-
-        Args:
-            cli_provider: Provider specified via command line flag
-            cli_model: Model specified via command line flag
-            env_provider: Provider specified via environment variable
-            env_model: Model specified via environment variable
-            auto_detect: Whether to auto-detect available providers
-            verbose: Whether to log selection details
-
-        Returns:
-            Dict containing provider, model, strategy, and metadata
-        """
-        selection_result = {
-            "provider": None,
-            "model": None,
-            "strategy": None,
-            "reason": None,
-            "available_providers": [],
-            "warnings": [],
-            "errors": [],
-        }
-
-        # Get available providers
-        available_providers = self._get_available_providers()
-        selection_result["available_providers"] = [p.value for p in available_providers]
-
-        if not available_providers:
-            selection_result["errors"].append("No LLM providers are available")
-            if verbose:
-                logger.error(
-                    "❌ No LLM providers are available. Please check your configuration."
-                )
-            return selection_result
-
-        # Strategy 1: Command line flag (highest priority)
-        if cli_provider:
-            try:
-                provider_type = LLMProviderType(cli_provider)
-                if provider_type in available_providers:
-                    model = cli_model or self.DEFAULT_MODELS.get(provider_type)
-                    selection_result.update(
-                        {
-                            "provider": provider_type,
-                            "model": model,
-                            "strategy": ProviderSelectionStrategy.CLI_FLAG,
-                            "reason": f"Command line flag specified: {cli_provider}",
-                        }
-                    )
-                    if verbose:
-                        logger.info(
-                            f"🎯 Using LLM provider '{provider_type.value}' (CLI flag: --provider {cli_provider})"
-                        )
-                        logger.info(f"🤖 Using model '{model}'")
-                    return selection_result
-                else:
-                    selection_result["warnings"].append(
-                        f"CLI provider '{cli_provider}' not available"
-                    )
-                    if verbose:
-                        logger.warning(
-                            f"⚠️  CLI provider '{cli_provider}' not available, falling back to other options"
-                        )
-            except ValueError:
-                selection_result["warnings"].append(
-                    f"Invalid CLI provider '{cli_provider}'"
-                )
-                if verbose:
-                    logger.warning(
-                        f"⚠️  Invalid CLI provider '{cli_provider}', falling back to other options"
-                    )
-
-        # Strategy 2: Environment variable
-        if env_provider:
-            try:
-                provider_type = LLMProviderType(env_provider)
-                if provider_type in available_providers:
-                    model = (
-                        env_model or cli_model or self.DEFAULT_MODELS.get(provider_type)
-                    )
-                    selection_result.update(
-                        {
-                            "provider": provider_type,
-                            "model": model,
-                            "strategy": ProviderSelectionStrategy.ENV_VAR,
-                            "reason": f"Environment variable specified: {env_provider}",
-                        }
-                    )
-                    if verbose:
-                        logger.info(
-                            f"🎯 Using LLM provider '{provider_type.value}' (ENV: LLM_PROVIDER={env_provider})"
-                        )
-                        logger.info(f"🤖 Using model '{model}'")
-                    return selection_result
-                else:
-                    selection_result["warnings"].append(
-                        f"ENV provider '{env_provider}' not available"
-                    )
-                    if verbose:
-                        logger.warning(
-                            f"⚠️  ENV provider '{env_provider}' not available, falling back to other options"
-                        )
-            except ValueError:
-                selection_result["warnings"].append(
-                    f"Invalid ENV provider '{env_provider}'"
-                )
-                if verbose:
-                    logger.warning(
-                        f"⚠️  Invalid ENV provider '{env_provider}', falling back to other options"
-                    )
-
-        # Strategy 3: Auto-detection (if enabled)
-        if auto_detect:
-            best_provider = self._auto_detect_best_provider(available_providers)
-            if best_provider:
-                model = cli_model or env_model or self.DEFAULT_MODELS.get(best_provider)
-                selection_result.update(
-                    {
-                        "provider": best_provider,
-                        "model": model,
-                        "strategy": ProviderSelectionStrategy.AUTO_DETECT,
-                        "reason": f"Auto-detected best available provider: {best_provider.value}",
-                    }
-                )
-                if verbose:
-                    logger.info(
-                        f"🎯 Auto-detected LLM provider '{best_provider.value}' (best available)"
-                    )
-                    logger.info(f"🤖 Using model '{model}'")
-                return selection_result
-
-        # Strategy 4: Default fallback
-        default_provider = self._get_default_provider(available_providers)
-        if default_provider:
-            model = cli_model or env_model or self.DEFAULT_MODELS.get(default_provider)
-            selection_result.update(
-                {
-                    "provider": default_provider,
-                    "model": model,
-                    "strategy": ProviderSelectionStrategy.DEFAULT,
-                    "reason": f"Using default provider: {default_provider.value}",
-                }
-            )
-            if verbose:
-                logger.info(f"🎯 Using default LLM provider '{default_provider.value}'")
-                logger.info(f"🤖 Using model '{model}'")
-            return selection_result
-
-        # If we get here, something went wrong
-        selection_result["errors"].append("Failed to select any provider")
-        if verbose:
-            logger.error("❌ Failed to select any LLM provider")
-
-        return selection_result
 
     def invalidate_availability_cache(self) -> None:
         """Drop cached provider availability (call after credentials change)."""
@@ -311,96 +130,23 @@ class LLMProviderSelector:
         return False
 
     def _is_ollama_available(self) -> bool:
-        """Check if Ollama is available locally."""
-        try:
-            import asyncio
+        """Whether ollama has been opted into.
 
-            import httpx
+        Deliberately NOT a network probe. It used to open a connection to a
+        hardcoded localhost address and, when it could not check — which is
+        always, from inside a running event loop — report available anyway. So
+        every node claimed a local model it did not have.
 
-            async def check_ollama():
-                try:
-                    async with httpx.AsyncClient(timeout=2.0) as client:
-                        response = await client.get("http://localhost:11434/api/tags")
-                        return response.status_code == 200
-                except:
-                    return False
-
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
-                # Cannot block on the probe from inside a running loop. Report
-                # unavailable rather than assuming: claiming a local model that
-                # is not there sends every request to a dead endpoint.
-                logger.debug("Cannot probe Ollama from a running event loop")
-                return False
-            return asyncio.run(check_ollama())
-        except Exception:
-            return False
-
-    def _auto_detect_best_provider(
-        self, available_providers: List[LLMProviderType]
-    ) -> Optional[LLMProviderType]:
-        """Auto-detect the best provider from available options."""
-        # Use our preference order
-        for preferred in self.DEFAULT_PROVIDER_PREFERENCES:
-            if preferred in available_providers:
-                return preferred
-
-        # If none of our preferences are available, return the first available
-        return available_providers[0] if available_providers else None
-
-    def _get_default_provider(
-        self, available_providers: List[LLMProviderType]
-    ) -> Optional[LLMProviderType]:
-        """Get the default provider from available options."""
-        return self._auto_detect_best_provider(available_providers)
-
-    def create_llm_service(
-        self,
-        cli_provider: Optional[str] = None,
-        cli_model: Optional[str] = None,
-        verbose: bool = True,
-    ) -> LLMService:
+        Opt-in is the same test generation uses: the base URL is set, or ollama
+        is named as the provider. One question, one answer, both paths.
         """
-        Create an LLM service with the best available provider.
+        from .availability import OLLAMA_PROVIDER, _configured_ollama_url
 
-        Args:
-            cli_provider: Provider specified via command line flag
-            cli_model: Model specified via command line flag
-            verbose: Whether to log selection details
+        if _configured_ollama_url():
+            return True
+        from src.config.schema import get_settings
 
-        Returns:
-            Configured LLMService instance
-        """
-        # Get environment variables
-        env_provider = os.getenv("LLM_PROVIDER")
-        env_model = os.getenv("LLM_MODEL")
-
-        # Select provider
-        selection = self.select_provider(
-            cli_provider=cli_provider,
-            cli_model=cli_model,
-            env_provider=env_provider,
-            env_model=env_model,
-            verbose=verbose,
-        )
-
-        if not selection["provider"]:
-            raise RuntimeError(f"Failed to select LLM provider: {selection['errors']}")
-
-        # Create service configuration
-        service_config = LLMServiceConfig(
-            default_provider=selection["provider"], default_model=selection["model"]
-        )
-
-        # Create and return service
-        service = LLMService(service_config)
-
-        if verbose:
-            logger.info(
-                f"✅ LLM service created with provider '{selection['provider'].value}' and model '{selection['model']}'"
-            )
-
-        return service
+        return get_settings().llm_default_provider == OLLAMA_PROVIDER
 
     def get_provider_info(self) -> Dict[str, Any]:
         """Get information about all providers and their availability."""
@@ -476,11 +222,53 @@ async def create_llm_service_with_selection(
     Returns:
         Configured LLMService instance
     """
-    service = get_provider_selector().create_llm_service(
-        cli_provider=cli_provider, cli_model=cli_model, verbose=verbose
+    from .availability import LLMUnavailableReason, resolve_llm_availability
+
+    # ONE decision, shared with generation. This used to select independently
+    # from process environment variables only, so a credential stored through
+    # Settings reached generation but was invisible here — `ohm llm` reported no
+    # provider on a node that was happily generating with one.
+    availability = await resolve_llm_availability(preferred_provider=cli_provider)
+
+    if not availability.available:
+        raise RuntimeError(_no_provider_message(availability.reason, cli_provider))
+
+    provider = LLMProviderType(availability.provider)
+    model = cli_model or default_model_for(availability.provider)
+
+    if verbose:
+        logger.info(
+            "Using LLM provider '%s' (%s) with model '%s'",
+            availability.provider,
+            availability.source,
+            model,
+        )
+
+    # NB the name comes FIRST. Passing the config positionally leaves `config`
+    # None and silently falls back to defaults — which is what the previous
+    # implementation did, so `ohm llm --provider openai` has always quietly run
+    # Anthropic on the default model.
+    service = LLMService(
+        "LLMProviderSelection",
+        LLMServiceConfig(default_provider=provider, default_model=model),
     )
-
-    # Initialize the service
     await service.initialize()
-
     return service
+
+
+def _no_provider_message(reason: Optional[str], requested: Optional[str]) -> str:
+    """Say what to do about it, not just that it happened."""
+    from .availability import LLMUnavailableReason
+
+    if reason == LLMUnavailableReason.DISABLED:
+        return "LLM use is switched off (LLM_ENABLED=false)."
+    if requested:
+        return (
+            f"No credential configured for provider {requested!r}. Add one in "
+            f"Settings → LLM providers, or set its API key in the environment."
+        )
+    return (
+        "No LLM provider is configured. Add a credential in Settings → LLM "
+        "providers, set a provider API key in the environment, or run a local "
+        "model with LLM_DEFAULT_PROVIDER=local."
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,13 @@ _AMBIENT_LLM_CREDENTIALS = (
     "OLLAMA_BASE_URL",
 )
 
+# Pinned rather than cleared: this one is a bool the code branches on, and CI
+# sets it false for the whole job while a developer's .env commonly sets it
+# true. Left inherited, a test asserting LLM behaviour passes in one place and
+# fails in the other. "true" matches the schema default (a kill switch, not an
+# enable switch); tests exercising the disabled path set it themselves.
+_LLM_ENABLED_FOR_TESTS = "true"
+
 
 @pytest.fixture(autouse=True)
 def _no_ambient_llm_credentials(
@@ -113,6 +120,7 @@ def _no_ambient_llm_credentials(
         return
     for name in _AMBIENT_LLM_CREDENTIALS:
         monkeypatch.setenv(name, "")
+    monkeypatch.setenv("LLM_ENABLED", _LLM_ENABLED_FOR_TESTS)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_provider_selection_unified.py
+++ b/tests/unit/test_provider_selection_unified.py
@@ -1,0 +1,156 @@
+"""One mechanism decides which LLM provider is used, for every caller.
+
+Two used to. Generation read the encrypted credential store first, then the
+environment. The `ohm llm` CLI read the environment only, probed ollama over the
+network against a hardcoded localhost address, and fell through to auto-detection
+when an explicit choice was unavailable.
+
+So a credential stored through Settings reached generation but was invisible to
+the CLI: `ohm llm` reported no provider on a node that was generating happily
+with one. That is the same one-concept-two-surfaces defect the LLM work set out
+to remove, relocated rather than fixed.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.core.llm.availability import LLMAvailability, LLMUnavailableReason
+from src.core.llm.providers.base import LLMProviderType
+from src.core.llm.provider_selection import (
+    create_llm_service_with_selection,
+    get_provider_selector,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _resolves_to(availability):
+    return patch(
+        "src.core.llm.availability.resolve_llm_availability",
+        AsyncMock(return_value=availability),
+    )
+
+
+def _stored(mapping):
+    return patch(
+        "src.core.llm.availability._stored_key",
+        AsyncMock(side_effect=lambda provider: mapping.get(provider)),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _no_real_service():
+    """The subject is the decision, not constructing a live provider client."""
+    with patch("src.core.llm.service.LLMService.initialize", AsyncMock()):
+        yield
+
+
+# --- The CLI now sees what generation sees -----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_cli_uses_a_credential_stored_through_settings():
+    """THE fix. This path previously read process environment variables only."""
+    with _stored({"anthropic": "sk-from-settings"}):
+        service = await create_llm_service_with_selection(verbose=False)
+
+    assert service.config.default_provider is LLMProviderType.ANTHROPIC
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_provider_is_never_silently_replaced():
+    """It used to fall through to auto-detection, so asking for one provider
+    could quietly bill another."""
+    with _stored({"anthropic": "sk-anthropic"}):
+        with pytest.raises(RuntimeError, match="openai"):
+            await create_llm_service_with_selection(
+                cli_provider="openai", verbose=False
+            )
+
+
+@pytest.mark.asyncio
+async def test_the_kill_switch_is_honoured_here_too():
+    with _resolves_to(LLMAvailability.unavailable(LLMUnavailableReason.DISABLED)):
+        with pytest.raises(RuntimeError, match="LLM_ENABLED"):
+            await create_llm_service_with_selection(verbose=False)
+
+
+@pytest.mark.asyncio
+async def test_no_provider_says_what_to_do_about_it():
+    with _resolves_to(LLMAvailability.unavailable(LLMUnavailableReason.NOT_CONFIGURED)):
+        with pytest.raises(RuntimeError) as raised:
+            await create_llm_service_with_selection(verbose=False)
+
+    message = str(raised.value)
+    assert "Settings" in message
+    assert "LLM_DEFAULT_PROVIDER=local" in message  # the no-cloud-key option
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_model_still_wins():
+    with _stored({"anthropic": "sk-anthropic"}):
+        service = await create_llm_service_with_selection(
+            cli_model="claude-3-haiku", verbose=False
+        )
+
+    assert service.config.default_model == "claude-3-haiku"
+
+
+@pytest.mark.asyncio
+async def test_a_default_model_is_chosen_for_the_resolved_provider():
+    """Model defaults are the selector's own business and stay there."""
+    with _stored({"openai": "sk-openai"}):
+        service = await create_llm_service_with_selection(verbose=False)
+
+    assert service.config.default_provider is LLMProviderType.OPENAI
+    assert service.config.default_model
+
+
+# --- Ollama is answered the same way on both paths ---------------------------
+
+
+def test_ollama_is_not_reported_available_merely_because_it_could_be(monkeypatch):
+    """The listing used to probe a hardcoded localhost address and, when it
+    could not check — which is always, inside a running event loop — report
+    available anyway. Every node claimed a local model it did not have."""
+    monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+    monkeypatch.setenv("LLM_DEFAULT_PROVIDER", "")
+
+    selector = get_provider_selector()
+    selector.invalidate_availability_cache()
+
+    assert selector._is_provider_available(LLMProviderType.LOCAL) is False
+
+
+def test_ollama_is_available_once_opted_into(monkeypatch):
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://gpu-box.local:11434")
+
+    selector = get_provider_selector()
+    selector.invalidate_availability_cache()
+
+    assert selector._is_provider_available(LLMProviderType.LOCAL) is True
+
+
+def test_the_listing_never_opens_a_network_connection(monkeypatch):
+    """A provider listing should not depend on reaching anything."""
+    import socket
+
+    monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+
+    def _forbidden(*args, **kwargs):
+        raise AssertionError("provider availability must not use the network")
+
+    monkeypatch.setattr(socket.socket, "connect", _forbidden)
+
+    selector = get_provider_selector()
+    selector.invalidate_availability_cache()
+    selector._is_provider_available(LLMProviderType.LOCAL)


### PR DESCRIPTION
Closes #328. Also closes the honesty gap the LLM guide created: it says a credential stored in **Settings** takes effect, which was true for generation but not for `ohm llm`.

## Two mechanisms, two answers

| | Generation | `ohm llm` CLI |
|---|---|---|
| Credential store | **yes**, first | no |
| Environment | yes, as fallback | yes, only |
| Ollama | opt-in | network probe against hardcoded localhost |
| Explicit `--provider` | tried alone | fell through to auto-detection |

A credential stored through Settings reached generation but was invisible to the CLI — `ohm llm` reported no provider on a node that was generating happily with one.

Both paths now use the shared resolver. An explicit `--provider` is honoured or fails rather than quietly running a different one; the kill switch applies everywhere; ollama is opt-in identically on both. The provider listing no longer opens a network connection to decide whether a local model exists — it used to assume *available* whenever it could not check, which from inside a running event loop is always.

## A bug the tests found

**`ohm llm --provider` and `--model` have never worked.**

The service was constructed as `LLMService(service_config)`, but the signature is `LLMService(service_name, config)` — so the config was passed as the *name*, `config` stayed `None`, and it fell back to defaults. Every invocation quietly ran Anthropic on the default model, whatever you asked for.

My first version copied that call shape, and the tests caught it. That is why `test_an_explicit_model_still_wins` exists rather than being assumed.

## Backward pass

The unification made a cluster of code dead — `select_provider`, its strategy enum, two auto-detect helpers, the selector's `create_llm_service`, and a duplicated provider-preference order. All removed, verified self-referential first.

**486 lines → 280.** What remains is genuinely the selector's own business: environment-variable names, default models, the availability listing behind the admin API, and cache invalidation. None of it decides anything the resolver decides.

## Noted, not fixed

The listing still applies richer per-provider checks than the resolver — Azure OpenAI needs an endpoint and deployment id, Bedrock can fall back to IAM credentials. So the resolver can select a provider the listing would call unusable. Worth reconciling, but it is a different question from the one this issue asked, and folding it in would have hidden it.

`make ready` green; 1146 unit + api tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
