### PR TITLE
Release 0.10.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,73 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **Six defects in the Azure Terraform module, and the self-host path proven.**
-  `LLM_ENABLED=false` was set on both apps — once a no-op, but since the kill
-  switch became real it actively disabled the LLM even with a credential
-  configured; `MATCHING_EAGER_INIT` was set on the worker, which never runs the
-  lifespan that reads it; `rediss://` URLs carried no `ssl_cert_reqs`, so TLS
-  verification was silently off; `CACHE_REDIS_URL` was never wired, so a node
-  paid for Redis and cached in memory anyway; database 0 sat unused; and the
-  Redis access key was interpolated **unencoded**, so a base64 key containing
-  `/` truncated the URL. The module was then applied for real with jobs enabled,
-  a generation job submitted against it and completed, and the environment
-  destroyed — the `enable_jobs` path the public guide advertises had never
-  actually been run.
-
-
-### Fixed
-
-- **One mechanism now decides which LLM provider is used.** Generation read the
-  credential store then the environment; the `ohm llm` CLI read the environment
-  only, probed ollama over the network against a hardcoded localhost address, and
-  fell through to auto-detection when an explicit choice was unavailable. So a
-  credential stored through **Settings** reached generation but was invisible to
-  the CLI. Both now use the same resolver, so `--provider` is honoured or fails
-  rather than silently running a different provider, the kill switch applies
-  everywhere, and ollama is opt-in on both paths. Provider listing no longer
-  touches the network.
-- **`ohm llm --provider` and `--model` had no effect.** The service was
-  constructed with its config passed as the service *name*, leaving the config
-  `None` and falling back to defaults — so every invocation quietly ran Anthropic
-  on the default model. Found by the tests written for the unification above.
-
-
-### Fixed
-
-- **Deploys no longer overwrite Key Vault references with inline values.** After
-  the migration, both deploy scripts still minted Redis URLs and mirrored shared
-  secrets as *values*, and setting a secret by name replaces a Key Vault
-  reference — so the next release would have succeeded, kept working, and
-  silently undone the migration on an inline copy. Where an environment declares
-  `key_vault_name`, the deploys now write references only, mint the Redis URLs
-  *into the vault*, and stop copying secrets between apps entirely. Environments
-  without a vault are unchanged.
-
-
-### Security
-
-- **LLM generation requires authentication once a provider is configured.**
-  `GENERATE_FROM_URL_REQUIRE_AUTH_FOR_LLM` gated on the request's *intent* — the
-  `no_llm` flag — rather than on whether an LLM was actually available. Since the
-  web UI always requests LLM-enabled generation, switching it on would have
-  rejected every generation to guard a cost that could not occur, which is why it
-  stayed off and the spend path stayed unguarded. It now fires only when a
-  request would genuinely invoke an LLM, on both the synchronous and async
-  endpoints, and is **armed in production** — inert while no provider is
-  configured, protective the moment an admin adds a credential, with no step to
-  remember at the moment it would be easiest to forget.
-
-
-### Changed
-
-- **`make secrets-check` now checks what Key Vault made important.** It compared
-  resolved secret *values*, which proves little once there is only one copy — and
-  it read a separate list, so after the migration it verified a renamed-away
-  secret while never inspecting the live one. It now derives its scope from the
-  same mapping the deploys wire, and asserts both apps reference the **same vault
-  secret**, flagging any value left inline. It reads no secret values at all.
+## [0.10.7] - 2026-08-04
 
 ### Added
 
@@ -91,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   access, so the operator is granted Secrets Officer before any write.
 
 
-### Added
 
 - **Runs report whether the LLM actually contributed.** The quality report now
   carries `llm_used`, `llm_status` and the provider, and a degraded run adds a
@@ -105,37 +38,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   per-layer failures — neither leaves a usage count otherwise. The production
   probe gained `expect_llm`, which fails a release if a node with a configured
   provider silently drops to heuristic-only.
