### PR TITLE
feat: cooking-domain toggle with recipe/kitchen browse and matching

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 625
+Total Python files: 631
 
 ├── deploy/
 │   ├── __init__.py
@@ -876,6 +876,7 @@ Total Python files: 625
 │       │   │   │       def _fuzzy_overlap_count()
 │       │   │   ├── models.py
 │       │   │   │       class KitchenCapability (from_dict, to_dict, is_kitchen_data...)
+│       │   │   │       class Recipe (from_dict, to_dict, is_recipe_data...)
 │       │   │   ├── validation/
 │       │   │   │   ├── __init__.py
 │       │   │   │   ├── compatibility.py
@@ -1947,6 +1948,10 @@ Total Python files: 625
     │   ├── test_okh_generate_jobs.py
     │   │       def _get_app()
     │   │       def _llm_available()
+    │   ├── test_okh_okw_cooking_routes.py
+    │   │       def _get_app()
+    │   │       def _recipe()
+    │   │       def _kitchen()
     │   ├── test_okw_create_route.py
     │   │       def _get_app()
     │   ├── test_package_build_response.py
@@ -1970,6 +1975,9 @@ Total Python files: 625
     │   │       def _get_app()
     │   ├── test_space_routes.py
     │   │       def _get_app()
+    │   ├── test_utility_default_domain.py
+    │   │       def _get_app()
+    │   │       def _isolate_cache()
     │   ├── test_visibility_routes.py
     │   │       def _get_app()
     │   └── test_write_enforcement.py
@@ -1986,6 +1994,14 @@ Total Python files: 625
     │   │       def test_grants_subgroup_commands()
     │   │       def test_keys_subgroup_commands()
     │   │       def test_accounts_subgroup_commands()
+    │   ├── test_okh_okw_cooking_cli.py
+    │   │       class DummyCLIContext (__init__, start_command_tracking, end_command_tracking...)
+    │   │       def test_okh_exposes_list_recipes()
+    │   │       def test_okw_exposes_list_kitchens()
+    │   │       def _recipe()
+    │   │       def _kitchen()
+    │   │       def test_list_recipes_falls_back_to_direct_service_and_prints_json()
+    │   │       def test_list_kitchens_falls_back_to_direct_service_and_prints_json()
     │   ├── test_okh_okw_visibility_cli.py
     │   │       def test_okh_exposes_create_and_visibility()
     │   │       def test_okh_create_has_author_flags()
@@ -2550,6 +2566,11 @@ Total Python files: 625
         │       class TestDeployEnvVars (test_production_applies_storage_target, test_development_is_local, test_missing_environment_returns_empty...)
         │       class TestFrontendDeployEnvVars (test_production_frontend_config, test_keys_are_uppercased_env_names, test_absent_table_returns_empty...)
         │       def clean_env()
+        ├── test_cooking_models.py
+        │       class TestRecipeRoundTrip (test_from_dict_requires_id, test_from_dict_requires_name, test_to_dict_round_trips...)
+        │       class TestRecipeDiscriminator (test_recipe_shaped_data_is_a_recipe, test_okh_manifest_is_not_a_recipe, test_explicit_domain_overrides_shape...)
+        │       def recipe_dict()
+        │       def okh_manifest_dict()
         ├── test_country_names.py
         │       def test_display_country_name_codes()
         │       def test_countries_match_code_and_name()
@@ -2830,6 +2851,9 @@ Total Python files: 625
         │       def test_the_fetch_timeout_is_bounded()
         ├── test_mom_okw_source_routing.py
         │       def _mock_network()
+        ├── test_ohm_default_domain_setting.py
+        │       def test_default_domain_setting_defaults_to_manufacturing()
+        │       def test_default_domain_setting_honors_env_override()
         ├── test_okh_catalog_performance.py
         │       class FakeStorageManager (__init__)
         │       class FakeStorage (__init__)
@@ -2920,6 +2944,14 @@ Total Python files: 625
         │       def test_prose_fixture_flags_instruction_and_table_rows()
         │       def test_license_leak_detected_in_function()
         │       def test_layer_comparison_reports_deltas()
+        ├── test_okh_list_recipes.py
+        │       class FakeStorageManager (__init__)
+        │       class FakeStorage (__init__)
+        │       class TestListRecipes
+        │       def recipe_dict()
+        │       def manifest_dict()
+        │       def file_info()
+        │       def build_service()
         ├── test_okh_losh_converter.py
         │       def _write()
         │       def test_missing_file_raises()
@@ -3238,7 +3270,7 @@ Total Python files: 625
 
 ## Overview
 
-Total files analyzed: 625
+Total files analyzed: 631
 
 ## Entry Points
 
@@ -3282,6 +3314,13 @@ Args:
 ### `src/core/main.py`
 
 **Internal Dependencies:** 40 imports
+
+### `tests/api/test_utility_default_domain.py`
+> Contract test: GET /api/utility/domains surfaces default_domain.
+
+Regression guard for the cooking-d...
+
+**Internal Dependencies:** 2 imports
 
 ## Services
 
@@ -4465,7 +4504,7 @@ This module provides Pydantic models for validation r...
 
 ### `src/core/domains/cooking/models.py`
 
-**Exports:** KitchenCapability
+**Exports:** KitchenCapability, Recipe
 
 **Classes:**
 - `KitchenCapability`
@@ -4473,6 +4512,11 @@ This module provides Pydantic models for validation r...
   - A cooking-domain capability record stored under okw/ in remote storage.
 
 Kept in...
+- `Recipe`
+  - Methods: from_dict, to_dict, is_recipe_data, is_cooking_recipe
+  - A cooking-domain recipe record stored under okh/ in remote storage.
+
+Kept intent...
 
 ### `src/core/federation/models.py`
 > Pydantic models for federation catalog and peer state....
@@ -5307,6 +5351,25 @@ Args...
 
 **Internal Dependencies:** 13 imports
 
+### `tests/unit/test_cooking_models.py`
+> Recipe model: round-trip serialisation and the okh/recipe discriminator.
+
+Mirrors KitchenCapability'...
+
+**Exports:** recipe_dict, okh_manifest_dict, TestRecipeRoundTrip, TestRecipeDiscriminator
+
+**Classes:**
+- `TestRecipeRoundTrip`
+  - Methods: test_from_dict_requires_id, test_from_dict_requires_name, test_to_dict_round_trips, test_defaults_domain_to_cooking
+- `TestRecipeDiscriminator`
+  - Methods: test_recipe_shaped_data_is_a_recipe, test_okh_manifest_is_not_a_recipe, test_explicit_domain_overrides_shape, test_empty_data_is_not_a_recipe
+
+**Functions:**
+- `recipe_dict()`
+- `okh_manifest_dict()`
+
+**Internal Dependencies:** 1 imports
+
 ### `tests/unit/test_dev_env_spacy_model.py`
 > CI guard: the spaCy model must be a real, loadable, locked dependency.
 
@@ -5396,6 +5459,8 @@ These commands provide utility operations for the Ope...
 
 ### `src/core/api/routes/utility.py`
 > Utility API routes: domains, validation contexts, and system metrics....
+
+**Internal Dependencies:** 1 imports
 
 ### `src/core/cache/helper.py`
 > Service-level cache helper using the shared CacheService backend....
@@ -9712,6 +9777,13 @@ Regression: OKHResponse s...
 
 **Internal Dependencies:** 4 imports
 
+### `tests/api/test_okh_okw_cooking_routes.py`
+> Contract tests for GET /api/okh/recipes and GET /api/okw/kitchens.
+
+Regression guard: both routes mu...
+
+**Internal Dependencies:** 5 imports
+
 ### `tests/api/test_okw_create_route.py`
 > Contract test for POST /api/okw/create.
 
@@ -9795,6 +9867,25 @@ The policy knob ``require_au...
 - `test_directory_subgroup_commands()`
 
 **Internal Dependencies:** 1 imports
+
+### `tests/cli/test_okh_okw_cooking_cli.py`
+> CLI wiring + behavior tests for `ohm okh list-recipes` / `ohm okw list-kitchens`....
+
+**Exports:** test_okh_exposes_list_recipes, test_okw_exposes_list_kitchens, DummyCLIContext, test_list_recipes_falls_back_to_direct_service_and_prints_json, test_list_kitchens_falls_back_to_direct_service_and_prints_json
+
+**Classes:**
+- `DummyCLIContext`
+  - Methods: start_command_tracking, end_command_tracking, log
+  - Minimal stand-in for CLIContext, matching test_scaffold_cleanup_cli.py....
+
+**Functions:**
+- `test_okh_exposes_list_recipes()`
+- `test_okw_exposes_list_kitchens()`
+- `test_list_recipes_falls_back_to_direct_service_and_prints_json()`
+  - No server reachable in tests, so this exercises the fallback listing path....
+- `test_list_kitchens_falls_back_to_direct_service_and_prints_json()`
+
+**Internal Dependencies:** 4 imports
 
 ### `tests/cli/test_okh_okw_visibility_cli.py`
 > CLI wiring tests for okh/okw create + visibility (Slice 4)....
@@ -11483,6 +11574,19 @@ Since the union-default change, all sourc...
 
 **Internal Dependencies:** 10 imports
 
+### `tests/unit/test_ohm_default_domain_setting.py`
+> OHM_DEFAULT_DOMAIN: must default to 'manufacturing' when unset.
+
+Regression guard from the cooking-d...
+
+**Exports:** test_default_domain_setting_defaults_to_manufacturing, test_default_domain_setting_honors_env_override
+
+**Functions:**
+- `test_default_domain_setting_defaults_to_manufacturing(monkeypatch)`
+- `test_default_domain_setting_honors_env_override(monkeypatch)`
+
+**Internal Dependencies:** 2 imports
+
 ### `tests/unit/test_okh_catalog_performance.py`
 > The OKH catalogue is assembled concurrently and cached.
 
@@ -11615,6 +11719,26 @@ Both previo...
 - `test_prose_fixture_flags_instruction_and_table_rows()`
 - `test_license_leak_detected_in_function()`
 - `test_layer_comparison_reports_deltas()`
+
+### `tests/unit/test_okh_list_recipes.py`
+> OKHService.list_recipes() — mirrors OKWService.list_kitchens() but scans okh/.
+
+Follows the fake-sto...
+
+**Exports:** recipe_dict, manifest_dict, FakeStorageManager, FakeStorage, file_info
+
+**Classes:**
+- `FakeStorageManager`
+- `FakeStorage`
+- `TestListRecipes`
+
+**Functions:**
+- `recipe_dict(recipe_id, name)`
+- `manifest_dict(manifest_id, title)`
+- `file_info(key, minutes_old)`
+- `build_service(objects)`
+
+**Internal Dependencies:** 2 imports
 
 ### `tests/unit/test_okh_losh_converter.py`
 > OKH-LOSH v2.4 TOML -> OKH conversion field mapping....

--- a/docs-site/docs/guides/deploy-a-cooking-domain-instance.md
+++ b/docs-site/docs/guides/deploy-a-cooking-domain-instance.md
@@ -1,0 +1,111 @@
+---
+title: Deploy a cooking-domain instance
+area: selfhost
+surface: selfhost
+---
+
+# Deploy a cooking-domain instance
+
+A cooking-domain instance is an ordinary OHM deployment (see
+[Deploy a node on Azure](deploy-a-node-on-azure.md) or
+[Run your own node](run-your-own-node.md)) pointed at recipe/kitchen data
+instead of hardware designs and facilities. There is no separate build,
+image, or code path — matching, storage, and the API are identical. Only
+configuration differs.
+
+## What makes it a cooking instance
+
+| Setting | Manufacturing (default) | Cooking |
+|---------|--------------------------|---------|
+| `OHM_DEFAULT_DOMAIN` | `manufacturing` (or unset) | `cooking` |
+| Storage bucket contents | OKH manifests / OKW facilities under `okh/` / `okw/` | Recipes / kitchens under the same `okh/` / `okw/` prefixes |
+
+Recipe and kitchen records live in the **same bucket and prefixes** as OKH
+manifests and OKW facilities — content is distinguished by shape, not
+location. See `Recipe.is_cooking_recipe()` and
+`KitchenCapability.is_cooking_capability()` in
+`src/core/domains/cooking/models.py`. Pointing an instance at "a bucket with
+the relevant recipes and kitchens" needs no new storage mechanism: the
+existing `STORAGE_PROVIDER` / `AZURE_STORAGE_*` (or S3/GCS equivalent) env
+vars already used for manufacturing data do the whole job.
+
+`OHM_DEFAULT_DOMAIN` only changes what a **fresh browser tab** opens to
+(`GET /api/utility/domains` → `default_domain`) — it does not restrict the
+API. Manufacturing OKH/OKW endpoints keep working on a cooking instance and
+vice versa; the setting is a UI convenience, not an access boundary.
+
+## Configure the environment
+
+Add to the environment's `config/environments/<environment>.toml` (see
+`deploy_env_vars()` in `src/config/schema.py` — any scalar key in this file
+becomes an upper-cased env var on deploy, no schema change required):
+
+```toml
+ohm_default_domain = "cooking"
+
+storage_provider = "azure_blob"
+azure_storage_account = "..."
+azure_storage_container = "..."   # a container holding recipe/kitchen JSON
+```
+
+`azure_storage_key` (or the equivalent secret for another provider) stays a
+secret — set it via `--mirror-secrets-from` or a Key Vault reference, never
+in the TOML file. See [Deploy a node on Azure](deploy-a-node-on-azure.md) for
+the full secrets story.
+
+Then deploy as usual:
+
+```bash
+python deploy/scripts/deploy_azure.py \
+  --environment <environment> \
+  --image touchthesun/openhardwaremanager:<version> \
+  --subscription-id <subscription-id>
+```
+
+## Upload recipe and kitchen data
+
+Recipes and kitchens are read-only browse/match data — there is no create
+UI or CLI by design (`ohm okh list-recipes`, `ohm okw list-kitchens` are
+list-only). Upload correctly-shaped JSON directly to the bucket's `okh/` and
+`okw/` prefixes:
+
+```json title="okh/sourdough-bread.json"
+{
+  "id": "5b1f7e2a-...",
+  "name": "Sourdough Bread",
+  "ingredients": ["flour", "water", "salt", "starter"],
+  "instructions": ["Mix", "Bulk ferment", "Shape", "Bake"],
+  "equipment": ["oven", "mixing bowl"]
+}
+```
+
+```json title="okw/home-kitchen.json"
+{
+  "id": "9c4a3d10-...",
+  "name": "Home Kitchen",
+  "appliances": ["oven", "stovetop"],
+  "tools": ["mixing bowl", "knife"],
+  "ingredients": ["flour", "water", "salt", "starter", "yeast"]
+}
+```
+
+## Verify
+
+1. `GET /api/utility/domains` returns `"default_domain": "cooking"`.
+2. `GET /api/okh/recipes` and `GET /api/okw/kitchens` list the uploaded
+   records (also reachable via `ohm okh list-recipes` / `ohm okw
+   list-kitchens`).
+3. `POST /api/match` with an inline `recipe` and `okw_facilities` (kitchen
+   dicts) returns a real match — the matching engine already accepts this
+   shape; see `_extract_recipe()` in `src/core/api/routes/match.py`.
+
+## Tear down
+
+Cooking instances stood up for an experiment are disposable. Remove them
+with:
+
+```bash
+python deploy/scripts/teardown_azure_environment.py --environment <environment> --yes
+```
+
+The script refuses to touch `production` by design.

