### PR TITLE
Fix cooking-domain match coverage warning and add RFQ generation

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 631
+Total Python files: 633
 
 ├── deploy/
 │   ├── __init__.py
@@ -813,6 +813,7 @@ Total Python files: 631
 │       │       │       def _detect_domain_from_manifest()
 │       │       │       def _extract_facility_process_names_for_prefilter()
 │       │       │       def _prefilter_facilities_by_required_processes()
+│       │       │       def _build_cooking_match_explanation()
 │       │       │       def _matches_filters()
 │       │       ├── okh.py
 │       │       │       def _okh_success_response()
@@ -873,7 +874,7 @@ Total Python files: 631
 │       │   │   ├── matchers.py
 │       │   │   │       class CookingMatcher (match, _can_satisfy, generate_supply_tree)
 │       │   │   │       def _fuzzy_match()
-│       │   │   │       def _fuzzy_overlap_count()
+│       │   │   │       def _fuzzy_split()
 │       │   │   ├── models.py
 │       │   │   │       class KitchenCapability (from_dict, to_dict, is_kitchen_data...)
 │       │   │   │       class Recipe (from_dict, to_dict, is_recipe_data...)
@@ -2570,6 +2571,17 @@ Total Python files: 631
         │       class TestDeployEnvVars (test_production_applies_storage_target, test_development_is_local, test_missing_environment_returns_empty...)
         │       class TestFrontendDeployEnvVars (test_production_frontend_config, test_keys_are_uppercased_env_names, test_absent_table_returns_empty...)
         │       def clean_env()
+        ├── test_cooking_match_explanation.py
+        │       def _supply_tree()
+        │       def test_explanation_reports_matched_and_missing_requirements()
+        │       def test_explanation_matched_status_when_nothing_missing()
+        │       def test_explanation_to_dict_has_requirement_matches_frontend_expects()
+        ├── test_cooking_matchers.py
+        │       def _requirements()
+        │       def _capabilities()
+        │       def test_generate_supply_tree_reports_matched_and_missing_ingredients()
+        │       def test_generate_supply_tree_fuzzy_matches_qualifiers_and_plurals()
+        │       def test_generate_supply_tree_empty_kitchen_inventory_uses_moderate_default()
         ├── test_cooking_models.py
         │       class TestRecipeRoundTrip (test_from_dict_requires_id, test_from_dict_requires_name, test_to_dict_round_trips...)
         │       class TestRecipeFromOkhShape (test_title_becomes_name, test_materials_become_ingredients, test_tool_list_becomes_equipment...)
@@ -3276,7 +3288,7 @@ Total Python files: 631
 
 ## Overview
 
-Total files analyzed: 631
+Total files analyzed: 633
 
 ## Entry Points
 
@@ -11015,6 +11027,32 @@ Verifies that:
 - `test_manifest_round_trip_with_ids()`
 
 **Internal Dependencies:** 13 imports
+
+### `tests/unit/test_cooking_match_explanation.py`
+> _build_cooking_match_explanation: turns CookingMatcher's ingredient/tool
+overlap into a MatchExplana...
+
+**Exports:** test_explanation_reports_matched_and_missing_requirements, test_explanation_matched_status_when_nothing_missing, test_explanation_to_dict_has_requirement_matches_frontend_expects
+
+**Functions:**
+- `test_explanation_reports_matched_and_missing_requirements()`
+- `test_explanation_matched_status_when_nothing_missing()`
+- `test_explanation_to_dict_has_requirement_matches_frontend_expects()`
+
+**Internal Dependencies:** 5 imports
+
+### `tests/unit/test_cooking_matchers.py`
+> CookingMatcher.generate_supply_tree: confidence scoring and the matched/missing
+ingredient and tool ...
+
+**Exports:** test_generate_supply_tree_reports_matched_and_missing_ingredients, test_generate_supply_tree_fuzzy_matches_qualifiers_and_plurals, test_generate_supply_tree_empty_kitchen_inventory_uses_moderate_default
+
+**Functions:**
+- `test_generate_supply_tree_reports_matched_and_missing_ingredients()`
+- `test_generate_supply_tree_fuzzy_matches_qualifiers_and_plurals()`
+- `test_generate_supply_tree_empty_kitchen_inventory_uses_moderate_default()`
+
+**Internal Dependencies:** 3 imports
 
 ### `tests/unit/test_country_names.py`
 > Tests for country code ↔ name normalization....

--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 633
+Total Python files: 634
 
 ├── deploy/
 │   ├── __init__.py
@@ -837,6 +837,9 @@ Total Python files: 633
 │       │       │       def _extract_matched_capabilities_block()
 │       │       │       def _extract_manifest_extras()
 │       │       │       def _render_rfq()
+│       │       │       def _extract_recipe_lists()
+│       │       │       def _extract_cooking_match_summary()
+│       │       │       def _render_cooking_rfq()
 │       │       ├── rules.py
 │       │       ├── supply_tree.py
 │       │       │       def _dict_to_xml()
@@ -1974,6 +1977,9 @@ Total Python files: 633
     │   │       def mock_two_packages()
     │   ├── test_provenance_routes.py
     │   │       def _get_app()
+    │   ├── test_rfq_routes.py
+    │   │       def _get_app()
+    │   │       def _solution()
     │   ├── test_scaffold_cleanup_endpoint.py
     │   │       def _get_app()
     │   ├── test_security_policy_route.py
@@ -3288,7 +3294,7 @@ Total Python files: 633
 
 ## Overview
 
-Total files analyzed: 633
+Total files analyzed: 634
 
 ## Entry Points
 
@@ -9852,6 +9858,13 @@ Package names use ``org/project`` (a slash). Routes mus...
 > Contract tests for GET /api/okh/{id}/provenance and /api/okw/{id}/provenance....
 
 **Internal Dependencies:** 6 imports
+
+### `tests/api/test_rfq_routes.py`
+> Contract tests for POST /api/rfq/generate.
+
+Covers the cooking-domain branch (recipe + kitchen) adde...
+
+**Internal Dependencies:** 1 imports
 
 ### `tests/api/test_scaffold_cleanup_endpoint.py`
 

--- a/frontend/src/features/match/CookingMatchView.test.tsx
+++ b/frontend/src/features/match/CookingMatchView.test.tsx
@@ -1,9 +1,13 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { describe, expect, it } from "vitest";
 import type { Recipe } from "../../types/recipe";
 import type { Kitchen } from "../../types/kitchen";
+import type { CookingRfqNavigationState } from "../../types/rfq";
+import { server } from "../../test/msw/server";
 import { CookingMatchView } from "./CookingMatchView";
 
 const recipes: Recipe[] = [
@@ -17,7 +21,22 @@ const recipes: Recipe[] = [
   },
 ];
 
