### PR TITLE
fix: recognize OKH-shaped recipe manifests in Recipe discriminator

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -877,6 +877,10 @@ Total Python files: 631
 │       │   │   ├── models.py
 │       │   │   │       class KitchenCapability (from_dict, to_dict, is_kitchen_data...)
 │       │   │   │       class Recipe (from_dict, to_dict, is_recipe_data...)
+│       │   │   │       def _has_okh_cooking_process()
+│       │   │   │       def _okh_material_names()
+│       │   │   │       def _okh_tool_names()
+│       │   │   │       def _okh_instructions()
 │       │   │   ├── validation/
 │       │   │   │   ├── __init__.py
 │       │   │   │   ├── compatibility.py
@@ -2568,9 +2572,11 @@ Total Python files: 631
         │       def clean_env()
         ├── test_cooking_models.py
         │       class TestRecipeRoundTrip (test_from_dict_requires_id, test_from_dict_requires_name, test_to_dict_round_trips...)
+        │       class TestRecipeFromOkhShape (test_title_becomes_name, test_materials_become_ingredients, test_tool_list_becomes_equipment...)
         │       class TestRecipeDiscriminator (test_recipe_shaped_data_is_a_recipe, test_okh_manifest_is_not_a_recipe, test_explicit_domain_overrides_shape...)
         │       def recipe_dict()
         │       def okh_manifest_dict()
+        │       def okh_recipe_dict()
         ├── test_country_names.py
         │       def test_display_country_name_codes()
         │       def test_countries_match_code_and_name()
@@ -5356,17 +5362,24 @@ Args...
 
 Mirrors KitchenCapability'...
 
-**Exports:** recipe_dict, okh_manifest_dict, TestRecipeRoundTrip, TestRecipeDiscriminator
+**Exports:** recipe_dict, okh_manifest_dict, okh_recipe_dict, TestRecipeRoundTrip, TestRecipeFromOkhShape
 
 **Classes:**
 - `TestRecipeRoundTrip`
   - Methods: test_from_dict_requires_id, test_from_dict_requires_name, test_to_dict_round_trips, test_defaults_domain_to_cooking
+- `TestRecipeFromOkhShape`
+  - Methods: test_title_becomes_name, test_materials_become_ingredients, test_tool_list_becomes_equipment, test_making_instructions_become_instructions, test_manufacturing_processes_fill_in_when_no_making_instructions
+  - An OKH-shaped recipe (title/materials/tool_list/making_instructions)
+maps onto t...
 - `TestRecipeDiscriminator`
-  - Methods: test_recipe_shaped_data_is_a_recipe, test_okh_manifest_is_not_a_recipe, test_explicit_domain_overrides_shape, test_empty_data_is_not_a_recipe
+  - Methods: test_recipe_shaped_data_is_a_recipe, test_okh_manifest_is_not_a_recipe, test_explicit_domain_overrides_shape, test_empty_data_is_not_a_recipe, test_okh_shaped_recipe_with_cooking_process_is_a_recipe
 
 **Functions:**
 - `recipe_dict()`
 - `okh_manifest_dict()`
+- `okh_recipe_dict()`
+  - An OKH-shaped manifest that is actually a recipe -- the format real
+recipe data ...
 
 **Internal Dependencies:** 1 imports
 

--- a/src/core/domains/cooking/models.py
+++ b/src/core/domains/cooking/models.py
@@ -109,14 +109,118 @@ class KitchenCapability:
         return KitchenCapability.is_kitchen_data(data)
 
 
-# Cooking-specific fields that distinguish a recipe file from an OKH manifest.
-# At least one of these keys must be present for a JSON blob to be treated as
-# a Recipe.
+# Cooking-specific fields that distinguish a simple-format recipe file from
+# an OKH manifest. At least one of these keys must be present for a JSON blob
+# to be treated as a Recipe via the simple format.
 _RECIPE_FIELDS = {"ingredients", "instructions", "equipment"}
 
-# Presence of this key unambiguously marks an OKH manifest file and takes
-# priority over any incidental recipe-shaped fields.
+# Presence of this key marks an OKH-shaped manifest file (license is required
+# on every real OKH manifest, recipe or hardware).
 _OKH_DISCRIMINATOR = "license"
