### PR TITLE
Fix six Terraform module defects and prove the self-host path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Six defects in the Azure Terraform module, and the self-host path proven.**
+  `LLM_ENABLED=false` was set on both apps — once a no-op, but since the kill
+  switch became real it actively disabled the LLM even with a credential
+  configured; `MATCHING_EAGER_INIT` was set on the worker, which never runs the
+  lifespan that reads it; `rediss://` URLs carried no `ssl_cert_reqs`, so TLS
+  verification was silently off; `CACHE_REDIS_URL` was never wired, so a node
+  paid for Redis and cached in memory anyway; database 0 sat unused; and the
+  Redis access key was interpolated **unencoded**, so a base64 key containing
+  `/` truncated the URL. The module was then applied for real with jobs enabled,
+  a generation job submitted against it and completed, and the environment
+  destroyed — the `enable_jobs` path the public guide advertises had never
+  actually been run.
+
+
+### Fixed
+
 - **One mechanism now decides which LLM provider is used.** Generation read the
   credential store then the environment; the `ohm llm` CLI read the environment
   only, probed ollama over the network against a hardcoded localhost address, and

--- a/deploy/terraform/azure/README.md
+++ b/deploy/terraform/azure/README.md
@@ -54,6 +54,28 @@ self-host node that needs background generation and progress polling, set
 `enable_jobs = true` on the `ohm_node` module (see
 [examples/single-peer](examples/single-peer/README.md)).
 
+## Keeping this aligned with production
+
+Production does **not** use this module — it uses `deploy/scripts/deploy_azure.py`
+and `deploy_azure_worker.py`. Two descriptions of one system drift, and this one
+did: an audit found six defects, three of which `terraform validate` cannot see.
+
+So the policy is: **where this module and the production deploy path disagree,
+the production path is right and this is the bug.** It is the one that runs
+continuously against a live system.
+
+Concretely, this module must mirror:
+
+- the Redis database split (0 = cache, 1 = broker, 2 = results);
+- `?ssl_cert_reqs=required` on every `rediss://` URL — the client parses a bare
+  one as `CERT_NONE`, silently unverified;
+- URL-encoding the Redis access key — base64 keys contain `/`, which truncates
+  an unencoded URL;
+- the strictness rule in `src/config/schema.py::is_production_like`.
+
+Anything changed in the deploy scripts' secret or Redis handling should be
+checked here in the same change.
+
 ## Prerequisites
 
 - Azure CLI (`az login`) with permission to create RGs / ACA / storage

