### PR TITLE
fix: correct mirrored secret name for LLM_ENCRYPTION_PASSWORD

### DIFF
--- a/config/environments/cooking-test.toml
+++ b/config/environments/cooking-test.toml
@@ -1,0 +1,35 @@
+# Non-secret configuration for the `cooking-test` environment
+# (ENVIRONMENT=cooking-test).
+#
+# A disposable, parallel instance for a colleague to try the cooking-domain
+# functionality (see docs-site/docs/guides/deploy-a-cooking-domain-instance.md).
+# Isolated from production by BLOB CONTAINER only — same account, same
+# Container Apps environment, no new Azure resources. No worker/Redis table:
+# this instance does not need async generate-from-url jobs.
+#
+# NEVER put secrets here. Its app's secrets are mirrored from the production
+# app at deploy time (`deploy_azure.py --mirror-secrets-from openhardwaremanager`).
+
+storage_provider = "azure_blob"
+azure_storage_account = "projdatablobstorage"
+
+# Its own container in the shared account, holding recipe/kitchen JSON instead
+# of OKH manifests / OKW facilities. See the cooking-domain-instance guide.
+azure_storage_container = "newformats"
+
+# Fresh browser tabs on this instance open to the cooking domain by default
+# (see OHM_DEFAULT_DOMAIN in src/config/settings.py). This is a UI convenience
+# only -- it does not restrict the API.
+ohm_default_domain = "cooking"
+
+cache_backend = "memory"
+
+gunicorn_workers = "1"
+gunicorn_timeout = "300"
+
+# Frontend (nginx) container deploy config, applied by deploy_azure_frontend.py.
+# FQDN is predictable: this Container App shares production's `ohm-env`
+# environment, so it gets the same default domain suffix.
+[frontend]
+api_upstream_url = "https://openhardwaremanager-cooking-test.blackdune-e38fce01.westus3.azurecontainerapps.io"
+port = 8080

--- a/deploy/providers/azure/app_secrets.py
+++ b/deploy/providers/azure/app_secrets.py
@@ -29,7 +29,7 @@ MIRRORED_SECRET_ENV_REFS: Dict[str, str] = {
     # environment cannot catch it, because the guard only fires when ENVIRONMENT
     # is literally "production".
     "LLM_ENCRYPTION_SALT": "llm-encryption-salt",
-    "LLM_ENCRYPTION_PASSWORD": "llm-encryption-password",
+    "LLM_ENCRYPTION_PASSWORD": "llm-encrypt-password",
 }
 
 # The API additionally serves authenticated routes; a worker consumes jobs and

--- a/tests/unit/test_azure_worker_deploy.py
+++ b/tests/unit/test_azure_worker_deploy.py
@@ -102,7 +102,7 @@ def test_mirrored_names_match_the_live_secret_names():
         "azure-storage-key",
         "github-token",
         "gitlab-token",
-        "llm-encryption-password",
+        "llm-encrypt-password",
         "llm-encryption-salt",
     ]
 
@@ -118,7 +118,7 @@ def test_worker_carries_the_llm_encryption_secrets_even_without_llm():
     env_vars = mirrored_secret_env_vars()
 
     assert env_vars["LLM_ENCRYPTION_SALT"] == "secretref:llm-encryption-salt"
-    assert env_vars["LLM_ENCRYPTION_PASSWORD"] == "secretref:llm-encryption-password"
+    assert env_vars["LLM_ENCRYPTION_PASSWORD"] == "secretref:llm-encrypt-password"
 
 
 # --- The deploy itself -------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes a stale secret name in `deploy/providers/azure/app_secrets.py`: the Key Vault path secret was renamed `llm-encryption-password` → `llm-encrypt-password` (Key Vault reference names cap at 20 characters, per `test_key_vault_secrets.py`), but `MIRRORED_SECRET_ENV_REFS` — the non-vault mirroring path used by `deploy_azure.py --mirror-secrets-from` and `deploy_azure_worker.py` — was never updated to match. Any deploy that mirrors secrets from the production app failed outright, since `az containerapp secret show` for the stale name returns nothing.
- Found live while standing up a new parallel Azure Container App instance (`openhardwaremanager-cooking-test` + `openhardwaremanager-cooking-fe`) for a colleague to test the cooking-domain functionality — see [Deploy a cooking-domain instance](https://github.com/helpfulengineering/supply-graph-ai/blob/main/docs-site/docs/guides/deploy-a-cooking-domain-instance.md). That instance is now live, pointed at the existing `newformats` blob container (same storage account/resource group as production, isolated by container name only), with production fully unaffected.
- Adds `config/environments/cooking-test.toml` as the checked-in source of truth for that instance's non-secret config, matching the existing `staging.toml` pattern. No `[worker]`/`[redis]` table — this instance doesn't need async jobs.

## Test plan

- [x] `make ready` — all 11 gates pass
- [x] Updated `tests/unit/test_azure_worker_deploy.py` assertions to the corrected secret name; `tests/unit/test_key_vault_secrets.py` already expected it (that's where the original rename is documented)
- [x] Live-verified: redeployed `openhardwaremanager-cooking-test` with `--mirror-secrets-from openhardwaremanager` using the fix — secret mirroring succeeded, and the app is live and healthy (`GET /health` → `default_domain: "cooking"`, `storage.container: "newformats"`)
- [x] Confirmed production (`openhardwaremanager`, `openhardwaremanager-frontend`) is unaffected — distinct app names, distinct FQDNs, `storage.container: "production"` unchanged

Made with [Cursor](https://cursor.com)