--- a/docs-site/mkdocs.yml
+++ b/docs-site/mkdocs.yml
@@ -116,6 +116,7 @@ nav:
       - Configure an LLM: guides/configure-an-llm.md
       - Run your own node: guides/run-your-own-node.md
       - Deploy a node on Azure: guides/deploy-a-node-on-azure.md
+      - Deploy a cooking-domain instance: guides/deploy-a-cooking-domain-instance.md
       - Use the OHM API: guides/use-the-api.md
   - Contact: contact.md
   - Reference:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,7 +18,9 @@ import { GeneratePage } from "./pages/GeneratePage";
 import { CreateOkwPage } from "./features/okw/CreateOkwPage";
 import { EditOkwPage } from "./features/okw/EditOkwPage";
 import { ThemeContext } from "./context/ThemeContext";
+import { DomainContext } from "./context/DomainContext";
 import { useDarkMode } from "./hooks/useDarkMode";
+import { useDomainPreference } from "./hooks/useDomainPreference";
 
 function AdminSettings() {
   return (
@@ -30,49 +32,53 @@ function AdminSettings() {
 
 export function App() {
   const theme = useDarkMode();
+  const domainPreference = useDomainPreference();
 
   return (
     <ThemeContext.Provider value={theme}>
-      <PersistQueryClientProvider client={queryClient} persistOptions={persistOptions}>
-        <AuthProvider>
-          <BrowserRouter>
-            <Routes>
-              <Route element={<Layout />}>
-                <Route index element={<HomePage />} />
-                <Route path="okh" element={<OkhPage />} />
-                <Route path="okh/new" element={<CreateOkhPage />} />
-                <Route path="okh/generate" element={<GeneratePage />} />
-                <Route path="okh/:id/files/*" element={<OkhFilePreviewPage />} />
-                <Route path="okh/:id" element={<OkhPage />} />
-                <Route path="facilities" element={<OkwPage />} />
-                <Route path="facilities/new" element={<CreateOkwPage />} />
-                <Route path="facilities/:id/edit" element={<EditOkwPage />} />
-                <Route path="facilities/:id" element={<OkwPage />} />
-                <Route path="match" element={<MatchPage />} />
-                {/* Supply trees are reached directly from their match; no browse list. */}
-                <Route path="visualization" element={<Navigate to="/" replace />} />
-                <Route path="visualization/:solutionId" element={<VisualizationPage />} />
-                <Route path="rfq" element={<RfqPage />} />
-                <Route path="packages/:org/:project/:version" element={<PackagePage />} />
-                <Route path="packages" element={<PackagePage />} />
-                <Route path="settings" element={<Navigate to="/settings/session" replace />} />
-                {/* Session is reachable without admin so operators can paste a first API key. */}
-                <Route path="settings/session" element={<SettingsPage />} />
-                <Route path="settings/keys" element={<AdminSettings />} />
-                <Route path="settings/llm" element={<AdminSettings />} />
-                <Route path="settings/identities" element={<AdminSettings />} />
-                <Route path="settings/grants" element={<AdminSettings />} />
-                <Route path="settings/spaces" element={<AdminSettings />} />
-                <Route path="settings/reputation" element={<AdminSettings />} />
-                <Route path="settings/bindings" element={<AdminSettings />} />
-                <Route path="settings/directory" element={<AdminSettings />} />
-                <Route path="settings/federation" element={<AdminSettings />} />
-                <Route path="*" element={<Navigate to="/" replace />} />
-              </Route>
-            </Routes>
-          </BrowserRouter>
-        </AuthProvider>
-      </PersistQueryClientProvider>
+      <DomainContext.Provider value={domainPreference}>
+        <PersistQueryClientProvider client={queryClient} persistOptions={persistOptions}>
+          <AuthProvider>
+            <BrowserRouter>
+              <Routes>
+                <Route element={<Layout />}>
+                  <Route index element={<HomePage />} />
+                  <Route path="okh" element={<OkhPage />} />
+                  <Route path="okh/new" element={<CreateOkhPage />} />
+                  <Route path="okh/generate" element={<GeneratePage />} />
+                  <Route path="okh/:id/files/*" element={<OkhFilePreviewPage />} />
+                  <Route path="okh/:id" element={<OkhPage />} />
+                  <Route path="facilities" element={<OkwPage />} />
+                  <Route path="facilities/new" element={<CreateOkwPage />} />
+                  <Route path="facilities/:id/edit" element={<EditOkwPage />} />
+                  <Route path="facilities/:id" element={<OkwPage />} />
+                  <Route path="match" element={<MatchPage />} />
+                  {/* Supply trees are reached directly from their match; no browse list. */}
+                  <Route path="visualization" element={<Navigate to="/" replace />} />
+                  <Route path="visualization/:solutionId" element={<VisualizationPage />} />
+                  <Route path="rfq" element={<RfqPage />} />
+                  <Route path="packages/:org/:project/:version" element={<PackagePage />} />
+                  <Route path="packages" element={<PackagePage />} />
+                  <Route path="settings" element={<Navigate to="/settings/session" replace />} />
+                  {/* Session/Domain are reachable without admin (browser-local prefs / first key). */}
+                  <Route path="settings/session" element={<SettingsPage />} />
+                  <Route path="settings/domain" element={<SettingsPage />} />
+                  <Route path="settings/keys" element={<AdminSettings />} />
+                  <Route path="settings/llm" element={<AdminSettings />} />
+                  <Route path="settings/identities" element={<AdminSettings />} />
+                  <Route path="settings/grants" element={<AdminSettings />} />
+                  <Route path="settings/spaces" element={<AdminSettings />} />
+                  <Route path="settings/reputation" element={<AdminSettings />} />
+                  <Route path="settings/bindings" element={<AdminSettings />} />
+                  <Route path="settings/directory" element={<AdminSettings />} />
+                  <Route path="settings/federation" element={<AdminSettings />} />
+                  <Route path="*" element={<Navigate to="/" replace />} />
+                </Route>
+              </Routes>
+            </BrowserRouter>
+          </AuthProvider>
+        </PersistQueryClientProvider>
+      </DomainContext.Provider>
     </ThemeContext.Provider>
   );
 }

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -424,6 +424,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/okh/recipes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Recipes
+         * @description Get a paginated list of cooking-domain recipes found under the okh/ prefix.
+         *
+         *         Read-only browse surface for a cooking-domain instance — no create, edit,
+         *         or delete. See ``OKHService.list_recipes()``.
+         */
+        get: operations["list_recipes_api_okh_recipes_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/okh/{id}": {
         parameters: {
             query?: never;
@@ -1007,6 +1030,30 @@ export interface paths {
          *         `include_mom=false` returns local only; `force_refresh=true` refreshes MoM.
          */
         get: operations["get_okw_spaces_api_okw_spaces_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/okw/kitchens": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Kitchens
+         * @description Get a paginated list of cooking-domain kitchen capabilities found under
+         *         the okw/ prefix.
+         *
+         *         Read-only browse surface for a cooking-domain instance — no create,
+         *         edit, or delete. See ``OKWService.list_kitchens()``.
+         */
+        get: operations["list_kitchens_api_okw_kitchens_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -10379,6 +10426,59 @@ export interface operations {
             };
         };
     };
+    list_recipes_api_okh_recipes_get: {
+        parameters: {
+            query?: {
+                page?: number;
+                page_size?: number;
+                sort_by?: string | null;
+                sort_order?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     get_okh_api_okh__id__get: {
         parameters: {
             query?: {
@@ -11673,6 +11773,59 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    list_kitchens_api_okw_kitchens_get: {
+        parameters: {
+            query?: {
+                page?: number;
+                page_size?: number;
+                sort_by?: string | null;
+                sort_order?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedResponse"];
                 };
             };
             /** @description Bad Request */

--- a/frontend/src/api/ohm/kitchens.ts
+++ b/frontend/src/api/ohm/kitchens.ts
@@ -1,0 +1,36 @@
+import { apiClient, ApiError, errorMessage } from "./client";
+import type { Kitchen } from "../../types/kitchen";
+
+/** List-only: kitchens are uploaded to storage directly, not created via the UI. */
+export async function fetchAllKitchens(): Promise<Kitchen[]> {
+  const byId = new Map<string, Kitchen>();
+  let page = 1;
+  const pageSize = 100;
+
+  while (true) {
+    const { data, error, response } = await apiClient.GET("/api/okw/kitchens", {
+      params: { query: { page, page_size: pageSize } },
+    });
+    if (error || !response.ok) {
+      throw new ApiError(
+        response.status,
+        errorMessage(error, `Failed to load kitchens (HTTP ${response.status})`),
+      );
+    }
+
+    const body = (data ?? {}) as {
+      items?: Kitchen[];
+      pagination?: { has_next?: boolean; total_items?: number };
+    };
+    for (const kitchen of body.items ?? []) {
+      if (kitchen?.id != null) byId.set(kitchen.id, kitchen);
+    }
+
+    const total = body.pagination?.total_items ?? 0;
+    const hasNext = body.pagination?.has_next === true;
+    if (!hasNext || byId.size >= total || (body.items ?? []).length === 0) break;
+    page += 1;
+  }
+
+  return Array.from(byId.values());
+}

--- a/frontend/src/api/ohm/match.ts
+++ b/frontend/src/api/ohm/match.ts
@@ -12,6 +12,8 @@ export interface RunMatchParams {
    * `okh_manifest` as an alternative to `okh_id`.
    */
   okhManifest?: Record<string, unknown>;
+  /** Cooking-domain design id (mutually exclusive with okhId/okhManifest). */
+  recipeId?: string;
   maxResults?: number;
   qualityLevel?: string;
   strictMode?: boolean;
@@ -65,10 +67,12 @@ export async function runMatch(params: RunMatchParams): Promise<RawMatchResponse
     // needs (verified against the live endpoint). Cast to satisfy the strict
     // generated body type without enumerating server-defaulted fields.
     body: {
-      // Exactly one of these carries the design; the API accepts either.
+      // Exactly one of these carries the design; the API accepts any of them.
       ...(params.okhManifest
         ? { okh_manifest: params.okhManifest }
-        : { okh_id: params.okhId }),
+        : params.recipeId
+          ? { recipe_id: params.recipeId }
+          : { okh_id: params.okhId }),
       max_results: params.maxResults ?? 10,
       include_human_summary: true,
       include_explanation: true,

--- a/frontend/src/api/ohm/recipes.ts
+++ b/frontend/src/api/ohm/recipes.ts
@@ -1,0 +1,36 @@
+import { apiClient, ApiError, errorMessage } from "./client";
+import type { Recipe } from "../../types/recipe";
+
+/** List-only: recipes are uploaded to storage directly, not created via the UI. */
+export async function fetchAllRecipes(): Promise<Recipe[]> {
+  const byId = new Map<string, Recipe>();
+  let page = 1;
+  const pageSize = 100;
+
+  while (true) {
+    const { data, error, response } = await apiClient.GET("/api/okh/recipes", {
+      params: { query: { page, page_size: pageSize } },
+    });
+    if (error || !response.ok) {
+      throw new ApiError(
+        response.status,
+        errorMessage(error, `Failed to load recipes (HTTP ${response.status})`),
+      );
+    }
+
+    const body = (data ?? {}) as {
+      items?: Recipe[];
+      pagination?: { has_next?: boolean; total_items?: number };
+    };
+    for (const recipe of body.items ?? []) {
+      if (recipe?.id != null) byId.set(recipe.id, recipe);
+    }
+
+    const total = body.pagination?.total_items ?? 0;
+    const hasNext = body.pagination?.has_next === true;
+    if (!hasNext || byId.size >= total || (body.items ?? []).length === 0) break;
+    page += 1;
+  }
+
+  return Array.from(byId.values());
+}

--- a/frontend/src/api/ohm/utility.ts
+++ b/frontend/src/api/ohm/utility.ts
@@ -18,6 +18,25 @@ export async function fetchDomains(): Promise<Domain[]> {
   return ((data as { data?: { domains?: Domain[] } })?.data?.domains ?? []) as Domain[];
 }
 
+/**
+ * Server-configured default domain (`OHM_DEFAULT_DOMAIN`) for first-time
+ * visitors — e.g. a cooking-domain instance can default new browsers to
+ * "cooking" instead of the hardcoded "manufacturing" fallback. Not yet in the
+ * generated schema (the endpoint returns a plain dict), so read defensively;
+ * returns null on any failure rather than throwing, since callers treat this
+ * as a nice-to-have seed, not a hard requirement.
+ */
+export async function fetchDefaultDomain(): Promise<string | null> {
+  try {
+    const { data, error, response } = await apiClient.GET("/api/utility/domains");
+    if (error || !response.ok) return null;
+    const value = (data as { data?: { default_domain?: unknown } })?.data?.default_domain;
+    return typeof value === "string" ? value : null;
+  } catch {
+    return null;
+  }
+}
+
 export interface SystemMetrics {
   total_requests: number;
   recent_requests_1h: number;

--- a/frontend/src/components/layout/NavBar.tsx
+++ b/frontend/src/components/layout/NavBar.tsx
@@ -1,26 +1,23 @@
 import { NavLink } from "react-router-dom";
 import { useQueryClient, useIsFetching } from "@tanstack/react-query";
 import { useTheme } from "../../context/ThemeContext";
+import { useDomain } from "../../context/DomainContext";
 import { useAuth } from "../../context/AuthContext";
+import { navItemsForDomain } from "../../features/settings/domainPreference";
 import { refreshLowVolatilityData } from "../../queryClient";
-
-const navItems = [
-  { to: "/okh", label: "Designs", icon: "🔩" },
-  { to: "/facilities", label: "Facilities", icon: "🏭" },
-  { to: "/packages", label: "Packages", icon: "📦" },
-  { to: "/match", label: "Match", icon: "⚡" },
-  // Saved solutions are per-search, user-specific, and go stale fast — a supply
-  // tree is reached directly from its match (and can be downloaded), so there is
-  // no browse list. Revisit as user-scoped history once auth lands.
-  // RFQ stays dormant in v1 nav.
-] as const;
 
 export function NavBar() {
   const { isDark, toggle } = useTheme();
+  const { domain } = useDomain();
   const { isAdmin, token } = useAuth();
   const queryClient = useQueryClient();
   const isFetching = useIsFetching() > 0;
   const settingsLabel = isAdmin ? "Settings" : token ? "Session" : "Connect";
+  // Saved solutions are per-search, user-specific, and go stale fast — a supply
+  // tree is reached directly from its match (and can be downloaded), so there is
+  // no browse list. Revisit as user-scoped history once auth lands.
+  // RFQ stays dormant in v1 nav.
+  const navItems = navItemsForDomain(domain);
 
   return (
     <header className="sticky top-0 z-50 border-b border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-900">

--- a/frontend/src/context/DomainContext.tsx
+++ b/frontend/src/context/DomainContext.tsx
@@ -1,0 +1,19 @@
+import { createContext, useContext } from "react";
+import {
+  DEFAULT_DOMAIN,
+  type OhmDomain,
+} from "../features/settings/domainPreference";
+
+interface DomainContextValue {
+  domain: OhmDomain;
+  setDomain: (domain: OhmDomain) => void;
+}
+
+export const DomainContext = createContext<DomainContextValue>({
+  domain: DEFAULT_DOMAIN,
+  setDomain: () => {},
+});
+
+export function useDomain() {
+  return useContext(DomainContext);
+}

--- a/frontend/src/features/match/CookingMatchView.tsx
+++ b/frontend/src/features/match/CookingMatchView.tsx
@@ -1,0 +1,265 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { fetchAllRecipes } from "../../api/ohm/recipes";
+import { fetchAllKitchens } from "../../api/ohm/kitchens";
+import { runMatch } from "../../api/ohm/match";
+import { ApiError } from "../../api/ohm/client";
+import { solutionSelectionKey, toMatchView } from "./matchViewModel";
+import { defaultTolerance, toleranceCeiling, withinTolerance } from "./nearMiss";
+import { buildRecipeMatchRequest, SYSTEM_MODES, type SystemMode } from "./matchRequest";
+import { RecipePicker } from "./RecipePicker";
+import { KitchenFilter } from "./KitchenFilter";
+import { MatchResultCard } from "./MatchResultCard";
+import { LoadingState, EmptyState, ErrorState } from "../../components/ui/states";
+import { Button } from "../../components/ui/button";
+import { cn } from "@/lib/utils";
+
+/**
+ * Cooking-domain counterpart to MatchView: recipe + kitchens in, ranked
+ * solutions out. List-only surfaces feed it (no generate-from-URL, no RFQ
+ * handoff, no network/MoM scope — see the cooking-domain-instance plan's
+ * "Out of scope").
+ */
+export function CookingMatchView() {
+  const recipes = useQuery({ queryKey: ["recipes"], queryFn: fetchAllRecipes });
+  const kitchens = useQuery({ queryKey: ["kitchens"], queryFn: fetchAllKitchens });
+
+  const [selected, setSelected] = useState("");
+  const [mode, setMode] = useState<SystemMode>("standard");
+  const [kitchenIds, setKitchenIds] = useState<string[]>([]);
+  const [selectedSolutionKeys, setSelectedSolutionKeys] = useState<string[]>([]);
+
+  const mutation = useMutation({
+    mutationFn: ({ id, m, ids }: { id: string; m: SystemMode; ids: string[] }) =>
+      runMatch(buildRecipeMatchRequest(id, m, undefined, ids)),
+    onSuccess: () => setSelectedSolutionKeys([]),
+  });
+
+  const rawView = useMemo(
+    () => (mutation.data ? toMatchView(mutation.data) : null),
+    [mutation.data],
+  );
+
+  const requirementCount = useMemo(
+    () =>
+      rawView?.solutions.reduce((max, s) => Math.max(max, s.coverage?.total ?? 0), 0) ?? 0,
+    [rawView],
+  );
+  const ceiling = toleranceCeiling(requirementCount);
+  const [tolerance, setTolerance] = useState<number | null>(null);
+  const effectiveTolerance = Math.min(
+    tolerance ?? defaultTolerance(requirementCount),
+    ceiling,
+  );
+
+  const view = useMemo(() => {
+    if (!rawView) return null;
+    return {
+      ...rawView,
+      solutions: rawView.solutions.filter((s) => withinTolerance(s.coverage, effectiveTolerance)),
+    };
+  }, [rawView, effectiveTolerance]);
+
+  const hiddenCount = (rawView?.solutions.length ?? 0) - (view?.solutions.length ?? 0);
+  const modeInfo = SYSTEM_MODES.find((s) => s.mode === mode);
+  const canRun = !!selected && kitchenIds.length > 0 && !mutation.isPending;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">Match a Recipe</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Choose a recipe and the kitchens to compare, then run a match.
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        <RecipePicker
+          recipes={recipes.data ?? []}
+          selectedId={selected}
+          onSelect={setSelected}
+          isLoading={recipes.isLoading}
+          isError={recipes.isError}
+        />
+
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="flex-1">
+            <span className="mb-1 block text-sm text-muted-foreground">System mode</span>
+            <div
+              role="radiogroup"
+              aria-label="System mode"
+              className="inline-flex overflow-hidden rounded-md border border-input"
+            >
+              {SYSTEM_MODES.map((s) => (
+                <button
+                  key={s.mode}
+                  type="button"
+                  role="radio"
+                  aria-checked={mode === s.mode}
+                  onClick={() => setMode(s.mode)}
+                  className={cn(
+                    "px-3 py-1.5 text-sm transition-colors",
+                    mode === s.mode
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-background text-foreground hover:bg-accent",
+                  )}
+                >
+                  {s.label}
+                </button>
+              ))}
+            </div>
+            {modeInfo && (
+              <p className="mt-1.5 max-w-xl text-xs text-muted-foreground">
+                {modeInfo.description}
+              </p>
+            )}
+          </div>
+          <Button
+            disabled={!canRun}
+            onClick={() => mutation.mutate({ id: selected, m: mode, ids: kitchenIds })}
+          >
+            {mutation.isPending ? "Matching…" : "⚡ Run Match"}
+          </Button>
+        </div>
+        {selected && kitchenIds.length === 0 && (
+          <p className="text-xs text-amber-700 dark:text-amber-400">
+            Select at least one kitchen below before running a match.
+          </p>
+        )}
+        {!selected && (
+          <p className="text-xs text-amber-700 dark:text-amber-400">
+            Search and select a recipe above before running a match.
+          </p>
+        )}
+
+        <KitchenFilter
+          kitchens={kitchens.data ?? []}
+          selectedIds={kitchenIds}
+          onChange={setKitchenIds}
+          isLoading={kitchens.isLoading}
+          isError={kitchens.isError}
+        />
+      </div>
+
+      {mutation.isPending && <LoadingState message="Matching against kitchens…" />}
+      {mutation.isError && (
+        <ErrorState
+          description={
+            mutation.error instanceof ApiError
+              ? [
+                  mutation.error.message,
+                  mutation.error.requestId ? `Request ID: ${mutation.error.requestId}` : null,
+                ]
+                  .filter(Boolean)
+                  .join(" — ")
+              : mutation.error instanceof Error
+                ? mutation.error.message
+                : "Match failed."
+          }
+          onRetry={() => canRun && mutation.mutate({ id: selected, m: mode, ids: kitchenIds })}
+        />
+      )}
+
+      {view &&
+        !mutation.isPending &&
+        (view.solutions.length === 0 ? (
+          <EmptyState
+            icon="🔍"
+            title="No matches found"
+            description="No kitchens can currently make this recipe."
+          />
+        ) : (
+          <div className="space-y-4">
+            {view.summary && (
+              <p className="rounded-lg border bg-muted/40 p-4 text-sm text-foreground">
+                {view.summary}
+              </p>
+            )}
+            {view.coverageGaps.length > 0 && (
+              <div className="rounded-lg border border-yellow-300 bg-yellow-50 p-4 text-sm dark:border-yellow-800 dark:bg-yellow-950/30">
+                <p className="font-medium text-yellow-800 dark:text-yellow-300">
+                  Coverage gaps
+                </p>
+                <p className="mt-1 text-yellow-700 dark:text-yellow-400">
+                  Unmatched: {view.coverageGaps.join(", ")}
+                </p>
+              </div>
+            )}
+            {ceiling > 0 && (
+              <div className="rounded-lg border border-input bg-muted/30 p-4">
+                <label
+                  htmlFor="near-miss-tolerance"
+                  className="block text-sm font-medium text-foreground"
+                >
+                  Allow kitchens missing up to{" "}
+                  {effectiveTolerance === 0
+                    ? "nothing"
+                    : `${effectiveTolerance} requirement${effectiveTolerance === 1 ? "" : "s"}`}
+                </label>
+                <input
+                  id="near-miss-tolerance"
+                  type="range"
+                  min={0}
+                  max={ceiling}
+                  step={1}
+                  value={effectiveTolerance}
+                  onChange={(e) => setTolerance(Number(e.target.value))}
+                  className="mt-2 w-full max-w-sm"
+                />
+                <p className="mt-1 text-xs text-muted-foreground">
+                  This recipe has {requirementCount} requirements. The most you can relax to
+                  is {ceiling}, so a result always meets at least two.
+                  {hiddenCount > 0 &&
+                    ` ${hiddenCount} kitchen${hiddenCount === 1 ? " is" : "s are"} hidden at this setting.`}
+                </p>
+              </div>
+            )}
+
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <p className="text-xs text-muted-foreground">
+                {view.totalSolutions} solution{view.totalSolutions !== 1 ? "s" : ""}
+                {selectedSolutionKeys.length > 0 ? ` · ${selectedSolutionKeys.length} selected` : ""}
+              </p>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={view.solutions.length === 0}
+                  onClick={() =>
+                    setSelectedSolutionKeys(view.solutions.map((s, i) => solutionSelectionKey(s, i)))
+                  }
+                >
+                  Select all
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={selectedSolutionKeys.length === 0}
+                  onClick={() => setSelectedSolutionKeys([])}
+                >
+                  Clear selection
+                </Button>
+              </div>
+            </div>
+            {view.solutions.map((s, i) => {
+              const key = solutionSelectionKey(s, i);
+              return (
+                <MatchResultCard
+                  key={key}
+                  solution={s}
+                  solutionId={view.solutionId}
+                  selectionKey={key}
+                  selected={selectedSolutionKeys.includes(key)}
+                  onToggle={() =>
+                    setSelectedSolutionKeys((prev) =>
+                      prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key],
+                    )
+                  }
+                />
+              );
+            })}
+          </div>
+        ))}
+    </div>
+  );
+}

--- a/frontend/src/features/match/KitchenFilter.tsx
+++ b/frontend/src/features/match/KitchenFilter.tsx
@@ -1,0 +1,104 @@
+import { useMemo, useState } from "react";
+import type { Kitchen } from "../../types/kitchen";
+
+/**
+ * Kitchen scope for cooking-domain matching. Deliberately simpler than
+ * FacilityFilter (no geo filters): kitchens have no location fields.
+ */
+export function KitchenFilter({
+  kitchens,
+  selectedIds,
+  onChange,
+  isLoading,
+  isError,
+}: {
+  kitchens: Kitchen[];
+  selectedIds: string[];
+  onChange: (ids: string[]) => void;
+  isLoading?: boolean;
+  isError?: boolean;
+}) {
+  const [q, setQ] = useState("");
+  const selected = useMemo(() => new Set(selectedIds), [selectedIds]);
+
+  const visible = useMemo(() => {
+    const needle = q.trim().toLowerCase();
+    if (!needle) return kitchens;
+    return kitchens.filter((k) => k.name.toLowerCase().includes(needle));
+  }, [kitchens, q]);
+
+  const summary =
+    selectedIds.length === 0
+      ? "Select kitchens to match against"
+      : `${selectedIds.length} kitchen${selectedIds.length === 1 ? "" : "s"} selected`;
+
+  function toggle(id: string) {
+    const next = new Set(selected);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    onChange([...next]);
+  }
+
+  return (
+    <fieldset className="max-w-2xl rounded-lg border border-input p-4">
+      <legend className="px-1 text-sm font-medium text-foreground">Kitchens</legend>
+      <p className="mb-3 text-xs text-muted-foreground">{summary}</p>
+
+      {isLoading && <p className="text-sm text-muted-foreground">Loading kitchens…</p>}
+      {isError && (
+        <p className="text-sm text-red-600 dark:text-red-400">
+          Couldn’t load kitchens. Try again before running a match.
+        </p>
+      )}
+
+      {!isLoading && !isError && (
+        <div className="space-y-3">
+          <input
+            type="search"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Filter kitchens by name…"
+            aria-label="Filter kitchens by name"
+            className="w-full rounded-md border border-input bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+          <div className="flex gap-3 text-xs">
+            <button
+              type="button"
+              className="text-indigo-600 hover:underline dark:text-indigo-400"
+              onClick={() => onChange(visible.map((k) => k.id))}
+            >
+              Select all visible
+            </button>
+            <button
+              type="button"
+              className="text-slate-600 hover:underline dark:text-slate-300"
+              onClick={() => onChange([])}
+            >
+              Clear
+            </button>
+          </div>
+          <ul className="max-h-56 space-y-1 overflow-y-auto rounded-md border border-input p-2">
+            {visible.map((k) => (
+              <li key={k.id}>
+                <label className="flex items-center gap-2 text-sm text-foreground">
+                  <input
+                    type="checkbox"
+                    aria-label={k.name}
+                    checked={selected.has(k.id)}
+                    onChange={() => toggle(k.id)}
+                  />
+                  <span className="min-w-0 flex-1 truncate">{k.name}</span>
+                </label>
+              </li>
+            ))}
+            {visible.length === 0 && (
+              <li className="text-sm text-muted-foreground">
+                No kitchens match the current filter.
+              </li>
+            )}
+          </ul>
+        </div>
+      )}
+    </fieldset>
+  );
+}

--- a/frontend/src/features/match/RecipePicker.tsx
+++ b/frontend/src/features/match/RecipePicker.tsx
@@ -1,0 +1,128 @@
+import { useMemo, useState } from "react";
+import type { Recipe } from "../../types/recipe";
+
+const RESULT_LIMIT = 40;
+
+/**
+ * Search + pick a recipe for matching. Deliberately simpler than DesignPicker
+ * (no facets): a cooking-domain instance's recipe catalogue is expected to be
+ * small — see the cooking-domain-instance plan.
+ */
+export function RecipePicker({
+  recipes,
+  selectedId,
+  onSelect,
+  isLoading,
+  isError,
+}: {
+  recipes: Recipe[];
+  selectedId: string;
+  onSelect: (id: string) => void;
+  isLoading?: boolean;
+  isError?: boolean;
+}) {
+  const [q, setQ] = useState("");
+
+  const selected = useMemo(
+    () => recipes.find((r) => r.id === selectedId) ?? null,
+    [recipes, selectedId],
+  );
+
+  const matched = useMemo(() => {
+    const needle = q.trim().toLowerCase();
+    if (!needle) return recipes;
+    return recipes.filter((r) => r.name.toLowerCase().includes(needle));
+  }, [recipes, q]);
+
+  const shown = matched.slice(0, RESULT_LIMIT);
+
+  return (
+    <fieldset className="rounded-lg border border-input p-4">
+      <legend className="px-1 text-sm font-medium text-foreground">Recipe</legend>
+
+      {selected ? (
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-2 rounded-md border border-indigo-200 bg-indigo-50/70 px-3 py-2 dark:border-indigo-800 dark:bg-indigo-950/30">
+          <div className="min-w-0">
+            <p className="text-xs text-indigo-700 dark:text-indigo-400">Selected recipe</p>
+            <p className="truncate font-medium text-indigo-950 dark:text-indigo-100">
+              {selected.name}
+            </p>
+          </div>
+          <button
+            type="button"
+            className="shrink-0 text-xs text-indigo-700 hover:underline dark:text-indigo-300"
+            onClick={() => onSelect("")}
+          >
+            Clear
+          </button>
+        </div>
+      ) : (
+        <p className="mb-3 text-xs text-muted-foreground">
+          Search and pick a recipe to match.
+        </p>
+      )}
+
+      {isLoading && <p className="text-sm text-muted-foreground">Loading recipes…</p>}
+      {isError && (
+        <p className="text-sm text-red-600 dark:text-red-400">
+          Couldn’t load recipes. Try refreshing the page.
+        </p>
+      )}
+
+      {!isLoading && !isError && (
+        <div className="space-y-3">
+          <input
+            type="search"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search recipes…"
+            aria-label="Search recipes"
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+
+          {shown.length === 0 ? (
+            <p className="rounded-md border border-input px-3 py-2 text-sm text-muted-foreground">
+              No recipes match the current search.
+            </p>
+          ) : (
+            <div
+              role="listbox"
+              aria-label="Recipe search results"
+              className="max-h-56 space-y-1 overflow-y-auto rounded-md border border-input p-1"
+            >
+              {shown.map((r) => {
+                const active = r.id === selectedId;
+                return (
+                  <button
+                    key={r.id}
+                    type="button"
+                    role="option"
+                    aria-selected={active}
+                    onClick={() => onSelect(r.id)}
+                    className={
+                      active
+                        ? "flex w-full flex-col items-start rounded-md bg-indigo-100 px-3 py-2 text-left dark:bg-indigo-950/50"
+                        : "flex w-full flex-col items-start rounded-md px-3 py-2 text-left hover:bg-accent"
+                    }
+                  >
+                    <span className="text-sm font-medium text-foreground break-words">
+                      {r.name}
+                    </span>
+                    <span className="mt-0.5 text-xs text-muted-foreground">
+                      {r.ingredients.length} ingredient{r.ingredients.length !== 1 ? "s" : ""}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+          <p className="text-xs text-muted-foreground">
+            Showing {shown.length}
+            {matched.length > RESULT_LIMIT ? ` of ${matched.length}` : ""} recipe
+            {matched.length !== 1 ? "s" : ""}
+          </p>
+        </div>
+      )}
+    </fieldset>
+  );
+}

--- a/frontend/src/features/match/matchRequest.test.ts
+++ b/frontend/src/features/match/matchRequest.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildInlineMatchRequest, buildMatchRequest } from "./matchRequest";
+import {
+  buildInlineMatchRequest,
+  buildMatchRequest,
+  buildRecipeMatchRequest,
+} from "./matchRequest";
 
 describe("buildMatchRequest", () => {
   it("maps minimal to relaxed params", () => {
@@ -91,5 +95,32 @@ describe("buildInlineMatchRequest", () => {
 
   it("omits an empty facility subset", () => {
     expect(buildInlineMatchRequest(manifest, "standard", undefined, []).okwIds).toBeUndefined();
+  });
+});
+
+describe("buildRecipeMatchRequest", () => {
+  it("sends a recipeId instead of an okhId", () => {
+    const req = buildRecipeMatchRequest("recipe-1", "standard");
+    expect(req.recipeId).toBe("recipe-1");
+    expect(req.okhId).toBeUndefined();
+  });
+
+  it("carries the system mode through, like the OKH builder", () => {
+    const recipe = buildRecipeMatchRequest("recipe-1", "strict");
+    const okh = buildMatchRequest("okh-1", "strict");
+    expect(recipe.qualityLevel).toBe(okh.qualityLevel);
+    expect(recipe.strictMode).toBe(okh.strictMode);
+  });
+
+  it("includes okwIds when a kitchen subset is chosen", () => {
+    expect(
+      buildRecipeMatchRequest("recipe-1", "standard", undefined, ["k1", "k2"]).okwIds,
+    ).toEqual(["k1", "k2"]);
+  });
+
+  it("omits okwIds when the subset is empty (match all kitchens)", () => {
+    expect(buildRecipeMatchRequest("recipe-1", "standard", undefined, [])).not.toHaveProperty(
+      "okwIds",
+    );
   });
 });

--- a/frontend/src/features/match/matchRequest.ts
+++ b/frontend/src/features/match/matchRequest.ts
@@ -59,6 +59,21 @@ export function buildMatchRequest(
 }
 
 /**
+ * Cooking-domain equivalent of `buildMatchRequest`: matches a recipe against a
+ * set of kitchens (kitchen ids share the OKW id space — see
+ * `KitchenCapability.is_cooking_capability`, so they pass through as okwIds).
+ */
+export function buildRecipeMatchRequest(
+  recipeId: string,
+  mode: SystemMode,
+  maxResults?: number,
+  kitchenIds?: string[],
+): RunMatchParams {
+  const subset = kitchenIds && kitchenIds.length > 0 ? { okwIds: kitchenIds } : {};
+  return { recipeId, ...MODE_PARAMS[mode], maxResults, ...subset };
+}
+
+/**
  * Same, for a design that is not in the catalogue — a manifest generated from a
  * repository URL and reviewed in-session. Generation deliberately does not save,
  * so there is no id to match by.

--- a/frontend/src/features/okh/RecipeListView.tsx
+++ b/frontend/src/features/okh/RecipeListView.tsx
@@ -1,0 +1,60 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchAllRecipes } from "../../api/ohm/recipes";
+import { LoadingState, EmptyState, ErrorState } from "../../components/ui/states";
+
+/**
+ * Cooking-domain recipe browse: list-only (no facets, no create, no detail
+ * page — see the cooking-domain-instance plan's "Out of scope"). Recipes are
+ * uploaded to storage directly, not created here.
+ */
+export function RecipeListView() {
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: ["recipes"],
+    queryFn: fetchAllRecipes,
+  });
+
+  const recipes = data ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">Recipes</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Recipes available for matching on this cooking-domain instance.
+        </p>
+      </div>
+
+      {isLoading && <LoadingState message="Loading recipes…" />}
+      {isError && (
+        <ErrorState
+          description={error instanceof Error ? error.message : "Failed to load recipes."}
+          onRetry={() => refetch()}
+        />
+      )}
+      {!isLoading && !isError && recipes.length === 0 && (
+        <EmptyState
+          icon="🍳"
+          title="No recipes yet"
+          description="Upload recipe JSON to this instance's storage under okh/ to see them here."
+        />
+      )}
+      {!isLoading && !isError && recipes.length > 0 && (
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {recipes.map((recipe) => (
+            <div
+              key={recipe.id}
+              className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-900"
+            >
+              <h2 className="font-semibold text-foreground">{recipe.name}</h2>
+              <p className="mt-2 text-xs text-muted-foreground">
+                {recipe.ingredients.length} ingredient
+                {recipe.ingredients.length !== 1 ? "s" : ""} ·{" "}
+                {recipe.instructions.length} step{recipe.instructions.length !== 1 ? "s" : ""}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/okw/KitchenListView.tsx
+++ b/frontend/src/features/okw/KitchenListView.tsx
@@ -1,0 +1,60 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchAllKitchens } from "../../api/ohm/kitchens";
+import { LoadingState, EmptyState, ErrorState } from "../../components/ui/states";
+
+/**
+ * Cooking-domain kitchen browse: list-only (no facets, no create, no detail
+ * page — see the cooking-domain-instance plan's "Out of scope"). Kitchens
+ * are uploaded to storage directly, not created here.
+ */
+export function KitchenListView() {
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: ["kitchens"],
+    queryFn: fetchAllKitchens,
+  });
+
+  const kitchens = data ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">Kitchens</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Kitchens available for matching on this cooking-domain instance.
+        </p>
+      </div>
+
+      {isLoading && <LoadingState message="Loading kitchens…" />}
+      {isError && (
+        <ErrorState
+          description={error instanceof Error ? error.message : "Failed to load kitchens."}
+          onRetry={() => refetch()}
+        />
+      )}
+      {!isLoading && !isError && kitchens.length === 0 && (
+        <EmptyState
+          icon="🍽️"
+          title="No kitchens yet"
+          description="Upload kitchen JSON to this instance's storage under okw/ to see them here."
+        />
+      )}
+      {!isLoading && !isError && kitchens.length > 0 && (
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {kitchens.map((kitchen) => (
+            <div
+              key={kitchen.id}
+              className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-900"
+            >
+              <h2 className="font-semibold text-foreground">{kitchen.name}</h2>
+              <p className="mt-2 text-xs text-muted-foreground">
+                {kitchen.appliances.length} appliance
+                {kitchen.appliances.length !== 1 ? "s" : ""} · {kitchen.tools.length} tool
+                {kitchen.tools.length !== 1 ? "s" : ""}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/settings/DomainPanel.tsx
+++ b/frontend/src/features/settings/DomainPanel.tsx
@@ -1,0 +1,99 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchDomains } from "../../api/ohm/utility";
+import { useDomain } from "../../context/DomainContext";
+import { DEFAULT_DOMAIN, type OhmDomain } from "./domainPreference";
+
+const FALLBACK_OPTIONS: { id: OhmDomain; name: string; description: string }[] = [
+  {
+    id: "manufacturing",
+    name: "Manufacturing",
+    description: "Hardware designs and manufacturing facilities (OKH / OKW).",
+  },
+  {
+    id: "cooking",
+    name: "Cooking",
+    description: "Recipes and kitchens for cooking-domain matching.",
+  },
+];
+
+function domainChoices(
+  apiDomains: { id: string; name: string; description?: string | null }[] | undefined,
+): typeof FALLBACK_OPTIONS {
+  const byId = new Map(FALLBACK_OPTIONS.map((o) => [o.id, { ...o }]));
+  for (const d of apiDomains ?? []) {
+    if (d.id !== "manufacturing" && d.id !== "cooking") continue;
+    const id = d.id as OhmDomain;
+    const base = byId.get(id)!;
+    byId.set(id, {
+      id,
+      name: d.name || base.name,
+      description: d.description || base.description,
+    });
+  }
+  return FALLBACK_OPTIONS.map((f) => byId.get(f.id)!);
+}
+
+export function DomainPanel() {
+  const { domain, setDomain } = useDomain();
+  const domains = useQuery({ queryKey: ["domains"], queryFn: fetchDomains });
+  const choices = domainChoices(domains.data);
+
+  return (
+    <div className="space-y-6">
+      <section
+        aria-labelledby="domain-selection-heading"
+        className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900"
+      >
+        <h2 id="domain-selection-heading" className="text-lg font-semibold text-foreground">
+          Domain selection
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Choose one matching domain for this browser. Default is {DEFAULT_DOMAIN}. Cooking
+          shows Recipes and Kitchens in the nav; manufacturing shows Designs, Facilities,
+          Packages, and Match.
+        </p>
+
+        <fieldset className="mt-4 space-y-3">
+          <legend className="sr-only">Active domain</legend>
+          {choices.map((opt) => {
+            const selected = domain === opt.id;
+            return (
+              <label
+                key={opt.id}
+                className={[
+                  "flex cursor-pointer gap-3 rounded-lg border p-3 transition-colors",
+                  selected
+                    ? "border-indigo-600 bg-indigo-50 dark:border-indigo-400 dark:bg-indigo-950"
+                    : "border-slate-200 hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800",
+                ].join(" ")}
+              >
+                <input
+                  type="radio"
+                  name="ohm-domain"
+                  value={opt.id}
+                  checked={selected}
+                  onChange={() => setDomain(opt.id)}
+                  className="mt-1"
+                />
+                <span>
+                  <span className="block text-sm font-medium text-foreground">{opt.name}</span>
+                  {opt.description && (
+                    <span className="mt-0.5 block text-sm text-muted-foreground">
+                      {opt.description}
+                    </span>
+                  )}
+                </span>
+              </label>
+            );
+          })}
+        </fieldset>
+
+        {domains.isError && (
+          <p className="mt-3 text-xs text-muted-foreground" role="status">
+            Could not load domains from the API; showing built-in options.
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/features/settings/domainPreference.test.ts
+++ b/frontend/src/features/settings/domainPreference.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_DOMAIN,
+  navItemsForDomain,
+  parseDomain,
+} from "./domainPreference";
+
+describe("parseDomain", () => {
+  it("defaults to manufacturing for null/empty/invalid", () => {
+    expect(DEFAULT_DOMAIN).toBe("manufacturing");
+    expect(parseDomain(null)).toBe("manufacturing");
+    expect(parseDomain("")).toBe("manufacturing");
+    expect(parseDomain("unknown")).toBe("manufacturing");
+  });
+
+  it("accepts manufacturing and cooking", () => {
+    expect(parseDomain("manufacturing")).toBe("manufacturing");
+    expect(parseDomain("cooking")).toBe("cooking");
+  });
+});
+
+describe("navItemsForDomain", () => {
+  it("manufacturing shows Designs, Facilities, Packages, Match", () => {
+    expect(navItemsForDomain("manufacturing").map((i) => i.label)).toEqual([
+      "Designs",
+      "Facilities",
+      "Packages",
+      "Match",
+    ]);
+  });
+
+  it("cooking shows only Recipes and Kitchens", () => {
+    const items = navItemsForDomain("cooking");
+    expect(items.map((i) => i.label)).toEqual(["Recipes", "Kitchens"]);
+    expect(items.map((i) => i.to)).toEqual(["/okh", "/facilities"]);
+  });
+});

--- a/frontend/src/features/settings/domainPreference.ts
+++ b/frontend/src/features/settings/domainPreference.ts
@@ -1,0 +1,36 @@
+/** Browser-local OHM matching domain preference (Settings → Domain). */
+
+export type OhmDomain = "manufacturing" | "cooking";
+
+export const DEFAULT_DOMAIN: OhmDomain = "manufacturing";
+
+export const STORAGE_KEY = "ohm-domain";
+
+export interface DomainNavItem {
+  to: string;
+  label: string;
+  icon: string;
+}
+
+const MANUFACTURING_NAV: DomainNavItem[] = [
+  { to: "/okh", label: "Designs", icon: "🔩" },
+  { to: "/facilities", label: "Facilities", icon: "🏭" },
+  { to: "/packages", label: "Packages", icon: "📦" },
+  { to: "/match", label: "Match", icon: "⚡" },
+];
+
+const COOKING_NAV: DomainNavItem[] = [
+  { to: "/okh", label: "Recipes", icon: "🍳" },
+  { to: "/facilities", label: "Kitchens", icon: "🍽️" },
+];
+
+/** Coerce a stored/API value to a known domain; unknown → manufacturing. */
+export function parseDomain(raw: string | null | undefined): OhmDomain {
+  if (raw === "cooking" || raw === "manufacturing") return raw;
+  return DEFAULT_DOMAIN;
+}
+
+/** Primary nav items for the selected domain (Settings/Docs are separate). */
+export function navItemsForDomain(domain: OhmDomain): DomainNavItem[] {
+  return domain === "cooking" ? COOKING_NAV : MANUFACTURING_NAV;
+}

--- a/frontend/src/hooks/useDomainPreference.test.ts
+++ b/frontend/src/hooks/useDomainPreference.test.ts
@@ -1,0 +1,62 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { server } from "../test/msw/server";
+import { STORAGE_KEY } from "../features/settings/domainPreference";
+import { useDomainPreference } from "./useDomainPreference";
+
+function mockServerDefault(defaultDomain: string) {
+  server.use(
+    http.get("*/v1/api/utility/domains", () =>
+      HttpResponse.json({ data: { domains: [], default_domain: defaultDomain } }),
+    ),
+  );
+}
+
+/** This jsdom test environment has no real localStorage; stub a minimal one
+ * so the hook's stored-preference branch is actually exercised. */
+function stubLocalStorage() {
+  const store = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => void store.set(key, value),
+    clear: () => store.clear(),
+  });
+}
+
+describe("useDomainPreference", () => {
+  beforeEach(() => {
+    stubLocalStorage();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("defaults to manufacturing before the server default_domain resolves", () => {
+    const { result } = renderHook(() => useDomainPreference());
+    expect(result.current.domain).toBe("manufacturing");
+  });
+
+  it("adopts the server's default_domain on a first visit (no stored preference)", async () => {
+    mockServerDefault("cooking");
+    const { result } = renderHook(() => useDomainPreference());
+    await waitFor(() => expect(result.current.domain).toBe("cooking"));
+  });
+
+  it("does not override an existing stored preference", async () => {
+    localStorage.setItem(STORAGE_KEY, "manufacturing");
+    mockServerDefault("cooking");
+    const { result } = renderHook(() => useDomainPreference());
+    // Give the (unmade, but just in case) fetch a tick to resolve.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(result.current.domain).toBe("manufacturing");
+  });
+
+  it("does not clobber a manual change made while the fetch is in flight", async () => {
+    mockServerDefault("cooking");
+    const { result } = renderHook(() => useDomainPreference());
+    act(() => result.current.setDomain("manufacturing"));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(result.current.domain).toBe("manufacturing");
+  });
+});

--- a/frontend/src/hooks/useDomainPreference.ts
+++ b/frontend/src/hooks/useDomainPreference.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef, useState } from "react";
+import { fetchDefaultDomain } from "../api/ohm/utility";
+import {
+  DEFAULT_DOMAIN,
+  STORAGE_KEY,
+  parseDomain,
+  type OhmDomain,
+} from "../features/settings/domainPreference";
+
+function getInitialDomain(): OhmDomain {
+  try {
+    return parseDomain(localStorage.getItem(STORAGE_KEY));
+  } catch {
+    return DEFAULT_DOMAIN;
+  }
+}
+
+function hasStoredPreference(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) != null;
+  } catch {
+    return false;
+  }
+}
+
+export function useDomainPreference() {
+  const [domain, setDomainState] = useState<OhmDomain>(getInitialDomain);
+  // Only a *first* visit (no stored preference yet) should adopt the server's
+  // configured default — e.g. a cooking-domain Azure instance defaulting new
+  // browsers to "cooking". Once a choice exists, localStorage owns it.
+  const hadStoredPreference = useRef(hasStoredPreference());
+  const userChanged = useRef(false);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, domain);
+    } catch {
+      // ignore (private browsing, quota, etc.)
+    }
+  }, [domain]);
+
+  useEffect(() => {
+    if (hadStoredPreference.current) return;
+    let cancelled = false;
+    fetchDefaultDomain().then((serverDefault) => {
+      if (cancelled || userChanged.current || !serverDefault) return;
+      setDomainState(parseDomain(serverDefault));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return {
+    domain,
+    setDomain: (next: OhmDomain) => {
+      userChanged.current = true;
+      setDomainState(parseDomain(next));
+    },
+  };
+}

--- a/frontend/src/pages/MatchPage.tsx
+++ b/frontend/src/pages/MatchPage.tsx
@@ -1,5 +1,7 @@
 import { useLocation, useSearchParams } from "react-router-dom";
 import { MatchView } from "../features/match/MatchView";
+import { CookingMatchView } from "../features/match/CookingMatchView";
+import { useDomain } from "../context/DomainContext";
 
 /** Hand-off payload from generate-from-URL: a reviewed but unsaved manifest. */
 export interface InlineMatchState {
@@ -10,8 +12,10 @@ export interface InlineMatchState {
 const NETWORK_AXES = ["country", "city", "process", "source", "status", "region", "access_type"] as const;
 
 export function MatchPage() {
+  const { domain } = useDomain();
   const [searchParams] = useSearchParams();
   const location = useLocation();
+  if (domain === "cooking") return <CookingMatchView />;
   const okhId = searchParams.get("okh_id") ?? undefined;
   const okwId = searchParams.get("okw_id") ?? undefined;
 

--- a/frontend/src/pages/OkhPage.tsx
+++ b/frontend/src/pages/OkhPage.tsx
@@ -1,8 +1,13 @@
 import { useParams } from "react-router-dom";
 import { OkhListView } from "../features/okh/OkhListView";
 import { OkhDetailView } from "../features/okh/OkhDetailView";
+import { RecipeListView } from "../features/okh/RecipeListView";
+import { useDomain } from "../context/DomainContext";
 
 export function OkhPage() {
   const { id } = useParams<{ id?: string }>();
-  return id ? <OkhDetailView id={id} /> : <OkhListView />;
+  const { domain } = useDomain();
+  if (id) return <OkhDetailView id={id} />;
+  // Cooking has no detail page (list-only, see the cooking-domain-instance plan).
+  return domain === "cooking" ? <RecipeListView /> : <OkhListView />;
 }

--- a/frontend/src/pages/OkwPage.tsx
+++ b/frontend/src/pages/OkwPage.tsx
@@ -1,10 +1,15 @@
 import { useParams } from "react-router-dom";
 import { NetworkView } from "../features/network/NetworkView";
 import { OkwDetailView } from "../features/okw/OkwDetailView";
+import { KitchenListView } from "../features/okw/KitchenListView";
+import { useDomain } from "../context/DomainContext";
 
 export function OkwPage() {
   const { id } = useParams<{ id?: string }>();
+  const { domain } = useDomain();
   // The list route is the unified network surface (local OKW ∪ MoM); the detail
-  // route stays the local OKW facility page.
-  return id ? <OkwDetailView id={id} /> : <NetworkView />;
+  // route stays the local OKW facility page. Cooking has no detail page
+  // (list-only, see the cooking-domain-instance plan).
+  if (id) return <OkwDetailView id={id} />;
+  return domain === "cooking" ? <KitchenListView /> : <NetworkView />;
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { NavLink, useLocation } from "react-router-dom";
 import { SessionPanel } from "../features/settings/SessionPanel";
+import { DomainPanel } from "../features/settings/DomainPanel";
 import { KeysAccountsPanel } from "../features/settings/KeysAccountsPanel";
 import { IdentitiesPanel } from "../features/settings/IdentitiesPanel";
 import { GrantsPanel } from "../features/settings/GrantsPanel";
@@ -12,7 +13,10 @@ import { LLMCredentialsPanel } from "../features/settings/LLMCredentialsPanel";
 import { SecurityPolicyBadge } from "../features/settings/SecurityPolicyBadge";
 import { useAuth } from "../context/AuthContext";
 
-const sessionTab = { to: "/settings/session", label: "Session" } as const;
+const sessionTabs = [
+  { to: "/settings/session", label: "Session" },
+  { to: "/settings/domain", label: "Domain" },
+] as const;
 
 const adminTabs = [
   { to: "/settings/keys", label: "Keys & accounts" },
@@ -27,6 +31,7 @@ const adminTabs = [
 ] as const;
 
 function panelFor(pathname: string) {
+  if (pathname.includes("/domain")) return <DomainPanel />;
   if (pathname.includes("/keys")) return <KeysAccountsPanel />;
   if (pathname.includes("/llm")) return <LLMCredentialsPanel />;
   if (pathname.includes("/identities")) return <IdentitiesPanel />;
@@ -42,7 +47,7 @@ function panelFor(pathname: string) {
 export function SettingsPage() {
   const { pathname } = useLocation();
   const { isAdmin } = useAuth();
-  const tabs = isAdmin ? [sessionTab, ...adminTabs] : [sessionTab];
+  const tabs = isAdmin ? [...sessionTabs, ...adminTabs] : [...sessionTabs];
 
   return (
     <div className="space-y-6">
@@ -50,8 +55,8 @@ export function SettingsPage() {
         <h1 className="text-2xl font-bold tracking-tight text-foreground">Settings</h1>
         <p className="mt-1 text-sm text-muted-foreground">
           {isAdmin
-            ? "Manage session, keys, LLM providers, identities, grants, spaces, bindings, directory, and federation for this OHM instance."
-            : "Paste an API key to authenticate this browser tab. Admin tabs appear after whoami reports admin."}
+            ? "Manage session, domain, keys, LLM providers, identities, grants, spaces, bindings, directory, and federation for this OHM instance."
+            : "Paste an API key or choose a matching domain for this browser tab. Admin tabs appear after whoami reports admin."}
         </p>
       </div>
 

--- a/frontend/src/test/fixtures/index.ts
+++ b/frontend/src/test/fixtures/index.ts
@@ -19,6 +19,7 @@ export const domainsFixture = {
       { id: "manufacturing", name: "Manufacturing", description: "Hardware manufacturing" },
       { id: "cooking", name: "Cooking & Food Prep", description: "Recipe matching" },
     ],
+    default_domain: "manufacturing",
   },
 };
 

--- a/frontend/src/types/kitchen.ts
+++ b/frontend/src/types/kitchen.ts
@@ -1,0 +1,10 @@
+/** Cooking-domain kitchen, mirroring src/core/domains/cooking/models.py KitchenCapability. */
+
+export interface Kitchen {
+  id: string;
+  name: string;
+  appliances: string[];
+  tools: string[];
+  ingredients: string[];
+  domain: "cooking";
+}

--- a/frontend/src/types/recipe.ts
+++ b/frontend/src/types/recipe.ts
@@ -1,0 +1,10 @@
+/** Cooking-domain recipe, mirroring src/core/domains/cooking/models.py Recipe. */
+
+export interface Recipe {
+  id: string;
+  name: string;
+  ingredients: string[];
+  instructions: string[];
+  equipment: string[];
+  domain: "cooking";
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,8 @@ dependencies = [
     "faker>=19.0.0",
     "geopy>=2.3.0",
     # Document parsing
-    "pypdf>=6.14.2",
+    # Security pin: PYSEC-2026-3655, PYSEC-2026-3656 (fixed 6.15.0).
+    "pypdf>=6.15.0",
     "python-docx>=1.0.0",
     # TOML
     "tomli_w>=1.2.0",
@@ -107,6 +108,10 @@ docs = [
     # is licensed and its hook/theme story is settled.
     "mkdocs>=1.6,<2",
     "mkdocs-material>=9.7,<10",
+    # Transitive via mkdocs-material; pinned directly since pip-audit flags it on
+    # its own. Security pin: PYSEC-2026-2999, PYSEC-2026-3609, PYSEC-2026-3654
+    # (fixed 11.0.1).
+    "pymdown-extensions>=11.0.1",
 ]
 
 [tool.setuptools.packages.find]
@@ -145,9 +150,10 @@ override-dependencies = [
     "urllib3>=2.7.0",
     "idna>=3.15",
     # Security pins (pip-audit / OSV) — bump when CI security gate fails.
-    # GHSA-fjr4-x663-mwxc, GHSA-6p8h-3wgx-97gf, GHSA-r9mr-m37c-5fr3 (fixed 3.1.54)
-    # and GHSA-94p4-4cq8-9g67 (fixed 3.1.55).
-    "gitpython>=3.1.55",
+    # GHSA-fjr4-x663-mwxc, GHSA-6p8h-3wgx-97gf, GHSA-r9mr-m37c-5fr3 (fixed 3.1.54),
+    # GHSA-94p4-4cq8-9g67 (fixed 3.1.55), and GHSA-9rj7-rf2p-w77r, GHSA-4gmw-gg2m-w46p,
+    # GHSA-hh9p-6wh2-4mfc, GHSA-wvpp-8hx9-p66j, GHSA-jm78-9fvv-mhgr (fixed 3.1.58).
+    "gitpython>=3.1.58",
     "pillow>=12.3.0",
     "pyasn1>=0.6.4",
     "setuptools>=83.0.0",

--- a/src/cli/okh.py
+++ b/src/cli/okh.py
@@ -894,6 +894,97 @@ async def list_manifests(
         raise
 
 
+@okh_group.command("list-recipes")
+@click.option("--limit", default=10, help="Maximum number of recipes to list")
+@click.option("--offset", default=0, help="Number of recipes to skip")
+@standard_cli_command(
+    help_text="""
+    List cooking-domain recipes stored under okh/ in the system.
+
+    Read-only browse command for a cooking-domain OHM instance. Recipes are
+    uploaded as JSON directly to storage (see the cooking-domain deployment
+    docs), not created via this CLI. Mirrors `ohm okw list-kitchens`.
+    """,
+    epilog="""
+    Examples:
+      # List all recipes
+      ohm okh list-recipes
+
+      # List with pagination
+      ohm okh list-recipes --limit 20 --offset 10
+    """,
+    async_cmd=True,
+    track_performance=True,
+    handle_errors=True,
+    format_output=True,
+    add_llm_config=False,
+)
+@click.pass_context
+async def list_recipes_cmd(
+    ctx,
+    limit: int,
+    offset: int,
+    verbose: bool,
+    output_format: str,
+    use_llm: bool,
+    llm_provider: str,
+    llm_model: Optional[str],
+    quality_level: str,
+    strict_mode: bool,
+):
+    """List cooking-domain recipes."""
+    cli_ctx = ctx.obj
+    cli_ctx.start_command_tracking("okh-list-recipes")
+
+    try:
+
+        async def http_list():
+            cli_ctx.log("Listing via HTTP API...", "info")
+            return await cli_ctx.api_client.request(
+                "GET", "/api/okh/recipes", params={"limit": limit, "offset": offset}
+            )
+
+        async def fallback_list():
+            cli_ctx.log("Using direct service listing...", "info")
+            okh_service = await OKHService.get_instance()
+            recipes = await okh_service.list_recipes()
+            page = recipes[offset : offset + limit]
+            return {
+                "recipes": [recipe.to_dict() for recipe in page],
+                "total": len(recipes),
+            }
+
+        command = SmartCommand(cli_ctx)
+        result = await command.execute_with_fallback(http_list, fallback_list)
+
+        if "data" in result and isinstance(result["data"], dict):
+            recipes = result["data"].get("items", result["data"].get("recipes", []))
+            pagination = result["data"].get("pagination", {})
+            total = pagination.get("total_items", len(recipes))
+        else:
+            recipes = result.get("items", result.get("recipes", []))
+            pagination = result.get("pagination", {})
+            total = pagination.get("total_items", result.get("total", len(recipes)))
+
+        if output_format == "json":
+            click.echo(json.dumps(result, indent=2, default=str))
+        elif recipes:
+            click.echo(f"\n🍳 Found {total} recipe(s):\n")
+            for i, recipe in enumerate(recipes, 1):
+                click.echo(f"  {i}. {recipe.get('name', 'Unknown')}")
+                click.echo(f"     Recipe ID: {recipe.get('id', 'Unknown')}")
+                click.echo(f"     Ingredients: {len(recipe.get('ingredients', []))}")
+            click.echo(f"\nTotal: {total} recipe(s)")
+        else:
+            click.echo("\nNo recipes found\n")
+
+        cli_ctx.end_command_tracking()
+
+    except Exception as e:
+        cli_ctx.log(f"Listing failed: {str(e)}", "error")
+        raise
+
+
 @okh_group.command()
 @click.argument("manifest_id", type=str)
 @click.option("--force", is_flag=True, help="Force deletion without confirmation")

--- a/src/cli/okw.py
+++ b/src/cli/okw.py
@@ -830,6 +830,97 @@ async def list_facilities(
         raise
 
 
+@okw_group.command("list-kitchens")
+@click.option("--limit", default=10, help="Maximum number of kitchens to list")
+@click.option("--offset", default=0, help="Number of kitchens to skip")
+@standard_cli_command(
+    help_text="""
+    List cooking-domain kitchens stored under okw/ in the system.
+
+    Read-only browse command for a cooking-domain OHM instance. Kitchens are
+    uploaded as JSON directly to storage (see the cooking-domain deployment
+    docs), not created via this CLI. Mirrors `ohm okh list-recipes`.
+    """,
+    epilog="""
+    Examples:
+      # List all kitchens
+      ohm okw list-kitchens
+
+      # List with pagination
+      ohm okw list-kitchens --limit 20 --offset 10
+    """,
+    async_cmd=True,
+    track_performance=True,
+    handle_errors=True,
+    format_output=True,
+    add_llm_config=False,
+)
+@click.pass_context
+async def list_kitchens_cmd(
+    ctx,
+    limit: int,
+    offset: int,
+    verbose: bool,
+    output_format: str,
+    use_llm: bool,
+    llm_provider: str,
+    llm_model: Optional[str],
+    quality_level: str,
+    strict_mode: bool,
+):
+    """List cooking-domain kitchens."""
+    cli_ctx = ctx.obj
+    cli_ctx.start_command_tracking("okw-list-kitchens")
+
+    try:
+
+        async def http_list():
+            cli_ctx.log("Listing via HTTP API...", "info")
+            return await cli_ctx.api_client.request(
+                "GET", "/api/okw/kitchens", params={"limit": limit, "offset": offset}
+            )
+
+        async def fallback_list():
+            cli_ctx.log("Using direct service listing...", "info")
+            okw_service = await OKWService.get_instance()
+            kitchens = await okw_service.list_kitchens()
+            page = kitchens[offset : offset + limit]
+            return {
+                "kitchens": [kitchen.to_dict() for kitchen in page],
+                "total": len(kitchens),
+            }
+
+        command = SmartCommand(cli_ctx)
+        result = await command.execute_with_fallback(http_list, fallback_list)
+
+        if "data" in result and isinstance(result["data"], dict):
+            kitchens = result["data"].get("items", result["data"].get("kitchens", []))
+            pagination = result["data"].get("pagination", {})
+            total = pagination.get("total_items", len(kitchens))
+        else:
+            kitchens = result.get("items", result.get("kitchens", []))
+            pagination = result.get("pagination", {})
+            total = pagination.get("total_items", result.get("total", len(kitchens)))
+
+        if output_format == "json":
+            click.echo(json.dumps(result, indent=2, default=str))
+        elif kitchens:
+            click.echo(f"\n🍽️  Found {total} kitchen(s):\n")
+            for i, kitchen in enumerate(kitchens, 1):
+                click.echo(f"  {i}. {kitchen.get('name', 'Unknown')}")
+                click.echo(f"     Kitchen ID: {kitchen.get('id', 'Unknown')}")
+                click.echo(f"     Appliances: {len(kitchen.get('appliances', []))}")
+            click.echo(f"\nTotal: {total} kitchen(s)")
+        else:
+            click.echo("\nNo kitchens found\n")
+
+        cli_ctx.end_command_tracking()
+
+    except Exception as e:
+        cli_ctx.log(f"Listing failed: {str(e)}", "error")
+        raise
+
+
 @okw_group.command(name="spaces")
 @click.option("--no-mom", is_flag=True, help="Exclude Maps of Making; local only.")
 @click.option("--refresh", is_flag=True, help="Force a MoM cache refresh first.")

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -156,6 +156,11 @@ AUTH_KEY_LENGTH = int(_get_secret_or_env("AUTH_KEY_LENGTH", "32"))  # bytes
 # SecurityPolicy via src/config/security_policy.py. See docs/architecture/security-modes.md.
 OHM_SECURITY_MODE = _get_secret_or_env("OHM_SECURITY_MODE", "peacetime")
 
+# Default matching domain hint for a fresh browser session on this instance
+# (see GET /api/utility/domains -> default_domain). A dedicated cooking-domain
+# deployment sets this to "cooking"; every other instance keeps the default.
+OHM_DEFAULT_DOMAIN = _get_secret_or_env("OHM_DEFAULT_DOMAIN", "manufacturing")
+
 # Storage Configuration
 try:
     STORAGE_CONFIG = get_default_storage_config()

--- a/src/core/api/models/utility/response.py
+++ b/src/core/api/models/utility/response.py
@@ -18,6 +18,10 @@ class DomainsResponse(SuccessResponse, LLMResponseMixin):
     """Response model for available domains with standardized fields and LLM information"""
 
     domains: List[Domain]
+    # Which domain a fresh browser session should open in on this instance
+    # (OHM_DEFAULT_DOMAIN setting; "manufacturing" unless a deployment opts
+    # into e.g. a dedicated cooking-domain instance).
+    default_domain: str = "manufacturing"
 
     processing_time: float = 0.0
     validation_results: Optional[List[BaseValidationResult]] = None
@@ -32,6 +36,7 @@ class DomainsResponse(SuccessResponse, LLMResponseMixin):
                         "description": "Hardware manufacturing capabilities",
                     }
                 ],
+                "default_domain": "manufacturing",
                 "status": "success",
                 "message": "Domains retrieved successfully",
                 "timestamp": "2024-01-01T12:00:00Z",

--- a/src/core/api/routes/okh.py
+++ b/src/core/api/routes/okh.py
@@ -437,6 +437,75 @@ async def get_okh_file(
     )
 
 
+@router.get(
+    "/recipes",
+    response_model=PaginatedResponse,
+    summary="List Recipes",
+    description="""
+    Get a paginated list of cooking-domain recipes found under the okh/ prefix.
+
+    Read-only browse surface for a cooking-domain instance — no create, edit,
+    or delete. See ``OKHService.list_recipes()``.
+    """,
+)
+@paginated_response(default_page_size=20, max_page_size=100)
+async def list_recipes(
+    http_request: Request,
+    pagination: PaginationParams = Depends(),
+    okh_service: OKHService = Depends(get_okh_service),
+) -> Any:
+    """List cooking-domain recipes (paginated, read-only)."""
+    request_id = (
+        getattr(http_request.state, "request_id", None) if http_request else None
+    )
+
+    try:
+        recipes = await okh_service.list_recipes()
+        total = len(recipes)
+        start = (pagination.page - 1) * pagination.page_size
+        page_items = recipes[start : start + pagination.page_size]
+
+        total_pages = (total + pagination.page_size - 1) // pagination.page_size
+
+        pagination_info = PaginationInfo(
+            page=pagination.page,
+            page_size=pagination.page_size,
+            total_items=total,
+            total_pages=total_pages,
+            has_next=pagination.page < total_pages,
+            has_previous=pagination.page > 1,
+        )
+
+        return PaginatedResponse(
+            status=APIStatus.SUCCESS,
+            message="Recipes listed successfully",
+            pagination=pagination_info,
+            items=[recipe.to_dict() for recipe in page_items],
+            request_id=request_id,
+        )
+
+    except Exception as e:
+        error_response = create_error_response(
+            error=e,
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            request_id=request_id,
+            suggestion="Please try again or contact support if the issue persists",
+        )
+        logger.error(
+            f"Error listing recipes: {str(e)}",
+            extra={
+                "request_id": request_id,
+                "error": str(e),
+                "error_type": type(e).__name__,
+            },
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=error_response.model_dump(mode="json"),
+        )
+
+
 @router.get("/{id}", response_model=OKHResponse)
 async def get_okh(
     id: UUID = Path(..., title="The ID of the OKH manifest"),

--- a/src/core/api/routes/okw.py
+++ b/src/core/api/routes/okw.py
@@ -464,6 +464,76 @@ async def get_okw_spaces(
         )
 
 
+@router.get(
+    "/kitchens",
+    response_model=PaginatedResponse,
+    summary="List Kitchens",
+    description="""
+    Get a paginated list of cooking-domain kitchen capabilities found under
+    the okw/ prefix.
+
+    Read-only browse surface for a cooking-domain instance — no create,
+    edit, or delete. See ``OKWService.list_kitchens()``.
+    """,
+)
+@paginated_response(default_page_size=20, max_page_size=100)
+async def list_kitchens(
+    http_request: Request,
+    pagination: PaginationParams = Depends(),
+    okw_service: OKWService = Depends(get_okw_service),
+) -> Any:
+    """List cooking-domain kitchens (paginated, read-only)."""
+    request_id = (
+        getattr(http_request.state, "request_id", None) if http_request else None
+    )
+
+    try:
+        kitchens = await okw_service.list_kitchens()
+        total = len(kitchens)
+        start = (pagination.page - 1) * pagination.page_size
+        page_items = kitchens[start : start + pagination.page_size]
+
+        total_pages = (total + pagination.page_size - 1) // pagination.page_size
+
+        pagination_info = PaginationInfo(
+            page=pagination.page,
+            page_size=pagination.page_size,
+            total_items=total,
+            total_pages=total_pages,
+            has_next=pagination.page < total_pages,
+            has_previous=pagination.page > 1,
+        )
+
+        return PaginatedResponse(
+            status=APIStatus.SUCCESS,
+            message="Kitchens listed successfully",
+            pagination=pagination_info,
+            items=[kitchen.to_dict() for kitchen in page_items],
+            request_id=request_id,
+        )
+
+    except Exception as e:
+        error_response = create_error_response(
+            error=e,
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            request_id=request_id,
+            suggestion="Please try again or contact support if the issue persists",
+        )
+        logger.error(
+            f"Error listing kitchens: {str(e)}",
+            extra={
+                "request_id": request_id,
+                "error": str(e),
+                "error_type": type(e).__name__,
+            },
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=error_response.model_dump(mode="json"),
+        )
+
+
 @router.get("/{id}", response_model=OKWResponse)
 async def get_okw(
     id: UUID = Path(..., title="The ID of the OKW facility"),

--- a/src/core/api/routes/utility.py
+++ b/src/core/api/routes/utility.py
@@ -13,6 +13,8 @@ from fastapi import (
     status,
 )
 
+from src.config import settings
+
 from ...errors.metrics import get_metrics_tracker
 from ...utils.logging import get_logger
 from ..constants.openapi import RESPONSES_400_401_422_500
@@ -120,6 +122,7 @@ async def get_domains(
         # Return dict for api_endpoint decorator to wrap
         return {
             "domains": [domain.model_dump(mode="json") for domain in domains],
+            "default_domain": settings.OHM_DEFAULT_DOMAIN,
             "processing_time": processing_time,
             "validation_results": [
                 vr.model_dump(mode="json") if hasattr(vr, "model_dump") else vr

--- a/src/core/domains/cooking/models.py
+++ b/src/core/domains/cooking/models.py
@@ -107,3 +107,104 @@ class KitchenCapability:
         if domain == "cooking":
             return True
         return KitchenCapability.is_kitchen_data(data)
+
+
+# Cooking-specific fields that distinguish a recipe file from an OKH manifest.
+# At least one of these keys must be present for a JSON blob to be treated as
+# a Recipe.
+_RECIPE_FIELDS = {"ingredients", "instructions", "equipment"}
+
+# Presence of this key unambiguously marks an OKH manifest file and takes
+# priority over any incidental recipe-shaped fields.
+_OKH_DISCRIMINATOR = "license"
+
+
+@dataclass
+class Recipe:
+    """A cooking-domain recipe record stored under okh/ in remote storage.
+
+    Kept intentionally lean: the three list fields map directly to the
+    simple-format path in ``CookingExtractor._detailed_extract_requirements()``.
+    """
+
+    id: UUID
+    name: str
+    ingredients: List[str] = field(default_factory=list)
+    instructions: List[str] = field(default_factory=list)
+    equipment: List[str] = field(default_factory=list)
+    domain: str = "cooking"
+
+    # ------------------------------------------------------------------ #
+    # Factory / serialisation                                              #
+    # ------------------------------------------------------------------ #
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Recipe":
+        """Parse a raw dictionary into a Recipe.
+
+        Raises ``ValueError`` if required keys are missing.
+        """
+        if "id" not in data:
+            raise ValueError("Recipe requires an 'id' field")
+        if "name" not in data:
+            raise ValueError("Recipe requires a 'name' field")
+
+        return cls(
+            id=UUID(str(data["id"])),
+            name=str(data["name"]),
+            ingredients=list(data.get("ingredients", [])),
+            instructions=list(data.get("instructions", [])),
+            equipment=list(data.get("equipment", [])),
+            domain=str(data.get("domain", "cooking")),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a plain dictionary suitable for JSON serialisation and for
+        passing directly into ``CookingExtractor.extract_requirements()``.
+        """
+        return {
+            "id": str(self.id),
+            "name": self.name,
+            "ingredients": list(self.ingredients),
+            "instructions": list(self.instructions),
+            "equipment": list(self.equipment),
+            "domain": self.domain,
+        }
+
+    # ------------------------------------------------------------------ #
+    # Type discriminator                                                   #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def is_recipe_data(data: Dict[str, Any]) -> bool:
+        """Return ``True`` when *data* looks like a recipe file.
+
+        Rules (evaluated in order):
+        1. Any data containing ``license`` is an OKH manifest → False.
+        2. Data that contains at least one recipe-specific key
+           (``ingredients``, ``instructions``, ``equipment``) → True.
+        3. Everything else → False.
+        """
+        if not data:
+            return False
+        if _OKH_DISCRIMINATOR in data:
+            return False
+        return bool(_RECIPE_FIELDS & data.keys())
+
+    @staticmethod
+    def is_cooking_recipe(data: Dict[str, Any]) -> bool:
+        """Return ``True`` when *data* should be treated as a recipe.
+
+        Domain-first: if ``domain`` is set, it overrides heuristic shape.
+        - ``domain == "manufacturing"`` → False (treat as OKH manifest).
+        - ``domain == "cooking"`` → True (treat as recipe).
+        - Otherwise fall back to ``is_recipe_data(data)``.
+        """
+        if not data:
+            return False
+        domain = data.get("domain")
+        if domain == "manufacturing":
+            return False
+        if domain == "cooking":
+            return True
+        return Recipe.is_recipe_data(data)

--- a/src/core/services/okh_service.py
+++ b/src/core/services/okh_service.py
@@ -9,6 +9,8 @@ import yaml
 
 from src.config import settings
 
+from ..domains.cooking.models import Recipe
+
 # Lazy import: GenerationEngine imports heavy dependencies (spacy, numpy, thinc)
 # from ..generation.engine import GenerationEngine
 from ..generation.models import LayerConfig, PlatformType
@@ -457,6 +459,72 @@ class OKHService(BaseService["OKHService"]):
             paginated_manifests = all_manifests[start_idx : start_idx + page_size]
 
             return paginated_manifests, total
+
+    async def list_recipes(self) -> List[Recipe]:
+        """Return all recipes found under the ``okh/`` prefix.
+
+        Returns only ``Recipe`` objects.  Any file under ``okh/`` that is
+        *not* identified as a recipe by ``Recipe.is_cooking_recipe()`` (e.g.
+        an OKH manifest) is skipped and logged at DEBUG level.
+
+        Mirrors ``OKWService.list_kitchens()``:
+        - Only returns files that pass ``Recipe.is_cooking_recipe()``.
+        - Deduplicates by ``Recipe.id``, keeping the most-recently modified
+          file when the same ID appears at multiple paths.
+        """
+        await self.ensure_initialized()
+        logger.info("Listing recipes")
+
+        if not self.storage:
+            return []
+
+        discovery = SmartFileDiscovery(self.storage.manager)
+        file_infos = await discovery.discover_files("okh")
+
+        logger.info(f"Scanning {len(file_infos)} OKH files for recipes")
+
+        recipes_by_id: Dict[UUID, Recipe] = {}
+        file_info_by_id: Dict[UUID, Any] = {}
+
+        for file_info in file_infos:
+            try:
+                data = await self.storage.manager.get_object(file_info.key)
+                raw = json.loads(data.decode("utf-8"))
+
+                if not Recipe.is_cooking_recipe(raw):
+                    logger.debug(
+                        f"Skipping non-recipe file {file_info.key} in list_recipes()"
+                    )
+                    continue
+
+                recipe = Recipe.from_dict(raw)
+                recipe_id = recipe.id
+
+                if recipe_id not in recipes_by_id:
+                    recipes_by_id[recipe_id] = recipe
+                    file_info_by_id[recipe_id] = file_info
+                else:
+                    existing_modified = getattr(
+                        file_info_by_id[recipe_id], "last_modified", None
+                    )
+                    current_modified = getattr(file_info, "last_modified", None)
+                    if current_modified and (
+                        not existing_modified or current_modified > existing_modified
+                    ):
+                        recipes_by_id[recipe_id] = recipe
+                        file_info_by_id[recipe_id] = file_info
+                        logger.debug(
+                            f"Replacing recipe {recipe_id} with more recent version from {file_info.key}"
+                        )
+            except Exception as e:
+                logger.warning(
+                    f"Skipping file {file_info.key}: could not parse as Recipe: {e}"
+                )
+                continue
+
+        recipes = list(recipes_by_id.values())
+        logger.info(f"Found {len(recipes)} unique recipes")
+        return recipes
 
     def _invalidate_catalog_cache(self) -> None:
         """Drop the cached catalogue after a write.

--- a/tests/api/test_okh_okw_cooking_routes.py
+++ b/tests/api/test_okh_okw_cooking_routes.py
@@ -1,0 +1,104 @@
+"""Contract tests for GET /api/okh/recipes and GET /api/okw/kitchens.
+
+Regression guard: both routes must be registered ahead of their sibling
+``/{id}`` GET route, otherwise "recipes"/"kitchens" is parsed as a UUID path
+parameter and the request 422s instead of listing.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+from src.core.domains.cooking.models import KitchenCapability, Recipe
+
+
+def _get_app() -> tuple[FastAPI, FastAPI]:
+    from src.core.main import api_v1
+
+    app = FastAPI()
+    app.mount("/v1", api_v1)
+    return app, api_v1
+
+
+def _recipe() -> Recipe:
+    return Recipe.from_dict(
+        {
+            "id": str(uuid4()),
+            "name": "Sourdough Bread",
+            "ingredients": ["flour", "water", "salt"],
+            "instructions": ["Mix", "Bake"],
+            "equipment": ["oven"],
+        }
+    )
+
+
+def _kitchen() -> KitchenCapability:
+    return KitchenCapability.from_dict(
+        {
+            "id": str(uuid4()),
+            "name": "Test Kitchen",
+            "appliances": ["oven"],
+            "tools": ["knife"],
+            "ingredients": [],
+        }
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_list_recipes_returns_paginated_recipes():
+    from src.core.api.routes.okh import get_okh_service
+
+    app, api_v1 = _get_app()
+    svc = MagicMock()
+    svc.list_recipes = AsyncMock(return_value=[_recipe(), _recipe()])
+    api_v1.dependency_overrides[get_okh_service] = lambda: svc
+
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as client:
+            resp = await client.get("/v1/api/okh/recipes")
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["pagination"]["total_items"] == 2
+        assert len(body["items"]) == 2
+        assert body["items"][0]["ingredients"] == ["flour", "water", "salt"]
+    finally:
+        api_v1.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_list_kitchens_returns_paginated_kitchens():
+    from src.core.api.routes.okw import get_okw_service
+
+    app, api_v1 = _get_app()
+    svc = MagicMock()
+    svc.list_kitchens = AsyncMock(return_value=[_kitchen()])
+    api_v1.dependency_overrides[get_okw_service] = lambda: svc
+
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as client:
+            resp = await client.get("/v1/api/okw/kitchens")
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["pagination"]["total_items"] == 1
+        assert body["items"][0]["name"] == "Test Kitchen"
+    finally:
+        api_v1.dependency_overrides.clear()

--- a/tests/api/test_utility_default_domain.py
+++ b/tests/api/test_utility_default_domain.py
@@ -1,0 +1,70 @@
+"""Contract test: GET /api/utility/domains surfaces default_domain.
+
+Regression guard for the cooking-domain-instance plan: default_domain must
+be "manufacturing" whenever OHM_DEFAULT_DOMAIN is unset, and must reflect the
+setting when an instance opts into a different domain (e.g. cooking).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+
+def _get_app() -> tuple[FastAPI, FastAPI]:
+    from src.core.main import api_v1
+
+    app = FastAPI()
+    app.mount("/v1", api_v1)
+    return app, api_v1
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache():
+    """GET /api/utility/domains is cached; isolate so tests don't see each other's response."""
+    from src.core.services.cache_service import get_cache_service
+
+    get_cache_service().clear()
+    yield
+    get_cache_service().clear()
+
+
+async def _fetch_domains(app: FastAPI) -> dict:
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as client:
+        resp = await client.get("/v1/api/utility/domains")
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_default_domain_is_manufacturing_with_no_override():
+    app, _ = _get_app()
+
+    with patch(
+        "src.core.api.routes.utility.settings.OHM_DEFAULT_DOMAIN", "manufacturing"
+    ):
+        body = await _fetch_domains(app)
+
+    assert body["data"]["default_domain"] == "manufacturing"
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_default_domain_reflects_cooking_override():
+    app, _ = _get_app()
+
+    with patch("src.core.api.routes.utility.settings.OHM_DEFAULT_DOMAIN", "cooking"):
+        body = await _fetch_domains(app)
+
+    assert body["data"]["default_domain"] == "cooking"

--- a/tests/cli/test_okh_okw_cooking_cli.py
+++ b/tests/cli/test_okh_okw_cooking_cli.py
@@ -1,0 +1,117 @@
+"""CLI wiring + behavior tests for `ohm okh list-recipes` / `ohm okw list-kitchens`."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+from click.testing import CliRunner
+
+from src.cli.okh import okh_group
+from src.cli.okw import okw_group
+from src.core.domains.cooking.models import KitchenCapability, Recipe
+
+
+def test_okh_exposes_list_recipes():
+    runner = CliRunner()
+    result = runner.invoke(okh_group, ["--help"])
+    assert result.exit_code == 0
+    assert "list-recipes" in result.output
+
+
+def test_okw_exposes_list_kitchens():
+    runner = CliRunner()
+    result = runner.invoke(okw_group, ["--help"])
+    assert result.exit_code == 0
+    assert "list-kitchens" in result.output
+
+
+def _recipe() -> Recipe:
+    return Recipe.from_dict(
+        {
+            "id": str(uuid4()),
+            "name": "Sourdough Bread",
+            "ingredients": ["flour", "water", "salt"],
+            "instructions": ["Mix", "Bake"],
+            "equipment": ["oven"],
+        }
+    )
+
+
+def _kitchen() -> KitchenCapability:
+    return KitchenCapability.from_dict(
+        {
+            "id": str(uuid4()),
+            "name": "Test Kitchen",
+            "appliances": ["oven"],
+            "tools": ["knife"],
+            "ingredients": [],
+        }
+    )
+
+
+class DummyCLIContext:
+    """Minimal stand-in for CLIContext, matching test_scaffold_cleanup_cli.py."""
+
+    def __init__(self):
+        self.output_format = "text"
+        self.verbose = False
+
+    def start_command_tracking(self, *_args, **_kwargs):
+        pass
+
+    def end_command_tracking(self):
+        pass
+
+    def log(self, *_args, **_kwargs):
+        pass
+
+
+def test_list_recipes_falls_back_to_direct_service_and_prints_json():
+    """No server reachable in tests, so this exercises the fallback listing path."""
+    runner = CliRunner()
+    svc = AsyncMock()
+    svc.list_recipes = AsyncMock(return_value=[_recipe()])
+
+    async def run_fallback(_self, _http_op, fallback_op):
+        return await fallback_op()
+
+    with (
+        patch("src.cli.okh.OKHService.get_instance", AsyncMock(return_value=svc)),
+        patch("src.cli.okh.SmartCommand.execute_with_fallback", run_fallback),
+    ):
+        result = runner.invoke(
+            okh_group, ["list-recipes", "--json"], obj=DummyCLIContext()
+        )
+
+    assert result.exit_code == 0, result.output
+    body = json.loads(result.output)
+    assert body["total"] == 1
+    assert body["recipes"][0]["name"] == "Sourdough Bread"
+
+
+def test_list_kitchens_falls_back_to_direct_service_and_prints_json():
+    runner = CliRunner()
+    svc = AsyncMock()
+    svc.list_kitchens = AsyncMock(return_value=[_kitchen()])
+
+    async def run_fallback(_self, _http_op, fallback_op):
+        return await fallback_op()
+
+    with (
+        patch("src.cli.okw.OKWService.get_instance", AsyncMock(return_value=svc)),
+        patch("src.cli.okw.SmartCommand.execute_with_fallback", run_fallback),
+    ):
+        result = runner.invoke(
+            okw_group, ["list-kitchens", "--json"], obj=DummyCLIContext()
+        )
+
+    assert result.exit_code == 0, result.output
+    body = json.loads(result.output)
+    assert body["total"] == 1
+    assert body["kitchens"][0]["name"] == "Test Kitchen"

--- a/tests/parity/manifest.py
+++ b/tests/parity/manifest.py
@@ -413,6 +413,12 @@ SITE_DOCS: tuple[SiteDoc, ...] = (
         path="guides/deploy-a-node-on-azure.md",
     ),
     SiteDoc(
+        "selfhost",
+        "Deploy a cooking-domain instance",
+        "deployed",
+        path="guides/deploy-a-cooking-domain-instance.md",
+    ),
+    SiteDoc(
         "api",
         "Use the OHM API from your own software",
         "deployed",
@@ -425,6 +431,21 @@ SITE_DOCS: tuple[SiteDoc, ...] = (
         "deployed",
         path="guides/import-from-a-url.md",
         requires_fe_call="/api/okh/generate-from-url",
+    ),
+    # Backend + CLI exist (GET /api/okh/recipes, GET /api/okw/kitchens); the
+    # frontend browse views land separately. Flip to "deployed" once the
+    # frontend actually calls these endpoints (R9 checks this).
+    SiteDoc(
+        "okh",
+        "Browse recipes",
+        "in_progress",
+        requires_fe_call="/api/okh/recipes",
+    ),
+    SiteDoc(
+        "okw",
+        "Browse kitchens",
+        "in_progress",
+        requires_fe_call="/api/okw/kitchens",
     ),
     SiteDoc("okw", "Search facilities by name", "roadmap"),
     SiteDoc("convert", "Bulk-import a design collection", "roadmap"),

--- a/tests/unit/test_cooking_models.py
+++ b/tests/unit/test_cooking_models.py
@@ -1,0 +1,85 @@
+"""Recipe model: round-trip serialisation and the okh/recipe discriminator.
+
+Mirrors KitchenCapability's test coverage (see the models themselves at
+src/core/domains/cooking/models.py) — there was previously no test file for
+either model.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from src.core.domains.cooking.models import Recipe
+
+
+def recipe_dict(**overrides) -> dict:
+    data = {
+        "id": str(uuid4()),
+        "name": "Sourdough Bread",
+        "ingredients": ["flour", "water", "salt", "starter"],
+        "instructions": ["Mix", "Rest", "Bake"],
+        "equipment": ["oven", "mixing bowl"],
+    }
+    data.update(overrides)
+    return data
+
+
+def okh_manifest_dict(**overrides) -> dict:
+    data = {
+        "id": str(uuid4()),
+        "title": "Widget",
+        "version": "1.0.0",
+        "license": {"hardware": "MIT"},
+        "function": "Does a thing",
+    }
+    data.update(overrides)
+    return data
+
+
+class TestRecipeRoundTrip:
+    def test_from_dict_requires_id(self):
+        data = recipe_dict()
+        del data["id"]
+        try:
+            Recipe.from_dict(data)
+            assert False, "expected ValueError"
+        except ValueError:
+            pass
+
+    def test_from_dict_requires_name(self):
+        data = recipe_dict()
+        del data["name"]
+        try:
+            Recipe.from_dict(data)
+            assert False, "expected ValueError"
+        except ValueError:
+            pass
+
+    def test_to_dict_round_trips(self):
+        data = recipe_dict()
+        recipe = Recipe.from_dict(data)
+        assert recipe.to_dict() == {**data, "domain": "cooking"}
+
+    def test_defaults_domain_to_cooking(self):
+        recipe = Recipe.from_dict(recipe_dict())
+        assert recipe.domain == "cooking"
+
+
+class TestRecipeDiscriminator:
+    def test_recipe_shaped_data_is_a_recipe(self):
+        assert Recipe.is_cooking_recipe(recipe_dict()) is True
+
+    def test_okh_manifest_is_not_a_recipe(self):
+        assert Recipe.is_cooking_recipe(okh_manifest_dict()) is False
+
+    def test_explicit_domain_overrides_shape(self):
+        # Recipe-shaped fields, but explicitly tagged manufacturing.
+        data = recipe_dict(domain="manufacturing")
+        assert Recipe.is_cooking_recipe(data) is False
+
+        # OKH-shaped fields, but explicitly tagged cooking.
+        data = okh_manifest_dict(domain="cooking")
+        assert Recipe.is_cooking_recipe(data) is True
+
+    def test_empty_data_is_not_a_recipe(self):
+        assert Recipe.is_cooking_recipe({}) is False

--- a/tests/unit/test_ohm_default_domain_setting.py
+++ b/tests/unit/test_ohm_default_domain_setting.py
@@ -1,0 +1,34 @@
+"""OHM_DEFAULT_DOMAIN: must default to 'manufacturing' when unset.
+
+Regression guard from the cooking-domain-instance plan: the manufacturing
+default must never depend on an env var being set.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+
+def test_default_domain_setting_defaults_to_manufacturing(monkeypatch):
+    monkeypatch.delenv("OHM_DEFAULT_DOMAIN", raising=False)
+
+    from src.config import settings
+
+    importlib.reload(settings)
+    try:
+        assert settings.OHM_DEFAULT_DOMAIN == "manufacturing"
+    finally:
+        importlib.reload(settings)
+
+
+def test_default_domain_setting_honors_env_override(monkeypatch):
+    monkeypatch.setenv("OHM_DEFAULT_DOMAIN", "cooking")
+
+    from src.config import settings
+
+    importlib.reload(settings)
+    try:
+        assert settings.OHM_DEFAULT_DOMAIN == "cooking"
+    finally:
+        monkeypatch.delenv("OHM_DEFAULT_DOMAIN", raising=False)
+        importlib.reload(settings)

--- a/tests/unit/test_okh_list_recipes.py
+++ b/tests/unit/test_okh_list_recipes.py
@@ -1,0 +1,134 @@
+"""OKHService.list_recipes() — mirrors OKWService.list_kitchens() but scans okh/.
+
+Follows the fake-storage pattern from test_okh_catalog_performance.py.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+from src.core.services.okh_service import OKHService
+from src.core.storage.smart_discovery import FileInfo
+
+
+def recipe_dict(recipe_id: str, name: str = "Sourdough Bread") -> dict:
+    return {
+        "id": recipe_id,
+        "name": name,
+        "ingredients": ["flour", "water", "salt"],
+        "instructions": ["Mix", "Bake"],
+        "equipment": ["oven"],
+    }
+
+
+def manifest_dict(manifest_id: str, title: str = "Widget") -> dict:
+    return {
+        "id": manifest_id,
+        "title": title,
+        "version": "1.0.0",
+        "license": {"hardware": "MIT"},
+        "function": "Does a thing",
+    }
+
+
+class FakeStorageManager:
+    def __init__(self, objects: dict[str, dict]):
+        self.objects = objects
+
+    async def get_object(self, key: str) -> bytes:
+        return json.dumps(self.objects[key]).encode("utf-8")
+
+
+class FakeStorage:
+    def __init__(self, manager):
+        self.manager = manager
+
+
+def file_info(key: str, minutes_old: int = 0) -> FileInfo:
+    return FileInfo(
+        key=key,
+        file_type="okh",
+        size=100,
+        last_modified=datetime(2026, 1, 1) - timedelta(minutes=minutes_old),
+        metadata={},
+    )
+
+
+def build_service(objects: dict[str, dict]):
+    service = OKHService()
+    service.storage = FakeStorage(FakeStorageManager(objects))
+    service._initialized = True
+    return service
+
+
+async def run_list_recipes(service, keys):
+    async def fake_discover(_prefix):
+        return keys
+
+    with (
+        patch("src.core.services.okh_service.SmartFileDiscovery") as Discovery,
+        patch.object(service, "ensure_initialized", return_value=None),
+    ):
+        Discovery.return_value.discover_files = fake_discover
+        return await service.list_recipes()
+
+
+@pytest.mark.asyncio
+class TestListRecipes:
+    async def test_returns_only_recipe_shaped_files(self):
+        recipe_id = str(uuid4())
+        manifest_id = str(uuid4())
+        objects = {
+            "okh/recipe.json": recipe_dict(recipe_id),
+            "okh/manifest.json": manifest_dict(manifest_id),
+        }
+        service = build_service(objects)
+        keys = [file_info(k) for k in objects]
+
+        recipes = await run_list_recipes(service, keys)
+
+        assert len(recipes) == 1
+        assert str(recipes[0].id) == recipe_id
+
+    async def test_deduplicates_by_id_keeping_newest(self):
+        shared = str(uuid4())
+        objects = {
+            "okh/old.json": recipe_dict(shared, name="Old"),
+            "okh/new.json": recipe_dict(shared, name="New"),
+        }
+        service = build_service(objects)
+        keys = [file_info("okh/old.json", minutes_old=60), file_info("okh/new.json")]
+
+        recipes = await run_list_recipes(service, keys)
+
+        assert len(recipes) == 1
+        assert recipes[0].name == "New"
+
+    async def test_unparseable_files_are_skipped_not_fatal(self):
+        good = str(uuid4())
+        objects = {
+            "okh/good.json": recipe_dict(good),
+            "okh/bad.json": {"ingredients": []},  # recipe-shaped but no id/name
+        }
+        service = build_service(objects)
+        keys = [file_info("okh/good.json"), file_info("okh/bad.json")]
+
+        recipes = await run_list_recipes(service, keys)
+
+        assert len(recipes) == 1
+        assert str(recipes[0].id) == good
+
+    async def test_no_storage_returns_empty(self):
+        service = OKHService()
+        service.storage = None
+        service._initialized = True
+
+        with patch.object(service, "ensure_initialized", return_value=None):
+            recipes = await service.list_recipes()
+
+        assert recipes == []

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ resolution-markers = [
 
 [manifest]
 overrides = [
-    { name = "gitpython", specifier = ">=3.1.55" },
+    { name = "gitpython", specifier = ">=3.1.58" },
     { name = "idna", specifier = ">=3.15" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "pyasn1", specifier = ">=0.6.4" },
@@ -1122,14 +1122,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.57"
+version = "3.1.59"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/0d/132ed135c871b6bf91adf16a0e43797cd535b81d4973b5d09291c54fc5ee/gitpython-3.1.57.tar.gz", hash = "sha256:c493ec57c0ef6b19743798b6a5af859c71814b524e7e6f97baa2f8e658961488", size = 225898, upload-time = "2026-07-26T07:33:26.351Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/dc/126b28e76b24a9268ba931ad3e012f71ebdadf62fd9f17758f7074bb0b20/gitpython-3.1.59.tar.gz", hash = "sha256:0a1475cfdc38a5bfba1a3e9a4a9da52a39749ecec322b772915c019f94e5b7e4", size = 230445, upload-time = "2026-08-10T12:03:20.271Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/6e/2139de986d9c7c3ac86f1f8be43858ce90bdfe2f7175e6c80c650ba15242/gitpython-3.1.57-py3-none-any.whl", hash = "sha256:4ccf7d73c10f5c9e76043fbb2675ac5a1b3ff5b41e648f56bcbed5f63792ecaf", size = 217151, upload-time = "2026-07-26T07:33:24.838Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ed/ae57eb7d344f43f87b74b3a281ead6ec7d6394eef72a7b1dcb28dd089550/gitpython-3.1.59-py3-none-any.whl", hash = "sha256:67a82f537384578643624c8b2c531938a9b82be431663e575dcf638526631d4c", size = 220996, upload-time = "2026-08-10T12:03:18.804Z" },
 ]
 
 [[package]]
@@ -2769,24 +2769,24 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.2"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]
 name = "pypdf"
-version = "6.14.2"
+version = "6.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/17/ee75a92718ec7212de831e71454d702225aa5e474a805cce169806044453/pypdf-6.15.0.tar.gz", hash = "sha256:d39c4d955a76409284a905e2d65b40076d77ab76129e0faaeeb6612403ecfc79", size = 6993794, upload-time = "2026-08-06T13:06:49.929Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
+    { url = "https://files.pythonhosted.org/packages/af/72/ce3067ac31e214a66388159f8462ddb8c13dd00170f24d555a1f1ae8ee91/pypdf-6.15.0-py3-none-any.whl", hash = "sha256:14e001d6504822cb1ca9c7ed9a69bccb320f59b320730f55af804361abe4d5ee", size = 378123, upload-time = "2026-08-06T13:06:47.709Z" },
 ]
 
 [[package]]
@@ -3379,6 +3379,7 @@ dev = [
 docs = [
     { name = "mkdocs" },
     { name = "mkdocs-material" },
+    { name = "pymdown-extensions" },
 ]
 
 [package.dev-dependencies]
@@ -3420,7 +3421,8 @@ requires-dist = [
     { name = "pydantic", extras = ["email"], specifier = ">=2.0.0,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.2.0,<3.0.0" },
     { name = "pydeck", specifier = ">=0.8.0" },
-    { name = "pypdf", specifier = ">=6.14.2" },
+    { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=11.0.1" },
+    { name = "pypdf", specifier = ">=6.15.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3.1" },


### PR DESCRIPTION
## Summary

Adds a domain selection toggle (manufacturing default, cooking opt-in) so a dedicated OHM instance can be spun up for a culinary supply-chain experiment: browse recipes/kitchens, run recipe-to-kitchen matches, and have new visitors default to whichever domain that instance's `OHM_DEFAULT_DOMAIN` configures.

- **Backend**: `Recipe`/`KitchenCapability` type discriminators on the existing cooking-domain models, `OKHService.list_recipes()` mirroring `list_kitchens()`, `GET /api/okh/recipes` + `GET /api/okw/kitchens` routes, matching `ohm okh list-recipes`/`ohm okw list-kitchens` CLI commands, and an `OHM_DEFAULT_DOMAIN` setting surfaced via `GET /api/utility/domains`.
- **Frontend**: `DomainContext`/`useDomainPreference` (persisted in `localStorage`, seeded from the backend's `default_domain` only on a visitor's first load — never overrides an existing or manually-changed preference), domain-aware nav, list-only recipe/kitchen browse views, and a `CookingMatchView` that reuses the existing match-results UI with a simpler recipe/kitchen picker (no facets, no geo-filtering, no detail pages — matches the smaller expected scale of a cooking-domain catalogue).
- **Docs**: a new deployment guide for standing up a cooking-domain instance, plus `tests/parity/manifest.py` rows for the new list-only surfaces.

## Test plan

- [x] `make ready` — all 11 gates pass (unit/API/CLI tests, service↔API↔CLI parity, docs validation, taxonomy/version/lockfile sync)
- [x] Frontend `tsc --noEmit` — no type errors
- [x] Frontend `vitest run` — 338/338 tests pass across 64 files, including new coverage for `parseDomain`/`navItemsForDomain`, `useDomainPreference` (default-to-manufacturing, server-seeded default, no-clobber-of-stored-or-manual-preference), and `buildRecipeMatchRequest`
- [x] End-to-end verified against a local cooking-domain instance rather than a live Azure deploy (this touches the shared, billed production resource group): started `uvicorn` with `OHM_DEFAULT_DOMAIN=cooking` and local storage, confirmed `default_domain: "cooking"` on `/api/utility/domains`, seeded a sample recipe + kitchen, confirmed both `GET /api/okh/recipes`/`GET /api/okw/kitchens` and the CLI list commands surfaced them, and ran a real `POST /api/match` (recipe → kitchen) that produced a ranked solution

Made with [Cursor](https://cursor.com)