-const kitchens: Kitchen[] = [];
+const kitchens: Kitchen[] = [
+  {
+    id: "kitchen-1",
+    name: "Test Kitchen",
+    appliances: ["oven"],
+    tools: ["mixing bowl"],
+    ingredients: ["flour", "water", "salt"],
+    domain: "cooking",
+  },
+];
+
+/** Renders the RFQ navigation state so a test can assert on it. */
+function RfqProbe() {
+  const state = useLocation().state as CookingRfqNavigationState | null;
+  return <div data-testid="rfq-state">{JSON.stringify(state)}</div>;
+}
 
 function renderView(initialRecipeId?: string) {
   const client = new QueryClient({
@@ -27,8 +46,14 @@ function renderView(initialRecipeId?: string) {
   client.setQueryData(["kitchens"], kitchens);
   return render(
     <QueryClientProvider client={client}>
-      <MemoryRouter>
-        <CookingMatchView initialRecipeId={initialRecipeId} />
+      <MemoryRouter initialEntries={["/match"]}>
+        <Routes>
+          <Route
+            path="/match"
+            element={<CookingMatchView initialRecipeId={initialRecipeId} />}
+          />
+          <Route path="/rfq" element={<RfqProbe />} />
+        </Routes>
       </MemoryRouter>
     </QueryClientProvider>,
   );
@@ -45,5 +70,45 @@ describe("CookingMatchView", () => {
   it("has no recipe selected when initialRecipeId is omitted", () => {
     renderView();
     expect(screen.queryByText("Selected recipe")).not.toBeInTheDocument();
+  });
+
+  it("navigates to /rfq with cooking nav state when contacting a selected kitchen", async () => {
+    server.use(
+      http.post("*/v1/api/match", () =>
+        HttpResponse.json({
+          data: {
+            solutions: [
+              {
+                facility_id: "kitchen-1",
+                facility_name: "Test Kitchen",
+                confidence: 0.65,
+                score: 0.65,
+                rank: 1,
+                explanation_human: "✓ Test Kitchen MATCHED (confidence: 65%)",
+                match_type: "cooking",
+              },
+            ],
+            total_solutions: 1,
+          },
+        }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderView("recipe-1");
+
+    await user.click(screen.getByLabelText("Test Kitchen"));
+    await user.click(screen.getByRole("button", { name: "⚡ Run Match" }));
+    await user.click(await screen.findByLabelText("Select Test Kitchen"));
+    await user.click(screen.getByRole("button", { name: "Contact selected kitchens →" }));
+
+    const state = JSON.parse(
+      (await screen.findByTestId("rfq-state")).textContent ?? "null",
+    ) as CookingRfqNavigationState;
+    expect(state.domain).toBe("cooking");
+    expect(state.recipeId).toBe("recipe-1");
+    expect(state.recipeTitle).toBe("Sourdough Bread");
+    expect(state.solutions).toHaveLength(1);
+    expect(state.solutions[0].facility_id).toBe("kitchen-1");
   });
 });

--- a/frontend/src/features/match/CookingMatchView.tsx
+++ b/frontend/src/features/match/CookingMatchView.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { fetchAllRecipes } from "../../api/ohm/recipes";
 import { fetchAllKitchens } from "../../api/ohm/kitchens";
@@ -7,12 +8,14 @@ import { ApiError } from "../../api/ohm/client";
 import { solutionSelectionKey, toMatchView } from "./matchViewModel";
 import { defaultTolerance, toleranceCeiling, withinTolerance } from "./nearMiss";
 import { buildRecipeMatchRequest, SYSTEM_MODES, type SystemMode } from "./matchRequest";
+import { toRfqSolutions } from "./rfqHandoff";
 import { RecipePicker } from "./RecipePicker";
 import { KitchenFilter } from "./KitchenFilter";
 import { MatchResultCard } from "./MatchResultCard";
 import { LoadingState, EmptyState, ErrorState } from "../../components/ui/states";
 import { Button } from "../../components/ui/button";
 import { cn } from "@/lib/utils";
+import type { CookingRfqNavigationState } from "../../types/rfq";
 
 interface Props {
   /** Recipe id to preselect, e.g. from a recipe card/detail page's "Run Match". */
@@ -21,11 +24,10 @@ interface Props {
 
 /**
  * Cooking-domain counterpart to MatchView: recipe + kitchens in, ranked
- * solutions out. List-only surfaces feed it (no generate-from-URL, no RFQ
- * handoff, no network/MoM scope — see the cooking-domain-instance plan's
- * "Out of scope").
+ * solutions out.
  */
 export function CookingMatchView({ initialRecipeId }: Props = {}) {
+  const navigate = useNavigate();
   const recipes = useQuery({ queryKey: ["recipes"], queryFn: fetchAllRecipes });
   const kitchens = useQuery({ queryKey: ["kitchens"], queryFn: fetchAllKitchens });
 
@@ -68,6 +70,7 @@ export function CookingMatchView({ initialRecipeId }: Props = {}) {
   const hiddenCount = (rawView?.solutions.length ?? 0) - (view?.solutions.length ?? 0);
   const modeInfo = SYSTEM_MODES.find((s) => s.mode === mode);
   const canRun = !!selected && kitchenIds.length > 0 && !mutation.isPending;
+  const selectedRecipe = recipes.data?.find((r) => r.id === selected);
 
   return (
     <div className="space-y-6">
@@ -243,6 +246,25 @@ export function CookingMatchView({ initialRecipeId }: Props = {}) {
                   onClick={() => setSelectedSolutionKeys([])}
                 >
                   Clear selection
+                </Button>
+                <Button
+                  size="sm"
+                  disabled={selectedSolutionKeys.length === 0 || !selectedRecipe}
+                  onClick={() => {
+                    const selectedSolutions = view.solutions.filter((s, i) =>
+                      selectedSolutionKeys.includes(solutionSelectionKey(s, i)),
+                    );
+                    const state: CookingRfqNavigationState = {
+                      domain: "cooking",
+                      recipeId: selectedRecipe!.id,
+                      recipeTitle: selectedRecipe!.name,
+                      recipe: selectedRecipe,
+                      solutions: toRfqSolutions(selectedSolutions),
+                    };
+                    navigate("/rfq", { state });
+                  }}
+                >
+                  Contact selected kitchens →
                 </Button>
               </div>
             </div>

--- a/frontend/src/features/rfq/RfqView.test.tsx
+++ b/frontend/src/features/rfq/RfqView.test.tsx
@@ -1,0 +1,113 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { server } from "../../test/msw/server";
+import type { CookingRfqNavigationState } from "../../types/rfq";
+import { RfqView } from "./RfqView";
+
+function renderView(navState: CookingRfqNavigationState) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <RfqView navState={navState} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+const cookingNavState: CookingRfqNavigationState = {
+  domain: "cooking",
+  recipeId: "recipe-1",
+  recipeTitle: "Chocolate Chip Cookies",
+  recipe: {
+    id: "recipe-1",
+    name: "Chocolate Chip Cookies",
+    ingredients: ["flour", "sugar", "chocolate chips"],
+    instructions: [],
+    equipment: ["oven"],
+    domain: "cooking",
+  },
+  solutions: [
+    {
+      facility_id: "kitchen-1",
+      facility_name: "Test Kitchen",
+      confidence: 0.65,
+      score: 0.65,
+      rank: 1,
+      match_type: "cooking",
+      explanation: null,
+      explanation_human: "✓ Test Kitchen MATCHED (confidence: 65%)",
+      metrics: { facility_count: 1, requirement_count: 0, capability_count: 0 },
+      tree: {
+        id: "tree-1",
+        facility_name: "Test Kitchen",
+        okh_reference: "",
+        confidence_score: 0.65,
+        estimated_cost: null,
+        estimated_time: null,
+        match_type: "cooking",
+        depth: 0,
+        production_stage: "",
+        metadata: {},
+      },
+      facility: { id: "kitchen-1", name: "Test Kitchen", location: { city: "", country: "" } },
+    },
+  ],
+};
+
+describe("RfqView — cooking domain", () => {
+  it("generates a recipe-flavoured RFQ, skipping the OKH manifest fetch", async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+    server.use(
+      http.post("*/v1/api/rfq/generate", async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          status: "success",
+          message: "ok",
+          timestamp: new Date().toISOString(),
+          data: {
+            rfqs: [
+              {
+                rfq_number: "RFQ-1",
+                facility_name: "Test Kitchen",
+                facility_id: "kitchen-1",
+                confidence: 0.65,
+                rank: 1,
+                quantity: 1,
+                text: "REQUEST FOR QUOTATION",
+              },
+            ],
+            total_rfqs: 1,
+            recipe_id: "recipe-1",
+            recipe_title: "Chocolate Chip Cookies",
+            generated_at: new Date().toISOString(),
+          },
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderView(cookingNavState);
+
+    expect(screen.getByText("Chocolate Chip Cookies")).toBeInTheDocument();
+    // Cooking uses batch-flavoured quantity wording, not manufacturing's "Production quantity".
+    expect(screen.getByText("Batch quantity")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Generate 1 RFQ/ }));
+
+    await waitFor(() => expect(capturedBody).not.toBeNull());
+    expect(capturedBody).toMatchObject({
+      domain: "cooking",
+      recipe_id: "recipe-1",
+      recipe_title: "Chocolate Chip Cookies",
+    });
+    expect(capturedBody?.okh_id).toBeUndefined();
+    expect(capturedBody?.okh_manifest).toBeUndefined();
+
+    expect(await screen.findByText("RFQ-1", { exact: false })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/rfq/RfqView.test.tsx
+++ b/frontend/src/features/rfq/RfqView.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { MemoryRouter } from "react-router-dom";
@@ -54,17 +54,25 @@ const cookingNavState: CookingRfqNavigationState = {
         production_stage: "",
         metadata: {},
       },
-      facility: { id: "kitchen-1", name: "Test Kitchen", location: { city: "", country: "" } },
+      facility: {
+        id: "kitchen-1",
+        name: "Test Kitchen",
+        location: { city: "", country: "" },
+        manufacturing_processes: [],
+      },
     },
   ],
 };
 
 describe("RfqView — cooking domain", () => {
   it("generates a recipe-flavoured RFQ, skipping the OKH manifest fetch", async () => {
-    let capturedBody: Record<string, unknown> | null = null;
+    let resolveBody: (body: Record<string, unknown>) => void;
+    const bodyPromise = new Promise<Record<string, unknown>>((resolve) => {
+      resolveBody = resolve;
+    });
     server.use(
       http.post("*/v1/api/rfq/generate", async ({ request }) => {
-        capturedBody = (await request.json()) as Record<string, unknown>;
+        resolveBody((await request.json()) as Record<string, unknown>);
         return HttpResponse.json({
           status: "success",
           message: "ok",
@@ -99,14 +107,14 @@ describe("RfqView — cooking domain", () => {
 
     await user.click(screen.getByRole("button", { name: /Generate 1 RFQ/ }));
 
-    await waitFor(() => expect(capturedBody).not.toBeNull());
-    expect(capturedBody).toMatchObject({
+    const body = await bodyPromise;
+    expect(body).toMatchObject({
       domain: "cooking",
       recipe_id: "recipe-1",
       recipe_title: "Chocolate Chip Cookies",
     });
-    expect(capturedBody?.okh_id).toBeUndefined();
-    expect(capturedBody?.okh_manifest).toBeUndefined();
+    expect(body.okh_id).toBeUndefined();
+    expect(body.okh_manifest).toBeUndefined();
 
     expect(await screen.findByText("RFQ-1", { exact: false })).toBeInTheDocument();
   });

--- a/frontend/src/features/rfq/RfqView.tsx
+++ b/frontend/src/features/rfq/RfqView.tsx
@@ -51,32 +51,54 @@ export function RfqView({ navState }: Props) {
     );
   }
 
-  const { okhId, okhTitle, okhFunction, okhVersion, solutions } = navState;
+  const isCooking = navState.domain === "cooking";
+  const solutions = navState.solutions;
+  const subjectId = isCooking ? navState.recipeId : navState.okhId;
+  const subjectTitle = isCooking ? navState.recipeTitle : navState.okhTitle;
+  const okhFunction = isCooking ? undefined : navState.okhFunction;
+  const okhVersion = isCooking ? undefined : navState.okhVersion;
 
-  // Fetch the full manifest so we can embed it in the RFQ output
+  // Fetch the full manifest so we can embed it in the RFQ output. Recipes are
+  // passed in via nav state already (no detail endpoint round-trip needed).
   // eslint-disable-next-line react-hooks/rules-of-hooks -- legacy reference page: conditional hook after early return. RFQ is out of v1 scope (PRD #184) and this page is slated for removal/rebuild; not refactoring throwaway code.
   const { data: fullManifest } = useQuery({
-    queryKey: ["okh-detail-rfq", okhId],
-    queryFn: () => fetchOkhDetail(okhId),
+    queryKey: ["okh-detail-rfq", subjectId],
+    queryFn: () => fetchOkhDetail(subjectId),
+    enabled: !isCooking,
   });
 
   const handleGenerate = () => {
+    const solutionInputs = solutions.map((s) => ({
+      facility_id: s.facility_id,
+      facility_name: s.facility_name,
+      confidence: s.confidence,
+      score: s.score,
+      rank: s.rank,
+      tree: s.tree as unknown as Record<string, unknown>,
+      facility: s.facility as unknown as Record<string, unknown>,
+      explanation_human: s.explanation_human,
+    }));
+
+    if (isCooking) {
+      mutate({
+        domain: "cooking",
+        recipe_id: navState.recipeId,
+        recipe_title: navState.recipeTitle,
+        recipe: navState.recipe as unknown as Record<string, unknown> | undefined,
+        quantity,
+        solutions: solutionInputs,
+      });
+      return;
+    }
+
     mutate({
-      okh_id: okhId,
-      okh_title: okhTitle,
+      okh_id: navState.okhId,
+      okh_title: navState.okhTitle,
       okh_function: okhFunction,
       okh_version: okhVersion,
       quantity,
       okh_manifest: fullManifest as unknown as Record<string, unknown> | undefined,
-      solutions: solutions.map((s) => ({
-        facility_id: s.facility_id,
-        facility_name: s.facility_name,
-        confidence: s.confidence,
-        score: s.score,
-        rank: s.rank,
-        tree: s.tree as unknown as Record<string, unknown>,
-        facility: s.facility as unknown as Record<string, unknown>,
-      })),
+      solutions: solutionInputs,
     });
   };
 
@@ -88,19 +110,21 @@ export function RfqView({ navState }: Props) {
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = `rfq-bundle-${okhId.slice(0, 8)}.txt`;
+    a.download = `rfq-bundle-${subjectId.slice(0, 8)}.txt`;
     a.click();
     URL.revokeObjectURL(url);
   };
 
   const handleDownloadAllJson = () => {
     const payload = {
-      okh_id: okhId,
-      okh_title: okhTitle,
+      domain: isCooking ? "cooking" : "manufacturing",
+      subject_id: subjectId,
+      subject_title: subjectTitle,
       quantity,
       generated_at: new Date().toISOString(),
-      // Full manifest is included so the recipient can inspect or rebuild the package
-      okh_manifest: fullManifest ?? null,
+      // Full manifest/recipe is included so the recipient can inspect the source
+      okh_manifest: isCooking ? null : fullManifest ?? null,
+      recipe: isCooking ? navState.recipe ?? null : null,
       rfqs,
     };
     const blob = new Blob([JSON.stringify(payload, null, 2)], {
@@ -109,7 +133,7 @@ export function RfqView({ navState }: Props) {
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = `rfq-bundle-${okhId.slice(0, 8)}.json`;
+    a.download = `rfq-bundle-${subjectId.slice(0, 8)}.json`;
     a.click();
     URL.revokeObjectURL(url);
   };
@@ -125,7 +149,7 @@ export function RfqView({ navState }: Props) {
           <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
             Generating requests for quotation for{" "}
             <span className="font-medium text-slate-700 dark:text-slate-200">
-              {okhTitle}
+              {subjectTitle}
             </span>
             {okhVersion && (
               <span className="ml-1 text-slate-400">v{okhVersion}</span>
@@ -185,7 +209,7 @@ export function RfqView({ navState }: Props) {
               htmlFor="rfq-quantity"
               className="text-sm font-medium text-slate-700 dark:text-slate-200"
             >
-              Production quantity
+              {isCooking ? "Batch quantity" : "Production quantity"}
             </label>
             <input
               id="rfq-quantity"
@@ -195,7 +219,9 @@ export function RfqView({ navState }: Props) {
               onChange={(e) => setQuantity(Math.max(1, parseInt(e.target.value, 10) || 1))}
               className="w-24 rounded-md border border-slate-300 bg-white px-3 py-1.5 text-sm text-slate-800 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
             />
-            <span className="text-sm text-slate-500 dark:text-slate-400">units</span>
+            <span className="text-sm text-slate-500 dark:text-slate-400">
+              {isCooking ? "batches" : "units"}
+            </span>
           </div>
 
           {okhFunction && (

--- a/frontend/src/types/rfq.ts
+++ b/frontend/src/types/rfq.ts
@@ -1,6 +1,7 @@
 /** RFQ generation request / response types. */
 
 import type { MatchSolution } from "./match";
+import type { Recipe } from "./recipe";
 
 export interface RFQSolutionInput {
   facility_id: string;
@@ -10,17 +11,25 @@ export interface RFQSolutionInput {
   rank: number;
   tree: Record<string, unknown>;
   facility: Record<string, unknown>;
+  /** Human-readable match explanation, shown in the cooking-domain RFQ's match summary. */
+  explanation_human?: string | null;
 }
 
 export interface RFQGenerateRequest {
-  okh_id: string;
-  okh_title: string;
+  /** "manufacturing" (default) or "cooking". Selects okh_* vs recipe_* fields. */
+  domain?: "manufacturing" | "cooking";
+  okh_id?: string;
+  okh_title?: string;
   okh_function?: string;
   okh_version?: string;
-  quantity: number;
-  solutions: RFQSolutionInput[];
   /** Full OKH manifest — embedded in the generated document and JSON export. */
   okh_manifest?: Record<string, unknown>;
+  recipe_id?: string;
+  recipe_title?: string;
+  /** Full recipe — embedded in the generated document and JSON export. */
+  recipe?: Record<string, unknown>;
+  quantity: number;
+  solutions: RFQSolutionInput[];
 }
 
 export interface RFQDocument {
@@ -37,8 +46,10 @@ export interface RFQDocument {
 export interface RFQGenerateResponseData {
   rfqs: RFQDocument[];
   total_rfqs: number;
-  okh_id: string;
-  okh_title: string;
+  okh_id?: string | null;
+  okh_title?: string | null;
+  recipe_id?: string | null;
+  recipe_title?: string | null;
   generated_at: string;
 }
 
@@ -50,10 +61,23 @@ export interface RFQGenerateResponse {
 }
 
 /** State passed via react-router when navigating to the RFQ page. */
-export interface RfqNavigationState {
+export interface ManufacturingRfqNavigationState {
+  domain?: "manufacturing";
   okhId: string;
   okhTitle: string;
   okhFunction?: string;
   okhVersion?: string;
   solutions: MatchSolution[];
 }
+
+export interface CookingRfqNavigationState {
+  domain: "cooking";
+  recipeId: string;
+  recipeTitle: string;
+  recipe?: Recipe;
+  solutions: MatchSolution[];
+}
+
+export type RfqNavigationState =
+  | ManufacturingRfqNavigationState
+  | CookingRfqNavigationState;

--- a/src/core/api/routes/match.py
+++ b/src/core/api/routes/match.py
@@ -34,6 +34,11 @@ from src.config.settings import (
 )
 
 from ...domains.cooking.models import KitchenCapability
+from ...models.match_explanation import (
+    MatchExplanation,
+    MatchStatus,
+    RequirementMatchDetail,
+)
 from ...models.okh import OKHManifest
 from ...models.okw import ManufacturingFacility
 from ...registry.domain_registry import DomainRegistry
@@ -2647,6 +2652,86 @@ async def _get_filtered_facilities(
         )
 
 
+def _build_cooking_match_explanation(
+    supply_tree: Any, facility_id: str, facility_name: str
+) -> MatchExplanation:
+    """Build a MatchExplanation for a cooking-domain result from the ingredient/tool
+    overlap CookingMatcher.generate_supply_tree() already computed (see its
+    matched_ingredients/missing_ingredients/matched_tools/missing_tools metadata).
+
+    Without this, cooking results never got a `requirement_matches` explanation
+    (that block was gated to `domain == "manufacturing"`), so the frontend's
+    coverage badge always fell back to "Coverage unknown" for a real recipe/kitchen
+    match.
+    """
+    metadata = getattr(supply_tree, "metadata", None) or {}
+    requirement_matches = (
+        [
+            RequirementMatchDetail(
+                requirement_value=name,
+                status=MatchStatus.MATCHED,
+                confidence=1.0,
+                requirement_source="ingredient",
+            )
+            for name in metadata.get("matched_ingredients", [])
+        ]
+        + [
+            RequirementMatchDetail(
+                requirement_value=name,
+                status=MatchStatus.NOT_MATCHED,
+                requirement_source="ingredient",
+            )
+            for name in metadata.get("missing_ingredients", [])
+        ]
+        + [
+            RequirementMatchDetail(
+                requirement_value=name,
+                status=MatchStatus.MATCHED,
+                confidence=1.0,
+                requirement_source="equipment",
+            )
+            for name in metadata.get("matched_tools", [])
+        ]
+        + [
+            RequirementMatchDetail(
+                requirement_value=name,
+                status=MatchStatus.NOT_MATCHED,
+                requirement_source="equipment",
+            )
+            for name in metadata.get("missing_tools", [])
+        ]
+    )
+
+    missing_ingredients = metadata.get("missing_ingredients", [])
+    missing_tools = metadata.get("missing_tools", [])
+    overall_status = (
+        MatchStatus.MATCHED
+        if not missing_ingredients and not missing_tools
+        else MatchStatus.NOT_MATCHED
+    )
+    confidence = getattr(supply_tree, "confidence_score", 0.0)
+
+    return MatchExplanation(
+        facility_id=facility_id,
+        facility_name=facility_name,
+        overall_status=overall_status,
+        overall_confidence=confidence,
+        requirement_matches=requirement_matches,
+        why_matched=(
+            "This kitchen has every ingredient and piece of equipment the recipe calls for."
+            if overall_status == MatchStatus.MATCHED
+            else ""
+        ),
+        why_not_matched=(
+            ""
+            if overall_status == MatchStatus.MATCHED
+            else "This kitchen is missing some ingredients or equipment the recipe calls for."
+        ),
+        matching_layers_used=["direct"],
+        missing_capabilities=list(missing_ingredients) + list(missing_tools),
+    )
+
+
 async def _perform_enhanced_matching(
     matching_service: MatchingService,
     requirements_data: Any,
@@ -2985,6 +3070,12 @@ async def _perform_enhanced_matching(
                         else 0.8
                     ),
                 }
+                if getattr(request, "include_explanation", False):
+                    explanation = _build_cooking_match_explanation(
+                        supply_tree, str(kitchen_id), kitchen_name_for_solution
+                    )
+                    solution["explanation"] = explanation.to_dict()
+                    solution["explanation_human"] = explanation.to_human_readable()
                 results.append(solution)
         else:
             raise ValueError(f"Unsupported domain: {domain}")

--- a/src/core/api/routes/rfq.py
+++ b/src/core/api/routes/rfq.py
@@ -40,18 +40,30 @@ class RFQSolutionInput(BaseModel):
     tree: Dict[str, Any]
     # full facility object for location / contact
     facility: Dict[str, Any]
+    # Human-readable match explanation, when the match response included one
+    # (see MatchExplanation.to_human_readable). Used for the cooking-domain
+    # RFQ's match summary section.
+    explanation_human: Optional[str] = None
 
 
 class RFQGenerateRequest(BaseModel):
-    okh_id: str
-    okh_title: str
+    # "manufacturing" (default, OKH design + facility) or "cooking" (recipe +
+    # kitchen). Selects which of the okh_* / recipe_* fields below are used.
+    domain: str = "manufacturing"
+    okh_id: Optional[str] = None
+    okh_title: Optional[str] = None
     okh_function: Optional[str] = None
     okh_version: Optional[str] = None
-    quantity: int = 1
-    solutions: List[RFQSolutionInput]
     # Full OKH manifest — included so the recipient has everything they need.
     # When present, a manifest appendix and package-pull instructions are added.
     okh_manifest: Optional[Dict[str, Any]] = None
+    recipe_id: Optional[str] = None
+    recipe_title: Optional[str] = None
+    # Full recipe (ingredients/instructions/equipment) — embedded in the
+    # generated document so the kitchen has everything they need.
+    recipe: Optional[Dict[str, Any]] = None
+    quantity: int = 1
+    solutions: List[RFQSolutionInput]
 
 
 class RFQDocument(BaseModel):
@@ -357,6 +369,117 @@ def _render_rfq(
 
 
 # ---------------------------------------------------------------------------
+# Cooking-domain template (recipe + kitchen)
+# ---------------------------------------------------------------------------
+
+_COOKING_TEMPLATE = """\
+REQUEST FOR QUOTATION (RFQ)
+
+Date: {date}
+RFQ Number: {rfq_number}
+Valid Until: {valid_until}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+ISSUED TO:
+  Kitchen:      {facility_name}
+  Location:     {facility_location}
+{facility_contact_block}
+ISSUED BY:
+  Platform:     Open Hardware Matching (OHM)
+  Recipe ID:    {recipe_id}
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+SUBJECT:  Kitchen Quotation Request — {recipe_name}
+
+1. RECIPE OVERVIEW
+  Name:         {recipe_name}
+  Ingredients:  {ingredient_list}
+  Equipment:    {equipment_list}
+
+2. SCOPE OF WORK
+  Quantity:     {quantity} batch(es)
+
+3. MATCH SUMMARY
+{match_summary_block}
+4. QUOTATION REQUIREMENTS
+  Please provide a response that includes all applicable items:
+  · Price per batch and total price for the quantity above
+  · Lead time from order to delivery or pickup
+  · Substitutions available for any missing ingredients or equipment noted above
+  · Dietary or allergen considerations
+  · Minimum order quantity (MOQ) if applicable
+
+5. TERMS & CONDITIONS
+  · This RFQ does not constitute a purchase order or commitment to buy.
+  · All submitted pricing and details will be treated as confidential unless
+    explicitly marked otherwise by the kitchen.
+
+Thank you for your consideration.
+"""
+
+
+def _extract_recipe_lists(recipe: Optional[Dict[str, Any]]) -> Dict[str, str]:
+    """Format a recipe's ingredients/equipment as comma-separated lists."""
+    if not recipe:
+        return {
+            "ingredient_list": "See recipe details",
+            "equipment_list": "See recipe details",
+        }
+    ingredients = recipe.get("ingredients") or []
+    equipment = recipe.get("equipment") or []
+    return {
+        "ingredient_list": ", ".join(str(i) for i in ingredients) or "None listed",
+        "equipment_list": ", ".join(str(e) for e in equipment) or "None listed",
+    }
+
+
+def _extract_cooking_match_summary(solution: "RFQSolutionInput") -> str:
+    """Summarise why this kitchen was selected.
+
+    Prefers the human-readable match explanation attached by POST /api/match
+    (ingredient/tool coverage), falling back to bare confidence/rank when the
+    match request did not ask for an explanation.
+    """
+    if solution.explanation_human:
+        return "\n".join(
+            f"  {line}" for line in solution.explanation_human.splitlines()
+        )
+    return (
+        f"  Match confidence: {round(solution.confidence * 100)}%\n"
+        f"  Match rank:       #{solution.rank}"
+    )
+
+
+def _render_cooking_rfq(
+    *,
+    solution: RFQSolutionInput,
+    recipe_title: str,
+    recipe_id: str,
+    quantity: int,
+    recipe: Optional[Dict[str, Any]] = None,
+) -> str:
+    lists = _extract_recipe_lists(recipe)
+    now = datetime.now()
+    valid_until = (now + timedelta(days=30)).strftime("%Y-%m-%d")
+    return _COOKING_TEMPLATE.format(
+        date=now.strftime("%Y-%m-%d"),
+        rfq_number=_rfq_number(),
+        valid_until=valid_until,
+        facility_name=solution.facility_name,
+        facility_contact_block=_extract_contact_block(solution.facility),
+        facility_location=_extract_location(solution.facility),
+        recipe_name=recipe_title,
+        recipe_id=recipe_id,
+        ingredient_list=lists["ingredient_list"],
+        equipment_list=lists["equipment_list"],
+        match_summary_block=_extract_cooking_match_summary(solution),
+        quantity=quantity,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Endpoint
 # ---------------------------------------------------------------------------
 
@@ -367,25 +490,38 @@ async def generate_rfq(request: RFQGenerateRequest) -> RFQGenerateResponse:
     Generate RFQ documents for selected match solutions.
 
     Accepts a subset of match results (as returned by POST /api/match) plus
-    OKH design metadata. Returns one RFQ document per selected solution.
+    either OKH design metadata (domain="manufacturing", the default) or
+    recipe metadata (domain="cooking"). Returns one RFQ document per selected
+    solution.
     """
+    is_cooking = request.domain == "cooking"
+    subject_id = request.recipe_id if is_cooking else request.okh_id
     logger.info(
-        f"Generating RFQs for okh_id={request.okh_id} "
+        f"Generating RFQs for domain={request.domain} subject_id={subject_id} "
         f"({len(request.solutions)} solution(s), qty={request.quantity})"
     )
 
     rfqs: List[Dict[str, Any]] = []
     for sol in request.solutions:
         rfq_num = _rfq_number()
-        text = _render_rfq(
-            solution=sol,
-            okh_title=request.okh_title,
-            okh_id=request.okh_id,
-            okh_function=request.okh_function,
-            okh_version=request.okh_version,
-            quantity=request.quantity,
-            okh_manifest=request.okh_manifest,
-        )
+        if is_cooking:
+            text = _render_cooking_rfq(
+                solution=sol,
+                recipe_title=request.recipe_title or "Unknown recipe",
+                recipe_id=request.recipe_id or "unknown",
+                quantity=request.quantity,
+                recipe=request.recipe,
+            )
+        else:
+            text = _render_rfq(
+                solution=sol,
+                okh_title=request.okh_title or "Unknown design",
+                okh_id=request.okh_id or "unknown",
+                okh_function=request.okh_function,
+                okh_version=request.okh_version,
+                quantity=request.quantity,
+                okh_manifest=request.okh_manifest,
+            )
         rfqs.append(
             RFQDocument(
                 rfq_number=rfq_num,
@@ -395,7 +531,7 @@ async def generate_rfq(request: RFQGenerateRequest) -> RFQGenerateResponse:
                 rank=sol.rank,
                 quantity=request.quantity,
                 text=text,
-                okh_manifest=request.okh_manifest,
+                okh_manifest=None if is_cooking else request.okh_manifest,
             ).model_dump()
         )
 
@@ -406,6 +542,8 @@ async def generate_rfq(request: RFQGenerateRequest) -> RFQGenerateResponse:
             "total_rfqs": len(rfqs),
             "okh_id": request.okh_id,
             "okh_title": request.okh_title,
+            "recipe_id": request.recipe_id,
+            "recipe_title": request.recipe_title,
             "generated_at": datetime.now(timezone.utc).isoformat(),
         },
     )

--- a/src/core/domains/cooking/matchers.py
+++ b/src/core/domains/cooking/matchers.py
@@ -22,15 +22,24 @@ def _fuzzy_match(a: str, b: str) -> bool:
     return a_l in b_l or b_l in a_l
 
 
-def _fuzzy_overlap_count(recipe_items: list, available_items: list) -> int:
-    """Count how many recipe items have at least one fuzzy match in available_items."""
-    count = 0
-    for r in recipe_items:
-        for a in available_items:
-            if _fuzzy_match(r, a):
-                count += 1
-                break
-    return count
+def _fuzzy_split(
+    original_items: List[str], available_lower: List[str]
+) -> "tuple[List[str], List[str]]":
+    """Split `original_items` into (matched, missing) against `available_lower`.
+
+    Matching is fuzzy (see `_fuzzy_match`) and case-insensitive; the original
+    (non-lowercased) item text is preserved in the output for display, e.g. in
+    a match explanation.
+    """
+    matched: List[str] = []
+    missing: List[str] = []
+    for item in original_items:
+        item_str = item if isinstance(item, str) else str(item)
+        if any(_fuzzy_match(item_str, a) for a in available_lower):
+            matched.append(item_str)
+        else:
+            missing.append(item_str)
+    return matched, missing
 
 
 class CookingMatcher(BaseMatcher):
@@ -135,24 +144,20 @@ class CookingMatcher(BaseMatcher):
         # Fuzzy ingredient overlap — "sugar" matches "brown sugar", "chocolate chip"
         # matches "chocolate chips", etc.  Plain set intersection is too strict for
         # real-world ingredient lists where names differ by qualifiers or plurals.
-        ingredient_match_count = _fuzzy_overlap_count(
-            ingredients_lower, available_ingredients_lower
+        matched_ingredients, missing_ingredients = _fuzzy_split(
+            list(ingredients), available_ingredients_lower
         )
         ingredient_score = (
-            ingredient_match_count / len(ingredients_lower)
+            len(matched_ingredients) / len(ingredients_lower)
             if ingredients_lower
             else 0.0
         )
 
         # Fuzzy tool / appliance availability
-        tool_match_count = _fuzzy_overlap_count(
-            tools_lower, combined_available_tools_lower
+        matched_tools, missing_tools = _fuzzy_split(
+            list(tools), combined_available_tools_lower
         )
-        tool_score = tool_match_count / len(tools_lower) if tools_lower else 0.0
-
-        # Keep overlap counts for metadata (exact count for ingredient, fuzzy for tool)
-        ingredient_overlap_count = ingredient_match_count
-        tool_overlap_count = tool_match_count
+        tool_score = len(matched_tools) / len(tools_lower) if tools_lower else 0.0
 
         # When the kitchen has no capability data at all (empty appliances, tools,
         # and ingredients), fall back to a moderate base confidence rather than 0.
@@ -180,8 +185,12 @@ class CookingMatcher(BaseMatcher):
                 "step_count": len(steps),
                 "ingredient_count": len(ingredients),
                 "tool_count": len(tools),
-                "ingredient_overlap": ingredient_overlap_count,
-                "tool_overlap": tool_overlap_count,
+                "ingredient_overlap": len(matched_ingredients),
+                "tool_overlap": len(matched_tools),
+                "matched_ingredients": matched_ingredients,
+                "missing_ingredients": missing_ingredients,
+                "matched_tools": matched_tools,
+                "missing_tools": missing_tools,
                 "generation_method": "simplified_cooking_matcher",
             },
         )

--- a/tests/api/test_rfq_routes.py
+++ b/tests/api/test_rfq_routes.py
@@ -1,0 +1,128 @@
+"""Contract tests for POST /api/rfq/generate.
+
+Covers the cooking-domain branch (recipe + kitchen) added alongside the
+existing manufacturing-domain branch (OKH design + facility), and guards
+against the manufacturing default regressing when `domain` is omitted.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+
+def _get_app() -> FastAPI:
+    from src.core.main import api_v1
+
+    app = FastAPI()
+    app.mount("/v1", api_v1)
+    return app
+
+
+def _solution(**overrides) -> dict:
+    data = {
+        "facility_id": "kitchen-1",
+        "facility_name": "Test Kitchen",
+        "confidence": 0.65,
+        "score": 0.65,
+        "rank": 1,
+        "tree": {},
+        "facility": {"location": {"city": "Portland", "country": "US"}},
+    }
+    data.update(overrides)
+    return data
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_generate_rfq_cooking_domain_uses_recipe_fields():
+    app = _get_app()
+    payload = {
+        "domain": "cooking",
+        "recipe_id": "recipe-1",
+        "recipe_title": "Chocolate Chip Cookies",
+        "recipe": {
+            "ingredients": ["flour", "sugar", "chocolate chips"],
+            "equipment": ["oven", "spatula"],
+        },
+        "quantity": 3,
+        "solutions": [
+            _solution(explanation_human="✓ Test Kitchen MATCHED (confidence: 65%)")
+        ],
+    }
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as client:
+        resp = await client.post("/v1/api/rfq/generate", json=payload)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["data"]["total_rfqs"] == 1
+    assert body["data"]["recipe_id"] == "recipe-1"
+    assert body["data"]["recipe_title"] == "Chocolate Chip Cookies"
+
+    doc = body["data"]["rfqs"][0]
+    assert doc["facility_name"] == "Test Kitchen"
+    assert doc["quantity"] == 3
+    assert "Chocolate Chip Cookies" in doc["text"]
+    assert "flour, sugar, chocolate chips" in doc["text"]
+    assert "oven, spatula" in doc["text"]
+    assert "✓ Test Kitchen MATCHED (confidence: 65%)" in doc["text"]
+    # Cooking RFQs never carry an OKH manifest.
+    assert doc["okh_manifest"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_generate_rfq_manufacturing_domain_is_default():
+    app = _get_app()
+    payload = {
+        "okh_id": "okh-1",
+        "okh_title": "Widget",
+        "quantity": 1,
+        "solutions": [_solution()],
+    }
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as client:
+        resp = await client.post("/v1/api/rfq/generate", json=payload)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    doc = body["data"]["rfqs"][0]
+    assert "Widget" in doc["text"]
+    assert "Manufacturing Quotation Request" in doc["text"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_generate_rfq_cooking_domain_falls_back_without_explanation():
+    app = _get_app()
+    payload = {
+        "domain": "cooking",
+        "recipe_id": "recipe-2",
+        "recipe_title": "Snickerdoodles",
+        "quantity": 1,
+        "solutions": [_solution(confidence=0.42, rank=2)],
+    }
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as client:
+        resp = await client.post("/v1/api/rfq/generate", json=payload)
+
+    assert resp.status_code == 200, resp.text
+    doc = resp.json()["data"]["rfqs"][0]
+    assert "Match confidence: 42%" in doc["text"]
+    assert "Match rank:       #2" in doc["text"]

--- a/tests/unit/test_cooking_match_explanation.py
+++ b/tests/unit/test_cooking_match_explanation.py
@@ -1,0 +1,98 @@
+"""_build_cooking_match_explanation: turns CookingMatcher's ingredient/tool
+overlap into a MatchExplanation the frontend can render as real coverage
+("Missing N of M requirements") instead of "Coverage unknown".
+
+Regression coverage for the bug where cooking-domain match results never got
+an `explanation.requirement_matches`, because that block was gated to
+`domain == "manufacturing"` in src/core/api/routes/match.py.
+"""
+
+from __future__ import annotations
+
+from src.core.api.routes.match import _build_cooking_match_explanation
+from src.core.domains.cooking.matchers import CookingMatcher
+from src.core.models.base.base_types import (
+    NormalizedCapabilities,
+    NormalizedRequirements,
+)
+from src.core.models.match_explanation import MatchStatus
+
+
+def _supply_tree(
+    matched_ingredients, missing_ingredients, matched_tools, missing_tools
+):
+    requirements = NormalizedRequirements(
+        content={
+            "ingredients": matched_ingredients + missing_ingredients,
+            "tools": matched_tools + missing_tools,
+            "steps": [],
+        },
+        domain="cooking",
+    )
+    capabilities = NormalizedCapabilities(
+        content={
+            "available_ingredients": matched_ingredients,
+            "available_tools": matched_tools,
+            "appliances": [],
+        },
+        domain="cooking",
+    )
+    return CookingMatcher().generate_supply_tree(requirements, capabilities)
+
+
+def test_explanation_reports_matched_and_missing_requirements():
+    tree = _supply_tree(
+        matched_ingredients=["flour", "sugar"],
+        missing_ingredients=["eggs"],
+        matched_tools=["oven"],
+        missing_tools=["mixer"],
+    )
+
+    explanation = _build_cooking_match_explanation(tree, "kitchen-1", "Test Kitchen")
+
+    values_by_status = {
+        (m.requirement_value, m.status) for m in explanation.requirement_matches
+    }
+    assert (("flour", MatchStatus.MATCHED)) in values_by_status
+    assert (("sugar", MatchStatus.MATCHED)) in values_by_status
+    assert (("eggs", MatchStatus.NOT_MATCHED)) in values_by_status
+    assert (("oven", MatchStatus.MATCHED)) in values_by_status
+    assert (("mixer", MatchStatus.NOT_MATCHED)) in values_by_status
+    assert len(explanation.requirement_matches) == 5
+
+    assert explanation.overall_status == MatchStatus.NOT_MATCHED
+    assert explanation.missing_capabilities == ["eggs", "mixer"]
+    assert explanation.overall_confidence == tree.confidence_score
+
+
+def test_explanation_matched_status_when_nothing_missing():
+    tree = _supply_tree(
+        matched_ingredients=["flour"],
+        missing_ingredients=[],
+        matched_tools=["oven"],
+        missing_tools=[],
+    )
+
+    explanation = _build_cooking_match_explanation(tree, "kitchen-2", "Full Kitchen")
+
+    assert explanation.overall_status == MatchStatus.MATCHED
+    assert explanation.missing_capabilities == []
+    assert all(m.status == MatchStatus.MATCHED for m in explanation.requirement_matches)
+
+
+def test_explanation_to_dict_has_requirement_matches_frontend_expects():
+    tree = _supply_tree(
+        matched_ingredients=["flour"],
+        missing_ingredients=["eggs"],
+        matched_tools=[],
+        missing_tools=[],
+    )
+
+    explanation = _build_cooking_match_explanation(tree, "kitchen-3", "Some Kitchen")
+    as_dict = explanation.to_dict()
+
+    # Shape expected by frontend/src/features/match/nearMiss.ts requirementStats().
+    assert "requirement_matches" in as_dict
+    for match in as_dict["requirement_matches"]:
+        assert "status" in match
+        assert "requirement_value" in match

--- a/tests/unit/test_cooking_matchers.py
+++ b/tests/unit/test_cooking_matchers.py
@@ -1,0 +1,88 @@
+"""CookingMatcher.generate_supply_tree: confidence scoring and the matched/missing
+ingredient and tool breakdown used to build a per-kitchen match explanation
+(see CookingMatcher usage in src/core/api/routes/match.py).
+"""
+
+from __future__ import annotations
+
+from src.core.domains.cooking.matchers import CookingMatcher
+from src.core.models.base.base_types import (
+    NormalizedCapabilities,
+    NormalizedRequirements,
+)
+
+
+def _requirements(**content) -> NormalizedRequirements:
+    return NormalizedRequirements(content=content, domain="cooking")
+
+
+def _capabilities(**content) -> NormalizedCapabilities:
+    return NormalizedCapabilities(content=content, domain="cooking")
+
+
+def test_generate_supply_tree_reports_matched_and_missing_ingredients():
+    requirements = _requirements(
+        ingredients=["flour", "eggs", "brown sugar", "chocolate chips"],
+        tools=["oven", "spatula"],
+        steps=["Bake"],
+    )
+    capabilities = _capabilities(
+        available_ingredients=["flour", "sugar", "chocolate chips"],
+        available_tools=["spatula"],
+        appliances=["stove"],
+    )
+
+    tree = CookingMatcher().generate_supply_tree(
+        requirements,
+        capabilities,
+        kitchen_name="Test Kitchen",
+        recipe_name="Test Recipe",
+    )
+
+    # "brown sugar" fuzzily matches the kitchen's "sugar" (substring match).
+    assert sorted(tree.metadata["matched_ingredients"]) == [
+        "brown sugar",
+        "chocolate chips",
+        "flour",
+    ]
+    assert tree.metadata["missing_ingredients"] == ["eggs"]
+    assert tree.metadata["matched_tools"] == ["spatula"]
+    assert tree.metadata["missing_tools"] == ["oven"]
+    assert tree.metadata["ingredient_overlap"] == 3
+    assert tree.metadata["tool_overlap"] == 1
+
+    # ingredient_score = 3/4 = 0.75, tool_score = 1/2 = 0.5 -> 0.75*0.6 + 0.5*0.4 = 0.65
+    assert tree.confidence_score == 0.65
+
+
+def test_generate_supply_tree_fuzzy_matches_qualifiers_and_plurals():
+    requirements = _requirements(
+        ingredients=["sugar", "chocolate chip"],
+        tools=[],
+        steps=[],
+    )
+    capabilities = _capabilities(
+        available_ingredients=["brown sugar", "chocolate chips"],
+        available_tools=[],
+        appliances=[],
+    )
+
+    tree = CookingMatcher().generate_supply_tree(requirements, capabilities)
+
+    assert tree.metadata["matched_ingredients"] == ["sugar", "chocolate chip"]
+    assert tree.metadata["missing_ingredients"] == []
+
+
+def test_generate_supply_tree_empty_kitchen_inventory_uses_moderate_default():
+    requirements = _requirements(ingredients=["flour"], tools=["oven"], steps=[])
+    capabilities = _capabilities(
+        available_ingredients=[], available_tools=[], appliances=[]
+    )
+
+    tree = CookingMatcher().generate_supply_tree(requirements, capabilities)
+
+    assert tree.confidence_score == 0.5
+    # Kitchen data is unknown, not necessarily missing every item -- the
+    # overlap fields are still reported, just as all-missing.
+    assert tree.metadata["missing_ingredients"] == ["flour"]
+    assert tree.metadata["missing_tools"] == ["oven"]


### PR DESCRIPTION
## Summary

Two follow-ups from the live `cooking-test` deployment:

1. **"Coverage unknown · confidence 30%" on every kitchen result** — cooking matches never got a structured `explanation.requirement_matches`, because that block was gated to `domain == "manufacturing"` in `POST /api/match`. `CookingMatcher` already computed ingredient/tool overlap; it now also reports *which* ingredients/tools matched vs. were missing, and the match route turns that into a real `MatchExplanation`. Kitchens now show e.g. "Missing 2 of 13 requirements" instead of an unexplained percentage.
2. **No way to generate an RFQ from a cooking match**, unlike the manufacturing flow. `CookingMatchView` gets a "Contact selected kitchens →" action next to the existing selection controls, and `POST /api/rfq/generate` accepts a `domain` field: `domain="cooking"` renders a recipe-flavoured RFQ (ingredients, equipment, and the match explanation from fix #1), while the existing manufacturing path is untouched.

## Test plan

- [x] `uv run pytest tests/unit/test_cooking_matchers.py tests/unit/test_cooking_match_explanation.py tests/api/test_rfq_routes.py -v`
- [x] `uv run pytest tests/unit tests/api` (1181 passed)
- [x] `npx vitest run` in `frontend/` (348 passed, including new `CookingMatchView` and `RfqView` cooking-domain tests)
- [x] `npx tsc --noEmit` in `frontend/`
- [x] `make ready` (all 11 gates pass)

Made with [Cursor](https://cursor.com)