### PR TITLE
fix: don't hide all cooking matches behind default near-miss tolerance

### DIFF
--- a/frontend/src/features/match/CookingMatchView.test.tsx
+++ b/frontend/src/features/match/CookingMatchView.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
@@ -110,5 +110,55 @@ describe("CookingMatchView", () => {
     expect(state.recipeTitle).toBe("Sourdough Bread");
     expect(state.solutions).toHaveLength(1);
     expect(state.solutions[0].facility_id).toBe("kitchen-1");
+  });
+
+  it("surfaces the tolerance slider instead of a blank empty state when every kitchen is hidden by default tolerance", async () => {
+    // 5 requirements, 3 missing: exceeds the default tolerance of 1, so the
+    // one and only solution is hidden by `withinTolerance` — but the API DID
+    // return a match, so this must not render the "no facilities returned"
+    // empty state used when there are truly zero solutions.
+    server.use(
+      http.post("*/v1/api/match", () =>
+        HttpResponse.json({
+          data: {
+            solutions: [
+              {
+                facility_id: "kitchen-1",
+                facility_name: "Test Kitchen",
+                confidence: 0.4,
+                score: 0.4,
+                rank: 1,
+                match_type: "cooking",
+                explanation: {
+                  requirement_matches: [
+                    { requirement_value: "flour", status: "matched" },
+                    { requirement_value: "water", status: "matched" },
+                    { requirement_value: "salt", status: "not_matched" },
+                    { requirement_value: "starter", status: "not_matched" },
+                    { requirement_value: "oven", status: "not_matched" },
+                  ],
+                },
+              },
+            ],
+            total_solutions: 1,
+          },
+        }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderView("recipe-1");
+
+    await user.click(screen.getByLabelText("Test Kitchen"));
+    await user.click(screen.getByRole("button", { name: "⚡ Run Match" }));
+
+    expect(await screen.findByLabelText(/Allow kitchens missing up to/)).toBeInTheDocument();
+    expect(screen.getByText(/1 kitchen is hidden at this setting/)).toBeInTheDocument();
+    expect(screen.queryByText("No matches found")).not.toBeInTheDocument();
+
+    const slider = screen.getByLabelText(/Allow kitchens missing up to/) as HTMLInputElement;
+    fireEvent.change(slider, { target: { value: "3" } });
+
+    expect(await screen.findByLabelText("Select Test Kitchen")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/match/CookingMatchView.tsx
+++ b/frontend/src/features/match/CookingMatchView.tsx
@@ -168,9 +168,10 @@ export function CookingMatchView({ initialRecipeId }: Props = {}) {
         />
       )}
 
-      {view &&
+      {rawView &&
+        view &&
         !mutation.isPending &&
-        (view.solutions.length === 0 ? (
+        (rawView.solutions.length === 0 ? (
           <EmptyState
             icon="🔍"
             title="No matches found"
@@ -223,68 +224,82 @@ export function CookingMatchView({ initialRecipeId }: Props = {}) {
               </div>
             )}
 
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <p className="text-xs text-muted-foreground">
-                {view.totalSolutions} solution{view.totalSolutions !== 1 ? "s" : ""}
-                {selectedSolutionKeys.length > 0 ? ` · ${selectedSolutionKeys.length} selected` : ""}
-              </p>
-              <div className="flex flex-wrap items-center gap-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={view.solutions.length === 0}
-                  onClick={() =>
-                    setSelectedSolutionKeys(view.solutions.map((s, i) => solutionSelectionKey(s, i)))
-                  }
-                >
-                  Select all
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={selectedSolutionKeys.length === 0}
-                  onClick={() => setSelectedSolutionKeys([])}
-                >
-                  Clear selection
-                </Button>
-                <Button
-                  size="sm"
-                  disabled={selectedSolutionKeys.length === 0 || !selectedRecipe}
-                  onClick={() => {
-                    const selectedSolutions = view.solutions.filter((s, i) =>
-                      selectedSolutionKeys.includes(solutionSelectionKey(s, i)),
-                    );
-                    const state: CookingRfqNavigationState = {
-                      domain: "cooking",
-                      recipeId: selectedRecipe!.id,
-                      recipeTitle: selectedRecipe!.name,
-                      recipe: selectedRecipe,
-                      solutions: toRfqSolutions(selectedSolutions),
-                    };
-                    navigate("/rfq", { state });
-                  }}
-                >
-                  Contact selected kitchens →
-                </Button>
-              </div>
-            </div>
-            {view.solutions.map((s, i) => {
-              const key = solutionSelectionKey(s, i);
-              return (
-                <MatchResultCard
-                  key={key}
-                  solution={s}
-                  solutionId={view.solutionId}
-                  selectionKey={key}
-                  selected={selectedSolutionKeys.includes(key)}
-                  onToggle={() =>
-                    setSelectedSolutionKeys((prev) =>
-                      prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key],
-                    )
-                  }
-                />
-              );
-            })}
+            {view.solutions.length === 0 ? (
+              <EmptyState
+                icon="🔍"
+                title="No matches within tolerance"
+                description="Every kitchen is missing more than the tolerance above allows. Increase it to see them."
+              />
+            ) : (
+              <>
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <p className="text-xs text-muted-foreground">
+                    {view.totalSolutions} solution{view.totalSolutions !== 1 ? "s" : ""}
+                    {selectedSolutionKeys.length > 0
+                      ? ` · ${selectedSolutionKeys.length} selected`
+                      : ""}
+                  </p>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={view.solutions.length === 0}
+                      onClick={() =>
+                        setSelectedSolutionKeys(
+                          view.solutions.map((s, i) => solutionSelectionKey(s, i)),
+                        )
+                      }
+                    >
+                      Select all
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={selectedSolutionKeys.length === 0}
+                      onClick={() => setSelectedSolutionKeys([])}
+                    >
+                      Clear selection
+                    </Button>
+                    <Button
+                      size="sm"
+                      disabled={selectedSolutionKeys.length === 0 || !selectedRecipe}
+                      onClick={() => {
+                        const selectedSolutions = view.solutions.filter((s, i) =>
+                          selectedSolutionKeys.includes(solutionSelectionKey(s, i)),
+                        );
+                        const state: CookingRfqNavigationState = {
+                          domain: "cooking",
+                          recipeId: selectedRecipe!.id,
+                          recipeTitle: selectedRecipe!.name,
+                          recipe: selectedRecipe,
+                          solutions: toRfqSolutions(selectedSolutions),
+                        };
+                        navigate("/rfq", { state });
+                      }}
+                    >
+                      Contact selected kitchens →
+                    </Button>
+                  </div>
+                </div>
+                {view.solutions.map((s, i) => {
+                  const key = solutionSelectionKey(s, i);
+                  return (
+                    <MatchResultCard
+                      key={key}
+                      solution={s}
+                      solutionId={view.solutionId}
+                      selectionKey={key}
+                      selected={selectedSolutionKeys.includes(key)}
+                      onToggle={() =>
+                        setSelectedSolutionKeys((prev) =>
+                          prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key],
+                        )
+                      }
+                    />
+                  );
+                })}
+              </>
+            )}
           </div>
         ))}
     </div>


### PR DESCRIPTION
## Summary

Now that cooking-domain matches carry a real requirement-coverage explanation (#354), the near-miss tolerance filter in `CookingMatchView` actually does something — and recipes with several ingredients/tools routinely exceed the default tolerance of 1 missing requirement. Every kitchen was silently filtered out, showing a blank **"No matches found"** with no way to reveal them, because the tolerance slider was only rendered *inside* the already-filtered results branch.

- Split the empty-state check: **"No matches found"** now only fires when the API returned zero solutions.
- When solutions exist but are all hidden by tolerance, the slider (and hidden-count message) render with a **"No matches within tolerance"** message instead, so raising the slider reveals them.

Same underlying pattern exists in `MatchView.tsx` (manufacturing) — it wasn't hit there because it depends on a facility having enough missing requirements to exceed tolerance, but it's the identical bug. Flagging but not touching it here to keep this change scoped to the reported issue; happy to follow up if wanted.

## Test plan
- [x] New regression test in `CookingMatchView.test.tsx` reproduces the bug (fails on `main`, passes after the fix)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npx vitest run src/features/match` (74/74 passing)
- [x] `npm run build`

Made with [Cursor](https://cursor.com)