### PR TITLE
fix: cover recipes/kitchens in low-volatility cache refresh

### DIFF
--- a/frontend/src/queryClient.ts
+++ b/frontend/src/queryClient.ts
@@ -69,6 +69,8 @@ export const LOW_VOLATILITY_QUERY_KEYS = [
   ["network"],
   ["package-list"],
   ["domains"],
+  ["recipes"],
+  ["kitchens"],
 ] as const;
 
 /** Invalidate (and trigger refetch of) the low-volatility datasets. */


### PR DESCRIPTION
## Summary

Diagnosed why the `cooking-test` instance still showed "No recipes yet" in
the browser after #350/#351 fixed the backend: it's a client-side cache
issue, not a backend regression.

- `RecipeListView`/`KitchenListView` query under `["recipes"]`/`["kitchens"]`,
  persisted to `localStorage` with a 1h `staleTime` (see `queryClient.ts`).
- Neither key was in `LOW_VOLATILITY_QUERY_KEYS`, so the "Refresh data"
  control (NavBar) had no way to invalidate a recipes result a browser had
  already cached from before the backend fix -- it would keep serving the
  stale empty list until the 1h staleTime elapsed on its own.
- Confirmed directly against the deployed backend (`curl .../v1/api/okh/recipes`)
  that all 3 recipes are returned correctly; the gap is purely this
  browser-side cache never being told to refetch.

## Fix

Add `["recipes"]` and `["kitchens"]` to `LOW_VOLATILITY_QUERY_KEYS`, so
clicking "Refresh data" invalidates and refetches them like the other
low-volatility datasets (OKH manifests, OKW facilities, packages).

## Test plan

- [x] `npx vitest run src/queryClient.test.ts` -- covers `LOW_VOLATILITY_QUERY_KEYS` generically, passes with the new keys
- [x] `npm run test:unit` -- 338 tests pass
- [x] `npm run typecheck` -- clean

Made with [Cursor](https://cursor.com)