-### Security
-
-- **Closed four dependency CVEs**: `aiohttp` 3.14.1 → 3.14.3 (CVE-2026-59881,
-  -69243, -69244) and `cryptography` 49.0.0 → 50.0.0 (CVE-2026-69247). The
-  version floors were raised as well as the lockfile, so a fresh resolve cannot
-  pick a vulnerable version again.
-
-
-### Fixed
-
-- **A stored LLM credential now actually reaches generation.** The gate deciding
-  whether the LLM layer joins the stack read process environment variables only,
-  while the service that would have run it reads the encrypted credential store
-  first — so a key set through **Settings → LLM providers** caused the layer to
-  be dropped *before* that service was ever constructed. The store worked;
-  nothing reached it. Availability is now resolved **once**, asynchronously, at
-  the generation entry point and carried as plain values the synchronous gate
-  reads, so the gate, the progress stages and the layer stack cannot disagree.
-  Environment keys keep working unchanged; the store simply wins when both exist.
-- **The generation layer no longer hardcodes Anthropic.** It built its LLM
-  service with a fixed provider and then looked for an *Anthropic* credential
-  specifically, so a configured OpenAI key was ignored even once the gate let the
-  layer run. It now uses the resolved provider.
-- **`LLM_ENABLED` means something.** It previously gated only a startup log line.
-  It is now a schema setting and a genuine **kill switch** — false disables the
-  LLM regardless of stored credentials, so an operator can stop spend without
-  deleting keys. Configuring a provider remains the enable action. Its duplicate
-  hand-written entry in `env.template` is gone; a later assignment there would
-  have silently overridden the schema-owned one.
 
 ### Changed
+
+- **`make secrets-check` now checks what Key Vault made important.** It compared
+  resolved secret *values*, which proves little once there is only one copy — and
+  it read a separate list, so after the migration it verified a renamed-away
+  secret while never inspecting the live one. It now derives its scope from the
+  same mapping the deploys wire, and asserts both apps reference the **same vault
+  secret**, flagging any value left inline. It reads no secret values at all.
+
 
 - **One predicate decides whether a deployment is "real".** `ENVIRONMENT` was
   doing two unrelated jobs: selecting `config/environments/<env>.toml`, and
@@ -158,6 +70,87 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now fails on any direct `== "production"` comparison in Python or Terraform,
   and the Terraform module mirrors the derived rule so a node named anything but
   `production` still provisions the encryption secrets the app demands of it.