--- a/deploy/terraform/azure/modules/ohm_node/main.tf
+++ b/deploy/terraform/azure/modules/ohm_node/main.tf
@@ -35,11 +35,25 @@ locals {
   # because `environment` is validated to test|development|production, which is
   # precisely why it would bite whoever first adds a name to that list.
   provision_encryption = !contains(["development", "test"], var.environment)
-  # Celery + cache DB split matches docker-compose.yml (0=cache, 1=broker, 2=results).
-  redis_password = var.enable_jobs ? azurerm_redis_cache.jobs[0].primary_access_key : ""
-  redis_host     = var.enable_jobs ? azurerm_redis_cache.jobs[0].hostname : ""
-  job_broker_url = var.enable_jobs ? "rediss://:${local.redis_password}@${local.redis_host}:6380/1" : ""
-  job_result_url = var.enable_jobs ? "rediss://:${local.redis_password}@${local.redis_host}:6380/2" : ""
+  # Celery + cache DB split matches docker-compose.yml: 0=cache, 1=broker,
+  # 2=results. Database 0 was previously left unused, so a node paid for Redis
+  # and still ran an in-memory cache.
+  redis_host = var.enable_jobs ? azurerm_redis_cache.jobs[0].hostname : ""
+
+  # urlencode is load-bearing. Azure Redis access keys are base64, whose
+  # alphabet includes "/" and "+"; an unencoded "/" terminates the URL's
+  # userinfo section and silently truncates the password, so the client
+  # authenticates with a fragment and fails far from the cause.
+  redis_password = var.enable_jobs ? urlencode(azurerm_redis_cache.jobs[0].primary_access_key) : ""
+
+  # ?ssl_cert_reqs=required is also load-bearing: the pinned client parses a
+  # bare rediss:// URL as CERT_NONE — no error, no warning, TLS verification
+  # silently off.
+  redis_url_base  = var.enable_jobs ? "rediss://:${local.redis_password}@${local.redis_host}:6380" : ""
+  redis_url_query = "?ssl_cert_reqs=required"
+  cache_redis_url = var.enable_jobs ? "${local.redis_url_base}/0${local.redis_url_query}" : ""
+  job_broker_url  = var.enable_jobs ? "${local.redis_url_base}/1${local.redis_url_query}" : ""
+  job_result_url  = var.enable_jobs ? "${local.redis_url_base}/2${local.redis_url_query}" : ""
 }
 
 resource "azurerm_storage_account" "this" {
@@ -124,6 +138,14 @@ resource "azurerm_container_app" "api" {
   dynamic "secret" {
     for_each = var.enable_jobs ? [1] : []
     content {
+      name  = "cache-redis-url"
+      value = local.cache_redis_url
+    }
+  }
+
+  dynamic "secret" {
+    for_each = var.enable_jobs ? [1] : []
+    content {
       name  = "job-broker-url"
       value = local.job_broker_url
     }
@@ -203,10 +225,11 @@ resource "azurerm_container_app" "api" {
         name  = "CORS_ORIGINS"
         value = "*"
       }
-      env {
-        name  = "LLM_ENABLED"
-        value = "false"
-      }
+      # LLM_ENABLED is deliberately NOT set. It is a kill switch, not an
+      # enable switch: forcing it false here disabled the LLM even when an
+      # operator had configured a credential, silently producing worse
+      # manifests. Leaving it unset means a configured provider is used, and an
+      # operator can still switch it off deliberately.
       env {
         name  = "MATCHING_EAGER_INIT"
         value = "false"
@@ -254,6 +277,25 @@ resource "azurerm_container_app" "api" {
       env {
         name  = "JOBS_ENABLED"
         value = var.enable_jobs ? "true" : "false"
+      }
+
+      dynamic "env" {
+        for_each = var.enable_jobs ? [1] : []
+        content {
+          name        = "CACHE_REDIS_URL"
+          secret_name = "cache-redis-url"
+        }
+      }
+
+      # cache_backend comes from config/environments/<env>.toml. Without the URL
+      # above it silently degrades to an in-memory cache, so a node paid for
+      # Redis and cached per-replica anyway.
+      dynamic "env" {
+        for_each = var.enable_jobs ? [1] : []
+        content {
+          name  = "CACHE_BACKEND"
+          value = "redis"
+        }
       }
 
       dynamic "env" {
@@ -316,6 +358,11 @@ resource "azurerm_container_app" "worker" {
   }
 
   secret {
+    name  = "cache-redis-url"
+    value = local.cache_redis_url
+  }
+
+  secret {
     name  = "job-broker-url"
     value = local.job_broker_url
   }
@@ -374,18 +421,27 @@ resource "azurerm_container_app" "worker" {
         name        = "AZURE_STORAGE_KEY"
         secret_name = "azure-storage-key"
       }
-      env {
-        name  = "LLM_ENABLED"
-        value = "false"
-      }
-      env {
-        name  = "MATCHING_EAGER_INIT"
-        value = "false"
-      }
+      # LLM_ENABLED is deliberately NOT set. It is a kill switch, not an
+      # enable switch: forcing it false here disabled the LLM even when an
+      # operator had configured a credential, silently producing worse
+      # manifests. Leaving it unset means a configured provider is used, and an
+      # operator can still switch it off deliberately.
+      # MATCHING_EAGER_INIT is not set here: it is read only in the API's
+      # lifespan, which a Celery worker never runs.
       env {
         name  = "JOBS_ENABLED"
         value = "true"
       }
+      env {
+        name        = "CACHE_REDIS_URL"
+        secret_name = "cache-redis-url"
+      }
+
+      env {
+        name  = "CACHE_BACKEND"
+        value = "redis"
+      }
+
       env {
         name        = "JOB_BROKER_URL"
         secret_name = "job-broker-url"


### PR DESCRIPTION
Closes #318. The module is the documented public self-host path, and its `enable_jobs` half — the one the guide advertises — had **never been applied**. Six defects lived there.

## Two of them had changed since filing

**`LLM_ENABLED=false` inverted from harmless to harmful.** I filed it as "a no-op — generation keys off the API key, not that flag." True then. #313 made it a *real* kill switch, so the module was **actively disabling the LLM** even when an operator had configured a credential — silently producing worse manifests. It was also on the **API app**, not just the worker, so synchronous generation was affected too.

**A sixth defect was never filed, because reading found five.** The Redis access key was interpolated into the URL **unencoded**:

```hcl
redis_password = azurerm_redis_cache.jobs[0].primary_access_key   # raw
```

Azure keys are base64, whose alphabet includes `/` — which terminates the URL's userinfo and truncates the password. That is the *identical* bug caught in the Python generator in #305, sitting undiscovered in HCL.

## All six

| # | Defect | Consequence |
|---|---|---|
| 1 | `LLM_ENABLED=false` on **both** apps | LLM disabled despite a configured credential |
| 2 | `MATCHING_EAGER_INIT` on the worker | no-op; the worker never runs that lifespan |
| 3 | No `ssl_cert_reqs` on `rediss://` | TLS verification silently off |
| 4 | `CACHE_REDIS_URL` never wired | paid for Redis, cached in memory |
| 5 | Database 0 unused | — |
| 6 | Access key interpolated raw | URL truncates on `/` |

## Proved, not just read

Fixing by reading is what produced the list in the first place, and **three of the six are invisible to `terraform validate`**. So:

- applied to a disposable resource group with `enable_jobs = true` (13 resources);
- confirmed the worker connected **over TLS to database 1** and the cache to **database 0**;
- confirmed `LLM_ENABLED` absent and `MATCHING_EAGER_INIT` present only on the API;
- submitted a real `generate-from-url` job against the node and watched it reach `SUCCESS`;
- destroyed everything and verified the resource group is gone, with no soft-deleted leftovers.

Production was untouched throughout, and re-verified healthy afterwards.

One honest note: the proof ran the published `0.10.6` image, so the quality report carried no `llm_status` — that reporting is merged but unreleased. It does not affect any of the six fixes.

## Alignment policy

The README now states what the issue asked for: **where this module and the production deploy scripts disagree, the production path is right and this is the bug** — it is the one that runs continuously against a live system. It lists the specifics that must mirror: the database split, `ssl_cert_reqs`, key encoding, and the strictness predicate.

`make ready` green; `terraform validate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