+
+# manufacturing_processes verbs that mark an OKH-shaped manifest as a recipe
+# rather than a hardware design. The OKH schema is generic enough to describe
+# a recipe's bill of materials, tools, and instructions exactly as well as a
+# hardware design's (see CookingExtractor._detailed_extract_requirements(),
+# which already parses this same tool_list/materials/making_instructions
+# shape for matching) -- shape alone cannot tell the two apart, so this is the
+# one positive cooking signal available on legacy OKH-shaped recipe data that
+# predates the `domain` field.
+_OKH_COOKING_PROCESSES = {
+    "bake",
+    "boil",
+    "braise",
+    "broil",
+    "chill",
+    "cook",
+    "ferment",
+    "freeze",
+    "fry",
+    "grill",
+    "knead",
+    "marinate",
+    "mix",
+    "poach",
+    "roast",
+    "saute",
+    "sauté",
+    "simmer",
+    "steam",
+    "stir",
+    "whisk",
+}
+
+
+def _has_okh_cooking_process(data: Dict[str, Any]) -> bool:
+    processes = data.get("manufacturing_processes")
+    if not isinstance(processes, list):
+        return False
+    return any(
+        isinstance(p, str) and p.strip().lower() in _OKH_COOKING_PROCESSES
+        for p in processes
+    )
+
+
+def _okh_material_names(data: Dict[str, Any]) -> List[str]:
+    """Ingredient names from an OKH manifest's ``materials`` field, falling
+    back to the non-standard ``metadata.original.bom_atoms`` mapping some
+    hand-authored recipe manifests use instead (keys are ingredient names)."""
+    names: List[str] = []
+    for material in data.get("materials") or []:
+        if isinstance(material, str):
+            if material:
+                names.append(material)
+        elif isinstance(material, dict):
+            name = (
+                material.get("name")
+                or material.get("material_type")
+                or material.get("identifier")
+            )
+            if name:
+                names.append(str(name))
+    if not names:
+        bom_atoms = ((data.get("metadata") or {}).get("original") or {}).get(
+            "bom_atoms"
+        )
+        if isinstance(bom_atoms, dict):
+            names = [str(k) for k in bom_atoms.keys()]
+    return names
+
+
+def _okh_tool_names(data: Dict[str, Any]) -> List[str]:
+    """Equipment names from an OKH manifest's ``tool_list`` field."""
+    names: List[str] = []
+    for tool in data.get("tool_list") or []:
+        if isinstance(tool, str):
+            if tool:
+                names.append(tool)
+        elif isinstance(tool, dict):
+            name = tool.get("name") or tool.get("tool") or tool.get("identifier")
+            if name:
+                names.append(str(name))
+    return names
+
+
+def _okh_instructions(data: Dict[str, Any]) -> List[str]:
+    """Instruction steps from an OKH manifest's ``making_instructions`` field,
+    falling back to its ``manufacturing_processes`` (cooking techniques) when
+    no instructions are present."""
+    steps: List[str] = []
+    for instruction in data.get("making_instructions") or []:
+        if isinstance(instruction, str):
+            if instruction:
+                steps.append(instruction)
+        elif isinstance(instruction, dict):
+            step = instruction.get("title") or instruction.get("path")
+            if step:
+                steps.append(str(step))
+    if not steps:
+        steps = [
+            str(p)
+            for p in (data.get("manufacturing_processes") or [])
+            if isinstance(p, str)
+        ]
+    return steps
 
 
 @dataclass
@@ -142,19 +246,30 @@ class Recipe:
     def from_dict(cls, data: Dict[str, Any]) -> "Recipe":
         """Parse a raw dictionary into a Recipe.
 
-        Raises ``ValueError`` if required keys are missing.
+        Accepts both the simple format (``ingredients``/``instructions``/
+        ``equipment``) and an OKH-shaped recipe (``title``/``materials``/
+        ``tool_list``/``making_instructions``/``manufacturing_processes``),
+        falling back field-by-field to the OKH equivalent so a partially
+        simple-format file (e.g. explicit ``ingredients`` but no
+        ``instructions``) still fills in from OKH fields where present.
+        Mirrors ``CookingExtractor._detailed_extract_requirements()``, which
+        parses this same OKH shape for matching.
+
+        Raises ``ValueError`` if required keys (id, and either name or title)
+        are missing.
         """
         if "id" not in data:
             raise ValueError("Recipe requires an 'id' field")