+
+### Fixed
+
+- **Six defects in the Azure Terraform module, and the self-host path proven.**
+  `LLM_ENABLED=false` was set on both apps — once a no-op, but since the kill
+  switch became real it actively disabled the LLM even with a credential
+  configured; `MATCHING_EAGER_INIT` was set on the worker, which never runs the
+  lifespan that reads it; `rediss://` URLs carried no `ssl_cert_reqs`, so TLS
+  verification was silently off; `CACHE_REDIS_URL` was never wired, so a node
+  paid for Redis and cached in memory anyway; database 0 sat unused; and the
+  Redis access key was interpolated **unencoded**, so a base64 key containing
+  `/` truncated the URL. The module was then applied for real with jobs enabled,
+  a generation job submitted against it and completed, and the environment
+  destroyed — the `enable_jobs` path the public guide advertises had never
+  actually been run.
+- **One mechanism now decides which LLM provider is used.** Generation read the
+  credential store then the environment; the `ohm llm` CLI read the environment
+  only, probed ollama over the network against a hardcoded localhost address, and
+  fell through to auto-detection when an explicit choice was unavailable. So a
+  credential stored through **Settings** reached generation but was invisible to
+  the CLI. Both now use the same resolver, so `--provider` is honoured or fails
+  rather than silently running a different provider, the kill switch applies
+  everywhere, and ollama is opt-in on both paths. Provider listing no longer
+  touches the network.
+- **`ohm llm --provider` and `--model` had no effect.** The service was
+  constructed with its config passed as the service *name*, leaving the config
+  `None` and falling back to defaults — so every invocation quietly ran Anthropic
+  on the default model. Found by the tests written for the unification above.
+
+
+
+- **Deploys no longer overwrite Key Vault references with inline values.** After
+  the migration, both deploy scripts still minted Redis URLs and mirrored shared
+  secrets as *values*, and setting a secret by name replaces a Key Vault
+  reference — so the next release would have succeeded, kept working, and
+  silently undone the migration on an inline copy. Where an environment declares
+  `key_vault_name`, the deploys now write references only, mint the Redis URLs
+  *into the vault*, and stop copying secrets between apps entirely. Environments
+  without a vault are unchanged.
+
+
+
+- **A stored LLM credential now actually reaches generation.** The gate deciding
+  whether the LLM layer joins the stack read process environment variables only,
+  while the service that would have run it reads the encrypted credential store
+  first — so a key set through **Settings → LLM providers** caused the layer to
+  be dropped *before* that service was ever constructed. The store worked;
+  nothing reached it. Availability is now resolved **once**, asynchronously, at
+  the generation entry point and carried as plain values the synchronous gate
+  reads, so the gate, the progress stages and the layer stack cannot disagree.
+  Environment keys keep working unchanged; the store simply wins when both exist.
+- **The generation layer no longer hardcodes Anthropic.** It built its LLM
+  service with a fixed provider and then looked for an *Anthropic* credential
+  specifically, so a configured OpenAI key was ignored even once the gate let the
+  layer run. It now uses the resolved provider.
+- **`LLM_ENABLED` means something.** It previously gated only a startup log line.
+  It is now a schema setting and a genuine **kill switch** — false disables the
+  LLM regardless of stored credentials, so an operator can stop spend without
+  deleting keys. Configuring a provider remains the enable action. Its duplicate
+  hand-written entry in `env.template` is gone; a later assignment there would
+  have silently overridden the schema-owned one.
+
+### Security
+
+- **LLM generation requires authentication once a provider is configured.**
+  `GENERATE_FROM_URL_REQUIRE_AUTH_FOR_LLM` gated on the request's *intent* — the
+  `no_llm` flag — rather than on whether an LLM was actually available. Since the
+  web UI always requests LLM-enabled generation, switching it on would have
+  rejected every generation to guard a cost that could not occur, which is why it
+  stayed off and the spend path stayed unguarded. It now fires only when a
+  request would genuinely invoke an LLM, on both the synchronous and async
+  endpoints, and is **armed in production** — inert while no provider is
+  configured, protective the moment an admin adds a credential, with no step to
+  remember at the moment it would be easiest to forget.
+
+
+
+- **Closed four dependency CVEs**: `aiohttp` 3.14.1 → 3.14.3 (CVE-2026-59881,
+  -69243, -69244) and `cryptography` 49.0.0 → 50.0.0 (CVE-2026-69247). The
+  version floors were raised as well as the lockfile, so a fresh resolve cannot
+  pick a vulnerable version again.
 
 ## [0.10.6] - 2026-08-03
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ OHM exposes a FastAPI HTTP API that can be run locally via Docker Compose, from 
 or deployed using the configurations in `deploy/`. A reference frontend ships in
 `frontend/`.
 
-**Current release:** `0.10.6` — see [CHANGELOG.md](CHANGELOG.md) and [Release process](docs/RELEASE.md).
+**Current release:** `0.10.7` — see [CHANGELOG.md](CHANGELOG.md) and [Release process](docs/RELEASE.md).
 
 ## Quick Start for New Users
 
@@ -64,11 +64,11 @@ After installing, open a new terminal so the tools are on your PATH.
 **Local storage (no credentials needed):**
 
 ```bash
-docker pull touchthesun/openhardwaremanager:0.10.6
+docker pull touchthesun/openhardwaremanager:0.10.7
 docker run -p 8001:8001 \
   -e STORAGE_PROVIDER=local \
   -e LLM_ENABLED=false \
-  touchthesun/openhardwaremanager:0.10.6
+  touchthesun/openhardwaremanager:0.10.7
 ```
 
 **Remote storage (Azure Blob, AWS S3, or GCS):**
@@ -79,7 +79,7 @@ The published image does not include a `.env` file — you must pass your storag
 # Copy the template, fill in your provider and credentials, then:
 docker run -p 8001:8001 \
   --env-file .env \
