### PR TITLE
fix: drop bom_atoms ingredient fallback, fix data file instead

### DIFF
--- a/src/core/domains/cooking/models.py
+++ b/src/core/domains/cooking/models.py
@@ -162,9 +162,7 @@ def _has_okh_cooking_process(data: Dict[str, Any]) -> bool:
 
 
 def _okh_material_names(data: Dict[str, Any]) -> List[str]:
-    """Ingredient names from an OKH manifest's ``materials`` field, falling
-    back to the non-standard ``metadata.original.bom_atoms`` mapping some
-    hand-authored recipe manifests use instead (keys are ingredient names)."""
+    """Ingredient names from an OKH manifest's ``materials`` field."""
     names: List[str] = []
     for material in data.get("materials") or []:
         if isinstance(material, str):
@@ -178,12 +176,6 @@ def _okh_material_names(data: Dict[str, Any]) -> List[str]:
             )
             if name:
                 names.append(str(name))
-    if not names:
-        bom_atoms = ((data.get("metadata") or {}).get("original") or {}).get(
-            "bom_atoms"
-        )
-        if isinstance(bom_atoms, dict):
-            names = [str(k) for k in bom_atoms.keys()]
     return names
 
 

--- a/tests/unit/test_cooking_models.py
+++ b/tests/unit/test_cooking_models.py
@@ -124,22 +124,6 @@ class TestRecipeFromOkhShape:
         except ValueError:
             pass
 
-    def test_bom_atoms_fill_in_ingredients_when_no_materials(self):
-        # Some hand-authored recipe manifests bury the BOM under
-        # metadata.original.bom_atoms instead of the standard `materials`
-        # field.
-        data = okh_recipe_dict(materials=[])
-        data["metadata"] = {
-            "original": {
-                "bom_atoms": {
-                    "flour": {"identifier": "Q779360"},
-                    "butter": {"identifier": "Q83037"},
-                }
-            }
-        }
-        recipe = Recipe.from_dict(data)
-        assert recipe.ingredients == ["flour", "butter"]
-
 
 class TestRecipeDiscriminator:
     def test_recipe_shaped_data_is_a_recipe(self):


### PR DESCRIPTION
## Summary

Follow-up to #350. That PR's discriminator fix landed on `main`, but a
same-day follow-up commit dropping the `metadata.original.bom_atoms`
ingredient fallback was pushed after #350 had already merged, so it never
made it in. This PR carries that commit over.

- Removes the `metadata.original.bom_atoms` fallback in
  `Recipe._okh_material_names()` / `from_dict()` -- that fallback existed
  purely to accommodate one hand-authored recipe file
  (`okh-chococolate-chip-cookies-recipe.json`) using a non-standard BOM
  location instead of extending our discriminator's standard to fit one file.
- The actual data file has already been fixed in the `newformats` storage
  container: its BOM was moved from `metadata.original.bom_atoms` into the
  standard top-level `materials` field (matching the shape the oatmeal
  recipe in the same container already used correctly).

## Test plan

- [x] `uv run pytest tests/unit/test_cooking_models.py tests/unit/test_okh_list_recipes.py` -- all pass
- [x] `make ready` -- all 11 gates pass
- [x] Confirmed the live `newformats` data file was updated to the standard shape and still resolves correctly via `Recipe.from_dict()`

Made with [Cursor](https://cursor.com)