-        if "name" not in data:
-            raise ValueError("Recipe requires a 'name' field")
+        name = data.get("name") or data.get("title")
+        if not name:
+            raise ValueError("Recipe requires a 'name' (or OKH 'title') field")
 
         return cls(
             id=UUID(str(data["id"])),
-            name=str(data["name"]),
-            ingredients=list(data.get("ingredients", [])),
-            instructions=list(data.get("instructions", [])),
-            equipment=list(data.get("equipment", [])),
+            name=str(name),
+            ingredients=list(data.get("ingredients") or _okh_material_names(data)),
+            instructions=list(data.get("instructions") or _okh_instructions(data)),
+            equipment=list(data.get("equipment") or _okh_tool_names(data)),
             domain=str(data.get("domain", "cooking")),
         )
 
@@ -180,16 +295,20 @@ class Recipe:
         """Return ``True`` when *data* looks like a recipe file.
 
         Rules (evaluated in order):
-        1. Any data containing ``license`` is an OKH manifest → False.
-        2. Data that contains at least one recipe-specific key
+        1. Data that contains at least one simple-format recipe key
            (``ingredients``, ``instructions``, ``equipment``) → True.
+        2. An OKH-shaped manifest (has ``license``) is a recipe only if its
+           ``manufacturing_processes`` name a cooking technique (e.g.
+           ``"bake"``) → True. Otherwise it is a hardware design → False.
         3. Everything else → False.
         """
         if not data:
             return False
+        if _RECIPE_FIELDS & data.keys():
+            return True
         if _OKH_DISCRIMINATOR in data:
-            return False
-        return bool(_RECIPE_FIELDS & data.keys())
+            return _has_okh_cooking_process(data)
+        return False
 
     @staticmethod
     def is_cooking_recipe(data: Dict[str, Any]) -> bool:

--- a/tests/unit/test_cooking_models.py
+++ b/tests/unit/test_cooking_models.py
@@ -36,6 +36,30 @@ def okh_manifest_dict(**overrides) -> dict:
     return data
 
 
+def okh_recipe_dict(**overrides) -> dict:
+    """An OKH-shaped manifest that is actually a recipe -- the format real
+    recipe data is uploaded in (see docs-site/docs/guides/deploy-a-cooking-domain-instance.md).
+    No `domain` field: this predates that tag, so the discriminator falls
+    back to the manufacturing_processes cooking-verb signal."""
+    data = {
+        "id": str(uuid4()),
+        "title": "Chocolate Chip Cookies",
+        "version": "0.0.1",
+        "license": {"documentation": "CC0-1.0"},
+        "function": "cooking",
+        "materials": [
+            {"name": "flour"},
+            {"material_type": "butter"},
+            "chocolate chips",
+        ],
+        "tool_list": ["Oven", "Sheet Pan", {"name": "Spatula"}],
+        "making_instructions": [{"title": "Mix and bake"}],
+        "manufacturing_processes": ["bake"],
+    }
+    data.update(overrides)
+    return data
+
+
 class TestRecipeRoundTrip:
     def test_from_dict_requires_id(self):
         data = recipe_dict()
@@ -65,6 +89,58 @@ class TestRecipeRoundTrip:
         assert recipe.domain == "cooking"
 
 
+class TestRecipeFromOkhShape:
+    """An OKH-shaped recipe (title/materials/tool_list/making_instructions)
+    maps onto the same Recipe fields as the simple format, mirroring
+    CookingExtractor._detailed_extract_requirements()."""
+
+    def test_title_becomes_name(self):
+        recipe = Recipe.from_dict(okh_recipe_dict())
+        assert recipe.name == "Chocolate Chip Cookies"
+
+    def test_materials_become_ingredients(self):
+        recipe = Recipe.from_dict(okh_recipe_dict())
+        assert recipe.ingredients == ["flour", "butter", "chocolate chips"]
+
+    def test_tool_list_becomes_equipment(self):
+        recipe = Recipe.from_dict(okh_recipe_dict())
+        assert recipe.equipment == ["Oven", "Sheet Pan", "Spatula"]
+
+    def test_making_instructions_become_instructions(self):
+        recipe = Recipe.from_dict(okh_recipe_dict())
+        assert recipe.instructions == ["Mix and bake"]
+
+    def test_manufacturing_processes_fill_in_when_no_making_instructions(self):
+        data = okh_recipe_dict(making_instructions=[])
+        recipe = Recipe.from_dict(data)
+        assert recipe.instructions == ["bake"]
+
+    def test_requires_name_or_title(self):
+        data = okh_recipe_dict()
+        del data["title"]
+        try:
+            Recipe.from_dict(data)
+            assert False, "expected ValueError"
+        except ValueError:
+            pass
+
+    def test_bom_atoms_fill_in_ingredients_when_no_materials(self):
+        # Some hand-authored recipe manifests bury the BOM under
+        # metadata.original.bom_atoms instead of the standard `materials`
+        # field.
+        data = okh_recipe_dict(materials=[])
+        data["metadata"] = {
+            "original": {
+                "bom_atoms": {
+                    "flour": {"identifier": "Q779360"},
+                    "butter": {"identifier": "Q83037"},
+                }
+            }
+        }
+        recipe = Recipe.from_dict(data)
+        assert recipe.ingredients == ["flour", "butter"]
+
+
 class TestRecipeDiscriminator:
     def test_recipe_shaped_data_is_a_recipe(self):
         assert Recipe.is_cooking_recipe(recipe_dict()) is True