-  touchthesun/openhardwaremanager:0.10.6
+  touchthesun/openhardwaremanager:0.10.7
 ```
 
 The minimum `.env` keys for Azure Blob are:

--- a/docs-site/docs/guides/configure-an-llm.md
+++ b/docs-site/docs/guides/configure-an-llm.md
@@ -69,6 +69,13 @@ is what enables it — OHM never assumes a local model is present just because
 ollama's client would default to `localhost`. Otherwise every node would believe
 it had a local model, and every generation would fail against nothing.
 
+### The command line uses the same configuration
+
+`ohm llm` commands read exactly what generation reads — including credentials
+stored through **Settings**, which they previously could not see. So a key added
+in the web app works on the command line too, without being repeated in the
+environment.
+
 ## When several are configured
 
 A stored credential wins over an environment variable for the same provider, so

--- a/docs/ops/async-generation.md
+++ b/docs/ops/async-generation.md
@@ -210,6 +210,21 @@ keeps its name reserved for 90 days, so a delete without a purge silently blocks
 the next rebuild of that environment with a name collision. Purging is
 irreversible, which is why it is opt-in.
 
+### Deploys write references, never values
+
+Where an environment declares `key_vault_name`, the deploy scripts set secret
+**references** on the apps and mint the Redis URLs **into the vault**. They never
+set a secret value on a container app.
+
+That is not a stylistic preference. Setting a secret by name *replaces* a Key
+Vault reference with an inline value, so a deploy that wrote values would
+succeed, leave both apps working, and silently undo the migration — putting the
+duplicated copies back with nothing to signal it. `make secrets-check` reports
+any value found inline for exactly this reason.
+
+Environments with no `key_vault_name` are unaffected and still stand up the old
+way, which is what makes a fresh self-host environment possible.
+
 ### Renaming a secret
 
 Do it additively, in this order, because an app that resolves the wrong name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "supply-graph-ai"
-version = "0.10.6"
+version = "0.10.7"
 description = "Open Hardware Manager (OHM) - A flexible, domain-agnostic framework for matching requirements with capabilities"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -3323,7 +3323,7 @@ wheels = [
 
 [[package]]
 name = "supply-graph-ai"
-version = "0.10.6"
+version = "0.10.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Prepares the release that ships everything from this cycle. **Merge, then tag `v0.10.7`** to fire the pipeline.

## What ships

Thirteen entries: the LLM configuration work (#313–#316, #328), the Key Vault migration and the deploy fixes that keep it (#317, #335), the environment-strictness predicate (#320–#322), four CVEs, and the Terraform module audit (#318).

The changelog needed **consolidating**, not just dating. Each PR had prepended its own heading, so `[Unreleased]` carried three separate `Fixed` blocks and two `Added` blocks. They are now one section per type in Keep a Changelog order, with all thirteen entries accounted for — verified by count before and after, and again after folding in #318's entry, which merged while this was being prepared.

## Two documentation gaps closed

**The ops guide did not say deploys write references, never values.** That is precisely the property stopping a release from silently undoing the Key Vault migration, so it belongs written down rather than living only in a PR description.

**The public LLM guide did not mention that `ohm llm` reads the same configuration as generation.** It could not have — that only became true with #328. The guide was written when it was still a gap.

## Secret cleanup: two of three

Done, after checking against the live apps rather than assuming:

- `llm-encryption-password` — unreferenced on both apps, removed
- `redis-access-url` — unreferenced, removed

**`gihub-token` deliberately remains.** Production still resolves `GITHUB_ACCESS_TOKEN` through it, and will until this release deploys. Deleting it now would drop both apps to anonymous GitHub cloning — which surfaces as intermittent 429s during generation rather than as an obvious failure. It goes after the deploy.

Production was re-verified healthy after the removals.

## One expected red

`make secrets-check` currently fails with `github-token: missing from openhardwaremanager`.

That is the check **working**. The repo now expects `github-token`; production still has `gihub-token`. It is reporting real drift between the two, and it clears the moment this release deploys. It is deliberately not in `make ready`, so it does not gate this PR.

## After merging

```bash
git checkout main && git pull
git tag v0.10.7 && git push origin v0.10.7
```

The pipeline runs worker → API → probe. Once green, the last cleanup step is deleting `gihub-token` from the vault and both apps, and `make secrets-check` should then pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
