### PR TITLE
feat: make recipe cards interactive with detail page and Run Match

### DIFF
--- a/frontend/src/features/match/CookingMatchView.test.tsx
+++ b/frontend/src/features/match/CookingMatchView.test.tsx
@@ -1,0 +1,49 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import type { Recipe } from "../../types/recipe";
+import type { Kitchen } from "../../types/kitchen";
+import { CookingMatchView } from "./CookingMatchView";
+
+const recipes: Recipe[] = [
+  {
+    id: "recipe-1",
+    name: "Sourdough Bread",
+    ingredients: ["flour", "water", "salt", "starter"],
+    instructions: ["Mix", "Rest", "Bake"],
+    equipment: ["oven"],
+    domain: "cooking",
+  },
+];
+
+const kitchens: Kitchen[] = [];
+
+function renderView(initialRecipeId?: string) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  client.setQueryData(["recipes"], recipes);
+  client.setQueryData(["kitchens"], kitchens);
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <CookingMatchView initialRecipeId={initialRecipeId} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("CookingMatchView", () => {
+  it("preselects the recipe passed via initialRecipeId (e.g. from a card's Run Match)", () => {
+    renderView("recipe-1");
+    expect(screen.getByText("Selected recipe")).toBeInTheDocument();
+    // Appears both in the "Selected recipe" banner and the picker's result list.
+    expect(screen.getAllByText("Sourdough Bread").length).toBeGreaterThan(0);
+  });
+
+  it("has no recipe selected when initialRecipeId is omitted", () => {
+    renderView();
+    expect(screen.queryByText("Selected recipe")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/match/CookingMatchView.tsx
+++ b/frontend/src/features/match/CookingMatchView.tsx
@@ -14,17 +14,22 @@ import { LoadingState, EmptyState, ErrorState } from "../../components/ui/states
 import { Button } from "../../components/ui/button";
 import { cn } from "@/lib/utils";
 
+interface Props {
+  /** Recipe id to preselect, e.g. from a recipe card/detail page's "Run Match". */
+  initialRecipeId?: string;
+}
+
 /**
  * Cooking-domain counterpart to MatchView: recipe + kitchens in, ranked
  * solutions out. List-only surfaces feed it (no generate-from-URL, no RFQ
  * handoff, no network/MoM scope — see the cooking-domain-instance plan's
  * "Out of scope").
  */
-export function CookingMatchView() {
+export function CookingMatchView({ initialRecipeId }: Props = {}) {
   const recipes = useQuery({ queryKey: ["recipes"], queryFn: fetchAllRecipes });
   const kitchens = useQuery({ queryKey: ["kitchens"], queryFn: fetchAllKitchens });
 
-  const [selected, setSelected] = useState("");
+  const [selected, setSelected] = useState(initialRecipeId ?? "");
   const [mode, setMode] = useState<SystemMode>("standard");
   const [kitchenIds, setKitchenIds] = useState<string[]>([]);
   const [selectedSolutionKeys, setSelectedSolutionKeys] = useState<string[]>([]);

--- a/frontend/src/features/okh/RecipeDetailView.test.tsx
+++ b/frontend/src/features/okh/RecipeDetailView.test.tsx
@@ -1,0 +1,71 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes, useSearchParams } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import type { Recipe } from "../../types/recipe";
+import { RecipeDetailView } from "./RecipeDetailView";
+
+const recipe: Recipe = {
+  id: "recipe-1",
+  name: "Sourdough Bread",
+  ingredients: ["flour", "water", "salt", "starter"],
+  instructions: ["Mix", "Rest", "Bake"],
+  equipment: ["oven", "mixing bowl"],
+  domain: "cooking",
+};
+
+function MatchPlaceholder() {
+  const [params] = useSearchParams();
+  return <div>match:{params.get("recipe_id")}</div>;
+}
+
+function renderDetail(seed: Recipe[] = [recipe]) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  client.setQueryData(["recipes"], seed);
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={["/okh/recipe-1"]}>
+        <Routes>
+          <Route path="/okh" element={<div>recipe list</div>} />
+          <Route path="/okh/:id" element={<RecipeDetailView id="recipe-1" />} />
+          <Route path="/match" element={<MatchPlaceholder />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("RecipeDetailView", () => {
+  it("shows the recipe's ingredients, instructions, and equipment", () => {
+    renderDetail();
+    expect(
+      screen.getByRole("heading", { name: "Sourdough Bread" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("flour")).toBeInTheDocument();
+    expect(screen.getByText("Mix")).toBeInTheDocument();
+    expect(screen.getByText("mixing bowl")).toBeInTheDocument();
+  });
+
+  it("links the breadcrumb back to the recipe list", () => {
+    renderDetail();
+    expect(screen.getByRole("link", { name: /Recipes/i })).toHaveAttribute(
+      "href",
+      "/okh",
+    );
+  });
+
+  it("navigates to the recipe's match page via Run Match", async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await user.click(screen.getByRole("button", { name: /Run Match/i }));
+    expect(await screen.findByText("match:recipe-1")).toBeInTheDocument();
+  });
+
+  it("shows a not-found error when the id has no matching recipe", () => {
+    renderDetail([]);
+    expect(screen.getByText(/Recipe not found/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/okh/RecipeDetailView.tsx
+++ b/frontend/src/features/okh/RecipeDetailView.tsx
@@ -1,0 +1,111 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link, useNavigate } from "react-router-dom";
+import { fetchAllRecipes } from "../../api/ohm/recipes";
+import { LoadingState, ErrorState } from "../../components/ui/states";
+import { Button } from "../../components/ui/button";
+
+interface Props {
+  id: string;
+}
+
+/**
+ * Cooking-domain counterpart to OkhDetailView. There is no per-recipe fetch
+ * endpoint (list-only, see the cooking-domain-instance plan), so this reuses
+ * the same ["recipes"] query the list view already populates and looks the
+ * recipe up by id -- no extra request for a catalogue this small.
+ */
+export function RecipeDetailView({ id }: Props) {
+  const navigate = useNavigate();
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: ["recipes"],
+    queryFn: fetchAllRecipes,
+  });
+
+  if (isLoading) return <LoadingState message="Loading recipe…" />;
+
+  const recipe = data?.find((r) => r.id === id);
+
+  if (isError || !recipe) {
+    return (
+      <ErrorState
+        description={
+          error instanceof Error ? error.message : "Recipe not found."
+        }
+        onRetry={() => refetch()}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <nav className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+        <Link
+          to="/okh"
+          className="hover:text-indigo-600 dark:hover:text-indigo-400"
+        >
+          Recipes
+        </Link>
+        <span aria-hidden="true">›</span>
+        <span className="truncate text-slate-700 dark:text-slate-200">
+          {recipe.name}
+        </span>
+      </nav>
+
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">
+          {recipe.name}
+        </h1>
+        <Button onClick={() => navigate(`/match?recipe_id=${recipe.id}`)}>
+          ⚡ Run Match
+        </Button>
+      </div>
+
+      <div className="grid gap-8 sm:grid-cols-3">
+        <section className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Ingredients
+          </h2>
+          {recipe.ingredients.length === 0 ? (
+            <p className="text-sm text-muted-foreground">None listed.</p>
+          ) : (
+            <ul className="list-inside list-disc space-y-1 text-sm text-slate-700 dark:text-slate-200">
+              {recipe.ingredients.map((i) => (
+                <li key={i}>{i}</li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Instructions
+          </h2>
+          {recipe.instructions.length === 0 ? (
+            <p className="text-sm text-muted-foreground">None listed.</p>
+          ) : (
+            <ol className="list-inside list-decimal space-y-1 text-sm text-slate-700 dark:text-slate-200">
+              {recipe.instructions.map((step, i) => (
+                <li key={i}>{step}</li>
+              ))}
+            </ol>
+          )}
+        </section>
+
+        <section className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Equipment
+          </h2>
+          {recipe.equipment.length === 0 ? (
+            <p className="text-sm text-muted-foreground">None listed.</p>
+          ) : (
+            <ul className="list-inside list-disc space-y-1 text-sm text-slate-700 dark:text-slate-200">
+              {recipe.equipment.map((e) => (
+                <li key={e}>{e}</li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/okh/RecipeListView.test.tsx
+++ b/frontend/src/features/okh/RecipeListView.test.tsx
@@ -1,0 +1,57 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes, useSearchParams } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import type { Recipe } from "../../types/recipe";
+import { RecipeListView } from "./RecipeListView";
+
+const recipes: Recipe[] = [
+  {
+    id: "recipe-1",
+    name: "Sourdough Bread",
+    ingredients: ["flour", "water", "salt", "starter"],
+    instructions: ["Mix", "Rest", "Bake"],
+    equipment: ["oven"],
+    domain: "cooking",
+  },
+];
+
+function MatchPlaceholder() {
+  const [params] = useSearchParams();
+  return <div>match:{params.get("recipe_id")}</div>;
+}
+
+function renderList() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  client.setQueryData(["recipes"], recipes);
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={["/okh"]}>
+        <Routes>
+          <Route path="/okh" element={<RecipeListView />} />
+          <Route path="/okh/:id" element={<div>detail page</div>} />
+          <Route path="/match" element={<MatchPlaceholder />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("RecipeListView", () => {
+  it("links each recipe card to its detail page", () => {
+    renderList();
+    expect(
+      screen.getByRole("link", { name: /Sourdough Bread/i }),
+    ).toHaveAttribute("href", "/okh/recipe-1");
+  });
+
+  it("navigates to the recipe's match page via Run Match", async () => {
+    const user = userEvent.setup();
+    renderList();
+    await user.click(screen.getByRole("button", { name: /Run Match/i }));
+    expect(await screen.findByText("match:recipe-1")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/okh/RecipeListView.tsx
+++ b/frontend/src/features/okh/RecipeListView.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { Link, useNavigate } from "react-router-dom";
 import { fetchAllRecipes } from "../../api/ohm/recipes";
 import { LoadingState, EmptyState, ErrorState } from "../../components/ui/states";
 
@@ -8,6 +9,7 @@ import { LoadingState, EmptyState, ErrorState } from "../../components/ui/states
  * uploaded to storage directly, not created here.
  */
 export function RecipeListView() {
+  const navigate = useNavigate();
   const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ["recipes"],
     queryFn: fetchAllRecipes,
@@ -43,14 +45,29 @@ export function RecipeListView() {
           {recipes.map((recipe) => (
             <div
               key={recipe.id}
-              className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-900"
+              className="group flex flex-col rounded-lg border border-slate-200 bg-white shadow-sm transition-shadow hover:shadow-md dark:border-slate-700 dark:bg-slate-900"
             >
-              <h2 className="font-semibold text-foreground">{recipe.name}</h2>
-              <p className="mt-2 text-xs text-muted-foreground">
-                {recipe.ingredients.length} ingredient
-                {recipe.ingredients.length !== 1 ? "s" : ""} ·{" "}
-                {recipe.instructions.length} step{recipe.instructions.length !== 1 ? "s" : ""}
-              </p>
+              <Link to={`/okh/${recipe.id}`} className="flex flex-1 flex-col gap-2 p-4 no-underline">
+                <h2 className="font-semibold text-slate-800 group-hover:text-indigo-600 transition-colors dark:text-slate-100 dark:group-hover:text-indigo-400">
+                  {recipe.name}
+                </h2>
+                <p className="text-xs text-muted-foreground">
+                  {recipe.ingredients.length} ingredient
+                  {recipe.ingredients.length !== 1 ? "s" : ""} ·{" "}
+                  {recipe.instructions.length} step{recipe.instructions.length !== 1 ? "s" : ""}
+                </p>
+              </Link>
+              <div className="flex items-center justify-end border-t border-slate-100 px-4 py-2.5 dark:border-slate-800">
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    navigate(`/match?recipe_id=${recipe.id}`);
+                  }}
+                  className="rounded-md bg-indigo-50 px-3 py-1 text-xs font-medium text-indigo-700 hover:bg-indigo-100 transition-colors dark:bg-indigo-950 dark:text-indigo-300 dark:hover:bg-indigo-900"
+                >
+                  Run Match ⚡
+                </button>
+              </div>
             </div>
           ))}
         </div>

--- a/frontend/src/pages/MatchPage.tsx
+++ b/frontend/src/pages/MatchPage.tsx
@@ -15,7 +15,16 @@ export function MatchPage() {
   const { domain } = useDomain();
   const [searchParams] = useSearchParams();
   const location = useLocation();
-  if (domain === "cooking") return <CookingMatchView />;
+  if (domain === "cooking") {
+    const recipeId = searchParams.get("recipe_id") ?? undefined;
+    // Remount when the preselected recipe changes so RecipePicker resets cleanly.
+    return (
+      <CookingMatchView
+        key={recipeId ?? "__none__"}
+        initialRecipeId={recipeId}
+      />
+    );
+  }
   const okhId = searchParams.get("okh_id") ?? undefined;
   const okwId = searchParams.get("okw_id") ?? undefined;
 

--- a/frontend/src/pages/OkhPage.tsx
+++ b/frontend/src/pages/OkhPage.tsx
@@ -2,12 +2,17 @@ import { useParams } from "react-router-dom";
 import { OkhListView } from "../features/okh/OkhListView";
 import { OkhDetailView } from "../features/okh/OkhDetailView";
 import { RecipeListView } from "../features/okh/RecipeListView";
+import { RecipeDetailView } from "../features/okh/RecipeDetailView";
 import { useDomain } from "../context/DomainContext";
 
 export function OkhPage() {
   const { id } = useParams<{ id?: string }>();
   const { domain } = useDomain();
-  if (id) return <OkhDetailView id={id} />;
-  // Cooking has no detail page (list-only, see the cooking-domain-instance plan).
+  if (id)
+    return domain === "cooking" ? (
+      <RecipeDetailView id={id} />
+    ) : (
+      <OkhDetailView id={id} />
+    );
   return domain === "cooking" ? <RecipeListView /> : <OkhListView />;
 }


### PR DESCRIPTION
## Summary
- Recipe cards on the cooking-domain browse page were static text — no way to open a recipe or run a match from the list, unlike design cards.
- Add `RecipeDetailView` (mirroring `OkhDetailView`'s breadcrumb/title/actions layout) rendered at the existing `okh/:id` route when `domain=cooking`, reusing the already-cached `["recipes"]` query since there's no per-recipe fetch endpoint.
- Link each recipe card's body to its detail page, and add a "Run Match ⚡" action on both the card and the detail page that navigates to `/match?recipe_id=<id>`.
- `MatchPage`/`CookingMatchView` now read `recipe_id` from the URL and preselect it in `RecipePicker`, mirroring how `okh_id` preselects a design on the hardware match page.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint` (no new warnings/errors on touched files)
- [x] `npm run test:unit` — 346/346 passing, including new tests for `RecipeListView`, `RecipeDetailView`, and `CookingMatchView`'s `initialRecipeId` preselect
- [ ] Manually click through a recipe card → detail page → Run Match on a deployed cooking-domain instance

Made with [Cursor](https://cursor.com)