@@ -83,3 +159,15 @@ class TestRecipeDiscriminator:
 
     def test_empty_data_is_not_a_recipe(self):
         assert Recipe.is_cooking_recipe({}) is False
+
+    def test_okh_shaped_recipe_with_cooking_process_is_a_recipe(self):
+        # Real recipe data is uploaded as an OKH manifest whose
+        # manufacturing_processes name a cooking technique (e.g. "bake").
+        assert Recipe.is_cooking_recipe(okh_recipe_dict()) is True
+
+    def test_okh_manifest_with_non_cooking_process_is_not_a_recipe(self):
+        # Shape alone can't distinguish a recipe from a hardware design --
+        # only a genuine hardware design's manufacturing_processes ("mill",
+        # "drill") is what keeps it classified as an OKH manifest.
+        data = okh_recipe_dict(manufacturing_processes=["mill", "drill"])
+        assert Recipe.is_cooking_recipe(data) is False


### PR DESCRIPTION
## Summary

- `Recipe.is_cooking_recipe()` treated *any* file with a top-level `license` key as an OKH hardware manifest, so the three recipe files uploaded to the `cooking-test` instance's `newformats` bucket (`okh/manifests/*.json`) — which are legitimate OKH-standard manifests describing recipes via `title`/`materials`/`tool_list`/`making_instructions`/`manufacturing_processes` — were silently dropped from `list_recipes()`. Kitchens were visible because `KitchenCapability` has no such veto.
- This is the exact format `CookingExtractor._detailed_extract_requirements()` already parses for matching (it checks `"tool_list" in data or "making_instructions" in data`), so the matching pipeline already understood this shape; only the newer `list_recipes()` browse path didn't.
- Root-caused by pulling the storage account's `newformats` container listing directly and running the real discriminator/`from_dict()` against the actual uploaded files — confirmed pathing/prefix discovery was already correct (Azure blob listing recurses into `okh/manifests/` fine; no delimiter is used), and the failure was purely shape-based.

## Fix

- `Recipe.is_recipe_data()` now recognizes an OKH-shaped manifest as a recipe when its `manufacturing_processes` names a cooking technique (e.g. `"bake"`) — since the OKH schema is generic enough to describe a recipe's BOM/tools/instructions exactly as well as a hardware design's, shape alone can't otherwise tell them apart.
- `Recipe.from_dict()` now maps OKH fields when the simple fields are absent: `title`→`name`, `materials`/`metadata.original.bom_atoms`→`ingredients`, `tool_list`→`equipment`, `making_instructions`/`manufacturing_processes`→`instructions`.
- New unit tests cover: OKH-shaped recipe recognition, a non-cooking OKH manifest (`mill`/`drill`) still correctly rejected, and full field-mapping including the `bom_atoms` fallback.

## Test plan

- [x] `uv run pytest tests/unit/test_cooking_models.py tests/unit/test_okh_list_recipes.py tests/api/test_okh_okw_cooking_routes.py tests/cli/test_okh_okw_cooking_cli.py` — all pass
- [x] Validated the fix against the actual 3 recipe files from the `cooking-test` instance's storage container — all now classified as recipes with fields correctly mapped
- [x] `make ready` — all 11 gates pass

Made with [Cursor](https://cursor.com)