### PR TITLE
test: Slice 0 characterization baseline for the frontend revamp integration

### DIFF
--- a/frontend/e2e/baseline.manifest.json
+++ b/frontend/e2e/baseline.manifest.json
@@ -1,0 +1,19 @@
+{
+  "e2e/a11y.ts": "9fe0b3d646f8022b64e7fdaaf59867be22eb9d218f0276a02ea1768cb326184f",
+  "e2e/a11y-journeys.spec.ts": "e5ee9f1b979523ecff5bf6327b6ce5802add7b029ecd92c3be6e30e66450eb73",
+  "e2e/cooking-domain.spec.ts": "5ffbd5e19c92933c0460b2660610d1f6b85a77ab65dc28f8c3902c465207604d",
+  "e2e/create.spec.ts": "90e109770b0878937e6a549ccb86ea4d87617b75a21b5461933c74a5ac9e3c5c",
+  "e2e/dashboard.spec.ts": "c3eb78ebb0401a5eb12922e40a9afc18930d48f565f592893f68cedd29037990",
+  "e2e/generate.spec.ts": "2584f50d0b1a4be844dff2b9cb5535f49a3e8b8ccf9c1251686dc4783d320c01",
+  "e2e/match.spec.ts": "3edaccaaaa3729c048e40d27ea36aeda3c122d0d802fb658c82fbc16ab242a4a",
+  "e2e/near-miss-tolerance.spec.ts": "b784da85d0161191d20b846b28f5928bb7b643301701c0837e81dc59f5f6a36f",
+  "e2e/network.spec.ts": "94464d4b0297de606e722952db3ca701732c61a11d5039758284ffd26b515848",
+  "e2e/okh-catalog.spec.ts": "86a53af010ee1cf5b34b50ba884f70e104a569798739d0e4ba5d7b4c98e31d69",
+  "e2e/okh-detail.spec.ts": "6d26add29a0d87e02f419a4fbb21eab6c00a44003fbe060cc78cd8d72a4620b3",
+  "e2e/okw-detail.spec.ts": "086cb7e4511be20356d24d5245e2871a9ed41ed4becbe5b32cc3c1b23b978056",
+  "e2e/packages.spec.ts": "9135c1c15d4f64ceb00f10c6b9725b9804c858b3a794631e5597c961a6c93601",
+  "e2e/screenshots.spec.ts": "d625811c7411996a29fc3eba208328723139e2fdfb7e912f6af816a7309f6426",
+  "e2e/settings.spec.ts": "b5cd88fced8791951eba65274907fa14584e5911e504be93986052d045518b68",
+  "e2e/smoke.spec.ts": "3d3685346ecf8b171f169cd66fe2dd8d6060f18a96e04adc811619f723614e5e",
+  "e2e/visualization.spec.ts": "f769e05da9faa1d18e21e076f7601e077dbfed06bb8946892b4b7f6f2143cfb8"
+}

--- a/frontend/e2e/cooking-domain.spec.ts
+++ b/frontend/e2e/cooking-domain.spec.ts
@@ -1,0 +1,160 @@
+import { test, expect } from "./mock-api";
+import { expectNoA11yViolations } from "./a11y";
+
+/**
+ * Characterization baseline for the cooking domain (Slice 0 of the frontend
+ * revamp integration — see notes/frontend-revamp-integration-plan.md).
+ *
+ * The contributor's fork branched before the cooking domain landed, and its
+ * Next.js `app/` shell contains no recipe or kitchen route. Git will merge
+ * `DomainPanel.tsx` and `useDomainPreference.ts` cleanly regardless: the files
+ * arrive, the wiring does not. Nothing in the existing suite would notice.
+ *
+ * These are black-box assertions against user-visible behaviour, so they must
+ * survive the Vite -> Next migration byte-for-byte. If a slice needs to edit
+ * this file, that is a deliberate behaviour change and belongs in its own PR
+ * with a stated reason.
+ */
+
+/** The domain is a browser-local preference; seed it before first paint. */
+async function useCookingDomain(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem("ohm-domain", "cooking");
+  });
+}
+
+test("cooking domain browses recipes at /okh", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "expects mocked recipe catalog");
+  await useCookingDomain(page);
+  await page.goto("/okh");
+
+  await expect(page.getByRole("heading", { name: "Recipes", level: 1 })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Sourdough Loaf" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Miso Soup" })).toBeVisible();
+
+  // Counts are the card's only summary line — a silent shape change in the
+  // Recipe type would surface here rather than as an empty card.
+  await expect(page.getByText("4 ingredients · 4 steps")).toBeVisible();
+  await expect(page.getByText("3 ingredients · 2 steps")).toBeVisible();
+
+  await expectNoA11yViolations(page);
+});
+
+test("cooking domain browses kitchens at /facilities", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "expects mocked kitchen catalog");
+  await useCookingDomain(page);
+  await page.goto("/facilities");
+
+  await expect(page.getByRole("heading", { name: "Kitchens", level: 1 })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Community Kitchen" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Pop-Up Canteen" })).toBeVisible();
+
+  await expectNoA11yViolations(page);
+});
+
+test("a recipe card opens its detail page", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "expects mocked recipe catalog");
+  await useCookingDomain(page);
+  await page.goto("/okh");
+
+  await page.getByRole("link", { name: "Sourdough Loaf" }).click();
+
+  await expect(page).toHaveURL(/\/okh\/recipe-1$/);
+  await expect(page.getByRole("heading", { name: "Sourdough Loaf", level: 1 })).toBeVisible();
+
+  // The three panels are the whole point of the detail page.
+  await expect(page.getByRole("heading", { name: "Ingredients" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Instructions" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Equipment" })).toBeVisible();
+  await expect(page.getByText("starter")).toBeVisible();
+  await expect(page.getByText("Bulk ferment")).toBeVisible();
+  await expect(page.getByText("dutch oven")).toBeVisible();
+
+  // Breadcrumb back to the list.
+  await expect(page.getByRole("link", { name: "Recipes" }).first()).toBeVisible();
+
+  await expectNoA11yViolations(page);
+});
+
+test("Run Match on a recipe card preselects that recipe", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "expects mocked recipe catalog");
+  await useCookingDomain(page);
+  await page.goto("/okh");
+
+  await page.getByRole("button", { name: "Run Match ⚡" }).first().click();
+
+  await expect(page).toHaveURL(/\/match\?recipe_id=recipe-1$/);
+  await expect(page.getByRole("heading", { name: "Match a Recipe", level: 1 })).toBeVisible();
+});
+
+test("Run Match on a recipe detail page preselects that recipe", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "expects mocked recipe catalog");
+  await useCookingDomain(page);
+  await page.goto("/okh/recipe-2");
+
+  await page.getByRole("button", { name: "⚡ Run Match" }).click();
+
+  await expect(page).toHaveURL(/\/match\?recipe_id=recipe-2$/);
+  await expect(page.getByRole("heading", { name: "Match a Recipe", level: 1 })).toBeVisible();
+});
+
+test("cooking match guards on recipe and kitchen selection", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "expects mocked catalogs");
+  await useCookingDomain(page);
+
+  // No recipe in the URL: the view asks for one before it will run.
+  await page.goto("/match");
+  await expect(page.getByRole("heading", { name: "Match a Recipe", level: 1 })).toBeVisible();
+  await expect(
+    page.getByText("Search and select a recipe above before running a match."),
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "⚡ Run Match" })).toBeDisabled();
+
+  // Recipe preselected but no kitchens chosen: still guarded, different reason.
+  await page.goto("/match?recipe_id=recipe-1");
+  await expect(
+    page.getByText("Select at least one kitchen below before running a match."),
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "⚡ Run Match" })).toBeDisabled();
+
+  await expectNoA11yViolations(page);
+});
+
+test("the domain toggle reshapes primary nav and persists across reloads", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "browser-local preference");
+  const nav = page.getByRole("navigation", { name: "Primary navigation" });
+
+  // A fresh browser is manufacturing, and the server default agrees.
+  await page.goto("/settings/domain");
+  await expect(nav.getByRole("link", { name: "Designs" })).toBeVisible();
+  await expect(nav.getByRole("link", { name: "Facilities" })).toBeVisible();
+  await expect(nav.getByRole("link", { name: "Packages" })).toBeVisible();
+  await expect(nav.getByRole("link", { name: "Match" })).toBeVisible();
+
+  await page.getByRole("radio", { name: /Cooking/ }).check();
+
+  // Cooking renames two entries and drops the other two entirely.
+  await expect(nav.getByRole("link", { name: "Recipes" })).toBeVisible();
+  await expect(nav.getByRole("link", { name: "Kitchens" })).toBeVisible();
+  await expect(nav.getByRole("link", { name: "Packages" })).toHaveCount(0);
+  await expect(nav.getByRole("link", { name: "Match" })).toHaveCount(0);
+
+  // localStorage owns the choice once it exists, so a reload keeps it.
+  await page.reload();
+  await expect(nav.getByRole("link", { name: "Recipes" })).toBeVisible();
+  await expect(page.getByRole("radio", { name: /Cooking/ })).toBeChecked();
+
+  await expectNoA11yViolations(page);
+});
+
+test("a stored preference outranks the server default", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "browser-local preference");
+  // The mocked /utility/domains reports default_domain "manufacturing"; a
+  // browser that already chose cooking must not be reset by it.
+  await useCookingDomain(page);
+  await page.goto("/okh");
+
+  await expect(page.getByRole("heading", { name: "Recipes", level: 1 })).toBeVisible();
+});

--- a/frontend/e2e/near-miss-tolerance.spec.ts
+++ b/frontend/e2e/near-miss-tolerance.spec.ts
@@ -1,0 +1,179 @@
+import { test, expect } from "./mock-api";
+
+/**
+ * Characterization baseline for near-miss tolerance (Slice 0 of the frontend
+ * revamp integration — see notes/frontend-revamp-integration-plan.md).
+ *
+ * Regression cover for #355 (cooking) and #356 (manufacturing): the tolerance
+ * filter can hide every result, and the slider that reveals them was rendered
+ * only inside the already-filtered branch — so once everything was filtered
+ * out the user saw a bare "No matches found" with no way back. The fix splits
+ * the two empty states: "No matches found" fires only when the API returned
+ * nothing; when results exist but are all hidden, the slider renders alongside
+ * "No matches within tolerance".
+ *
+ * This behaviour already has unit cover (MatchView.nearMissTolerance.test.tsx),
+ * but those tests mount through MemoryRouter — the exact category the fork's
+ * playbook flags as needing a harness rewrite under Next's App Router. These
+ * assertions are black-box, so they survive that migration untouched and keep
+ * proving the fix while the unit tests are being re-hosted.
+ */
+
+/** Requirement matches where `missing` of `total` are unmet, each counted once. */
+function requirements(total: number, missing: number) {
+  return Array.from({ length: total }, (_, i) => ({
+    requirement_value: `requirement-${i}`,
+    status: i < total - missing ? "matched" : "unmatched",
+  }));
+}
+
+/**
+ * Five requirements, so the ceiling is 3 (r-2) and the default tolerance is 1.
+ * Both facilities miss more than 1, so both start hidden — the state that used
+ * to render a dead end.
+ */
+function hiddenSolutionsResponse(nameA: string, nameB: string) {
+  return {
+    data: {
+      solutions: [
+        {
+          facility_name: nameA,
+          facility_id: "okw-1",
+          confidence: 0.6,
+          score: 0.6,
+          rank: 1,
+          explanation_human: "Partial match.",
+          explanation: { requirement_matches: requirements(5, 2) },
+          tree: { id: "tree-1" },
+        },
+        {
+          facility_name: nameB,
+          facility_id: "okw-2",
+          confidence: 0.4,
+          score: 0.4,
+          rank: 2,
+          explanation_human: "Partial match.",
+          explanation: { requirement_matches: requirements(5, 3) },
+          tree: { id: "tree-2" },
+        },
+      ],
+      coverage_gaps: [],
+      human_summary: { executive: "2 candidate solutions found." },
+      total_solutions: 2,
+      solution_id: "sol-1",
+    },
+  };
+}
+
+const emptyResponse = {
+  data: {
+    solutions: [],
+    coverage_gaps: [],
+    human_summary: { executive: "No solutions found." },
+    total_solutions: 0,
+    solution_id: "sol-empty",
+  },
+};
+
+async function runManufacturingMatch(page: import("@playwright/test").Page) {
+  await page.goto("/match");
+  await page.getByLabel("Search designs").fill("Ventilator");
+  await page.getByRole("option", { name: /Open Ventilator/i }).click();
+  await page.getByLabel("Laser Fab Lab").check();
+  await page.getByRole("button", { name: /run match/i }).click();
+}
+
+async function runCookingMatch(page: import("@playwright/test").Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem("ohm-domain", "cooking");
+  });
+  await page.goto("/match?recipe_id=recipe-1");
+  await page.getByRole("checkbox", { name: "Community Kitchen" }).check();
+  await page.getByRole("button", { name: "⚡ Run Match" }).click();
+}
+
+test("manufacturing: results hidden by tolerance keep the slider reachable (#356)", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "asserts fixture data");
+  await page.route("**/v1/api/match", (route) =>
+    route.fulfill({ json: hiddenSolutionsResponse("Partial Works", "Barely There") }),
+  );
+
+  await runManufacturingMatch(page);
+
+  // The regression: this must NOT be the "API returned nothing" empty state.
+  await expect(page.getByText("No matches within tolerance")).toBeVisible();
+  await expect(page.getByText("No matches found")).toHaveCount(0);
+
+  // The escape hatch renders even though zero results are showing.
+  const slider = page.locator("#near-miss-tolerance");
+  await expect(slider).toBeVisible();
+  await expect(page.getByText("Allow facilities missing up to 1 requirement")).toBeVisible();
+  await expect(page.getByText(/2 facilities are hidden at this setting/)).toBeVisible();
+  await expect(page.getByText(/This design has 5 requirements/)).toBeVisible();
+
+  // Raising tolerance to 2 reveals the closer of the two, and only that one.
+  await slider.fill("2");
+  await expect(page.getByRole("heading", { name: "Partial Works" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Barely There" })).toHaveCount(0);
+  await expect(page.getByText(/1 facility is hidden at this setting/)).toBeVisible();
+
+  // At the ceiling both are visible and nothing is hidden.
+  await slider.fill("3");
+  await expect(page.getByRole("heading", { name: "Partial Works" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Barely There" })).toBeVisible();
+  await expect(page.getByText(/hidden at this setting/)).toHaveCount(0);
+});
+
+test("manufacturing: an empty API result still reads as no matches found", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "asserts fixture data");
+  await page.route("**/v1/api/match", (route) => route.fulfill({ json: emptyResponse }));
+
+  await runManufacturingMatch(page);
+
+  // The other side of the split: zero solutions is a genuinely empty result,
+  // and the tolerance control has nothing to offer.
+  await expect(page.getByText("No matches found")).toBeVisible();
+  await expect(page.getByText("No matches within tolerance")).toHaveCount(0);
+  await expect(page.locator("#near-miss-tolerance")).toHaveCount(0);
+});
+
+test("cooking: results hidden by tolerance keep the slider reachable (#355)", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "asserts fixture data");
+  await page.route("**/v1/api/match", (route) =>
+    route.fulfill({ json: hiddenSolutionsResponse("Slow Kitchen", "Sparse Kitchen") }),
+  );
+
+  await runCookingMatch(page);
+
+  await expect(page.getByText("No matches within tolerance")).toBeVisible();
+  await expect(page.getByText("No matches found")).toHaveCount(0);
+
+  const slider = page.locator("#near-miss-tolerance");
+  await expect(slider).toBeVisible();
+  await expect(page.getByText("Allow kitchens missing up to 1 requirement")).toBeVisible();
+  await expect(page.getByText(/2 kitchens are hidden at this setting/)).toBeVisible();
+  await expect(page.getByText(/This recipe has 5 requirements/)).toBeVisible();
+
+  await slider.fill("3");
+  await expect(page.getByRole("heading", { name: "Slow Kitchen" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Sparse Kitchen" })).toBeVisible();
+});
+
+test("cooking: an empty API result still reads as no matches found", async ({
+  page,
+}, testInfo) => {
+  test.skip(testInfo.project.name === "real-api", "asserts fixture data");
+  await page.route("**/v1/api/match", (route) => route.fulfill({ json: emptyResponse }));
+
+  await runCookingMatch(page);
+
+  await expect(page.getByText("No matches found")).toBeVisible();
+  await expect(page.getByText("No matches within tolerance")).toHaveCount(0);
+  await expect(page.locator("#near-miss-tolerance")).toHaveCount(0);
+});

--- a/frontend/harness/proxy-contract.mjs
+++ b/frontend/harness/proxy-contract.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+/**
+ * `/v1` proxy contract test (Slice 0 of the frontend revamp integration — see
+ * notes/frontend-revamp-integration-plan.md).
+ *
+ * The incoming fork deletes deploy/nginx.conf.template and reimplements every
+ * guarantee it held as Next.js route handlers (app/v1/[...path]/route.ts,
+ * app/healthz/route.ts, proxy.ts). Same intended contract, entirely different
+ * implementation, on the surface that serves production.
+ *
+ * Nothing in the unit or mocked-e2e suites exercises that surface: they run
+ * against a dev server with the API stubbed in the browser, so the proxy is
+ * never in the path. This script is the missing gate. It builds the real image,
+ * runs it against a stub upstream that echoes what it received, and asserts the
+ * behaviours nginx guarantees today.
+ *
+ * It is deliberately implementation-agnostic — it speaks only HTTP — so the
+ * same assertions run unchanged against the Next.js image in Slice 3. That is
+ * the point: a contract you can only check on one implementation is not a
+ * contract.
+ *
+ *   node harness/proxy-contract.mjs              build the image, then test
+ *   node harness/proxy-contract.mjs --no-build   reuse the existing tag
+ *   BASE_URL=http://host:port node harness/proxy-contract.mjs --external
+ *                                               test an already-running origin
+ *
+ * Not part of `frontend-ready`: it needs a Docker daemon and takes minutes.
+ * Run it before merging anything that touches the serving layer.
+ */
+import { spawnSync } from "node:child_process";
+import { createServer } from "node:http";
+
+const IMAGE = "ohm-frontend:contract-test";
+const CONTAINER = "ohm-frontend-contract-test";
+const UPSTREAM_PORT = 8899;
+const HOST_PORT = 8899 + 1;
+
+const args = new Set(process.argv.slice(2));
+const external = args.has("--external");
+const baseUrl = external ? process.env.BASE_URL : `http://127.0.0.1:${HOST_PORT}`;
+
+if (external && !baseUrl) {
+  console.error("--external requires BASE_URL");
+  process.exit(2);
+}
+
+/* ---------------------------------------------------------------- assertions */
+
+const results = [];
+function check(name, fn) {
+  results.push({ name, fn });
+}
+function assert(cond, detail) {
+  if (!cond) throw new Error(detail);
+}
+
+/* ------------------------------------------------------------- stub upstream */
+
+/** Records what the proxy actually forwarded, so headers can be asserted. */
+const received = [];
+
+function startUpstream() {
+  const server = createServer((req, res) => {
+    const chunks = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => {
+      received.push({
+        method: req.method,
+        url: req.url,
+        headers: req.headers,
+        body: Buffer.concat(chunks).toString("utf-8"),
+      });
+      // A path the tests use to prove upstream status codes pass through.
+      if (req.url.startsWith("/v1/status/")) {
+        const code = Number(req.url.split("/v1/status/")[1].split("?")[0]);
+        res.writeHead(code, { "content-type": "text/plain", "x-upstream-marker": "yes" });
+        res.end(`status ${code}\n`);
+        return;
+      }
+      res.writeHead(200, { "content-type": "application/json", "x-upstream-marker": "yes" });
+      res.end(JSON.stringify({ saw: { method: req.method, url: req.url } }));
+    });
+  });
+  return new Promise((resolve) => server.listen(UPSTREAM_PORT, () => resolve(server)));
+}
+
+/* ----------------------------------------------------------------- container */
+
+function sh(cmd, cmdArgs, opts = {}) {
+  const r = spawnSync(cmd, cmdArgs, { encoding: "utf-8", ...opts });
+  return { code: r.status, out: (r.stdout || "") + (r.stderr || "") };
+}
+
+function buildImage() {
+  process.stdout.write(`→ docker build ${IMAGE} (this takes a few minutes)\n`);
+  const r = spawnSync("docker", ["build", "-t", IMAGE, "."], { stdio: "inherit" });
+  if (r.status !== 0) {
+    console.error("✗ docker build failed");
+    process.exit(1);
+  }
+}
+
+function startContainer() {
+  sh("docker", ["rm", "-f", CONTAINER]);
+  // host.docker.internal resolves the host from inside the container on Docker
+  // Desktop; --add-host keeps it working on plain Linux daemons too.
+  const r = sh("docker", [
+    "run", "-d", "--name", CONTAINER,
+    "--add-host", "host.docker.internal:host-gateway",
+    "-e", `API_UPSTREAM_URL=http://host.docker.internal:${UPSTREAM_PORT}`,
+    "-e", "PORT=8080",
+    "-p", `${HOST_PORT}:8080`,
+    IMAGE,
+  ]);
+  if (r.code !== 0) {
+    console.error(`✗ docker run failed:\n${r.out}`);
+    process.exit(1);
+  }
+}
+
+async function waitForReady(url, timeoutMs = 60_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${url}/healthz`);
+      if (res.ok) return;
+    } catch {
+      /* not up yet */
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  const logs = sh("docker", ["logs", CONTAINER]);
+  throw new Error(`container never became ready.\n${logs.out}`);
+}
+
+/* -------------------------------------------------------------- the contract */
+
+check("GET /healthz answers 200 'ok' without touching the backend", async () => {
+  const before = received.length;
+  const res = await fetch(`${baseUrl}/healthz`);
+  assert(res.status === 200, `expected 200, got ${res.status}`);
+  assert((await res.text()).trim() === "ok", "body should be 'ok'");
+  assert(received.length === before, "healthz must not reach the upstream");
+});
+
+check("/v1 prefix is preserved when proxying", async () => {
+  const before = received.length;
+  await fetch(`${baseUrl}/v1/api/okh`);
+  assert(received.length > before, "request never reached the upstream");
+  const last = received[received.length - 1];
+  assert(last.url === "/v1/api/okh", `upstream saw ${last.url}, expected /v1/api/okh`);
+});
+
+check("query strings survive the proxy", async () => {
+  await fetch(`${baseUrl}/v1/api/okh?page=2&page_size=100`);
+  const last = received[received.length - 1];
+  assert(
+    last.url === "/v1/api/okh?page=2&page_size=100",
+    `upstream saw ${last.url}`,
+  );
+});
+
+check("forwarding headers are set", async () => {
+  await fetch(`${baseUrl}/v1/api/okh`);
+  const h = received[received.length - 1].headers;
+  assert(h["x-real-ip"], "X-Real-IP missing");
+  assert(h["x-forwarded-for"], "X-Forwarded-For missing");
+  assert(h["x-forwarded-proto"] === "http", `X-Forwarded-Proto was ${h["x-forwarded-proto"]}`);
+});
+
+check("method and body are forwarded intact", async () => {
+  await fetch(`${baseUrl}/v1/api/match`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ okh_id: "design-1" }),
+  });
+  const last = received[received.length - 1];
+  assert(last.method === "POST", `method was ${last.method}`);
+  assert(last.body === '{"okh_id":"design-1"}', `body was ${last.body}`);
+});
+
+check("upstream status codes pass through unchanged", async () => {
+  for (const code of [404, 422, 500]) {
+    const res = await fetch(`${baseUrl}/v1/status/${code}`);
+    assert(res.status === code, `expected ${code}, got ${res.status}`);
+    assert(
+      res.headers.get("x-upstream-marker") === "yes",
+      `response for ${code} did not come from the upstream`,
+    );
+  }
+});
+
+check("a missing /docs page 404s rather than serving the SPA shell", async () => {
+  // The regression this exists for: /docs/* once fell through to index.html, so
+  // every docs URL returned 200 with the app shell and an undeployed docs site
+  // looked healthy to browsers and monitors alike.
+  const res = await fetch(`${baseUrl}/docs/definitely-not-a-page`);
+  assert(res.status === 404, `expected 404, got ${res.status}`);
+});
+
+check("bare /docs redirects to /docs/", async () => {
+  const res = await fetch(`${baseUrl}/docs`, { redirect: "manual" });
+  assert(res.status === 301, `expected 301, got ${res.status}`);
+  const loc = res.headers.get("location");
+  assert(loc && loc.endsWith("/docs/"), `Location was ${loc}`);
+});
+
+check("unknown app routes fall through to the SPA entry point", async () => {
+  const res = await fetch(`${baseUrl}/match`);
+  assert(res.status === 200, `expected 200, got ${res.status}`);
+  assert(
+    (res.headers.get("content-type") || "").includes("text/html"),
+    "expected an HTML document",
+  );
+});
+
+check("build-info.json identifies the image", async () => {
+  const res = await fetch(`${baseUrl}/build-info.json`);
+  assert(res.status === 200, `expected 200, got ${res.status}`);
+  const body = await res.json();
+  assert("build" in body, `expected a "build" key, got ${JSON.stringify(body)}`);
+});
+
+/* ---------------------------------------------------------------------- main */
+
+async function main() {
+  const upstream = await startUpstream();
+  let started = false;
+  try {
+    if (!external) {
+      if (!args.has("--no-build")) buildImage();
+      startContainer();
+      started = true;
+      await waitForReady(baseUrl);
+    }
+
+    let failed = 0;
+    for (const { name, fn } of results) {
+      try {
+        await fn();
+        process.stdout.write(`  ✓ ${name}\n`);
+      } catch (err) {
+        failed += 1;
+        process.stdout.write(`  ✗ ${name}\n      ${err.message}\n`);
+      }
+    }
+    process.stdout.write(
+      failed === 0
+        ? `\n✓ proxy contract: ${results.length} checks passed\n`
+        : `\n✗ proxy contract: ${failed} of ${results.length} checks failed\n`,
+    );
+    process.exitCode = failed === 0 ? 0 : 1;
+  } finally {
+    upstream.close();
+    if (started) sh("docker", ["rm", "-f", CONTAINER]);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  sh("docker", ["rm", "-f", CONTAINER]);
+  process.exit(1);
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,9 @@
     "e2e": "playwright test --project=mocked",
     "e2e:real": "playwright test --project=real-api",
     "gen:api": "node harness/gen-api-types.mjs",
-    "frontend-ready": "node harness/run-gate.mjs"
+    "frontend-ready": "node harness/run-gate.mjs",
+    "contract:proxy": "node harness/proxy-contract.mjs",
+    "baseline:bless": "BLESS_BASELINE=1 vitest run src/test/baselineFreeze.test.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",

--- a/frontend/src/features/match/RecipePicker.tsx
+++ b/frontend/src/features/match/RecipePicker.tsx
@@ -108,7 +108,19 @@ export function RecipePicker({
                     <span className="text-sm font-medium text-foreground break-words">
                       {r.name}
                     </span>
-                    <span className="mt-0.5 text-xs text-muted-foreground">
+                    {/*
+                      muted-foreground is tuned for the default surface; on the
+                      selected row's indigo background it falls to 3.84:1,
+                      under the 4.5:1 AA threshold. Darken it when active.
+                      (Same fix as DesignPicker's selected option.)
+                    */}
+                    <span
+                      className={
+                        active
+                          ? "mt-0.5 text-xs text-indigo-900 dark:text-indigo-200"
+                          : "mt-0.5 text-xs text-muted-foreground"
+                      }
+                    >
                       {r.ingredients.length} ingredient{r.ingredients.length !== 1 ? "s" : ""}
                     </span>
                   </button>

--- a/frontend/src/features/settings/DomainPanel.tsx
+++ b/frontend/src/features/settings/DomainPanel.tsx
@@ -78,7 +78,18 @@ export function DomainPanel() {
                 <span>
                   <span className="block text-sm font-medium text-foreground">{opt.name}</span>
                   {opt.description && (
-                    <span className="mt-0.5 block text-sm text-muted-foreground">
+                    // muted-foreground is tuned for the default surface; on the
+                    // selected option's indigo background it falls to 4.24:1,
+                    // under the 4.5:1 AA threshold. Darken it when selected.
+                    // (Same fix as DesignPicker/RecipePicker's selected option.)
+                    <span
+                      className={[
+                        "mt-0.5 block text-sm",
+                        selected
+                          ? "text-indigo-900 dark:text-indigo-200"
+                          : "text-muted-foreground",
+                      ].join(" ")}
+                    >
                       {opt.description}
                     </span>
                   )}

--- a/frontend/src/test/baselineFreeze.test.ts
+++ b/frontend/src/test/baselineFreeze.test.ts
@@ -1,0 +1,95 @@
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Baseline freeze guard (Slice 0 of the frontend revamp integration — see
+ * notes/frontend-revamp-integration-plan.md).
+ *
+ * The incoming fork modified EVERY pre-existing Playwright spec (-122 lines
+ * across 14 files), including removed assertions and at least one deleted
+ * test. Some of that is honest re-expression after a chrome redesign; some is
+ * coverage quietly going away. The difference is invisible in a diff that also
+ * touches 399 source files.
+ *
+ * So the black-box suite is frozen by content hash. It is not immutable — it
+ * is *load-bearing*: changing one is a deliberate behaviour change that has to
+ * be stated, not a detail that rides along inside a large refactor.
+ *
+ * To change a baseline spec:
+ *   1. Make the change in its own commit, with the reason in the message.
+ *   2. Re-bless:  BLESS_BASELINE=1 npm run test:unit
+ *   3. Commit the manifest change alongside it, so review sees both.
+ *
+ * `a11y.ts` is frozen too: it holds the shared assertion every spec's
+ * accessibility check routes through, so weakening it would silently downgrade
+ * the whole suite while every spec still reads as passing.
+ */
+
+const MANIFEST = resolve(process.cwd(), "e2e/baseline.manifest.json");
+
+/**
+ * The pre-existing suite (as of merge-base c3572e3) plus the Slice 0
+ * characterization specs. `mock-api.ts` is deliberately absent: route patterns
+ * and fixture wiring must be free to change as endpoints are added.
+ */
+const BASELINE_FILES = [
+  "e2e/a11y.ts",
+  "e2e/a11y-journeys.spec.ts",
+  "e2e/cooking-domain.spec.ts",
+  "e2e/create.spec.ts",
+  "e2e/dashboard.spec.ts",
+  "e2e/generate.spec.ts",
+  "e2e/match.spec.ts",
+  "e2e/near-miss-tolerance.spec.ts",
+  "e2e/network.spec.ts",
+  "e2e/okh-catalog.spec.ts",
+  "e2e/okh-detail.spec.ts",
+  "e2e/okw-detail.spec.ts",
+  "e2e/packages.spec.ts",
+  "e2e/screenshots.spec.ts",
+  "e2e/settings.spec.ts",
+  "e2e/smoke.spec.ts",
+  "e2e/visualization.spec.ts",
+];
+
+function hash(relPath: string): string {
+  const body = readFileSync(resolve(process.cwd(), relPath), "utf-8");
+  return createHash("sha256").update(body).digest("hex");
+}
+
+function currentHashes(): Record<string, string> {
+  return Object.fromEntries(BASELINE_FILES.map((f) => [f, hash(f)]));
+}
+
+describe("e2e baseline freeze", () => {
+  if (process.env.BLESS_BASELINE) {
+    it("re-blesses the manifest", () => {
+      writeFileSync(MANIFEST, `${JSON.stringify(currentHashes(), null, 2)}\n`);
+      expect(true).toBe(true);
+    });
+    return;
+  }
+
+  const recorded = JSON.parse(readFileSync(MANIFEST, "utf-8")) as Record<string, string>;
+  const actual = currentHashes();
+
+  it("covers exactly the files the manifest records", () => {
+    // A spec dropped from BASELINE_FILES would otherwise stop being checked
+    // without anything failing — the same silent-loss shape this guards.
+    expect(Object.keys(actual).sort()).toEqual(Object.keys(recorded).sort());
+  });
+
+  it.each(BASELINE_FILES)("%s is unchanged since it was blessed", (file) => {
+    expect(
+      actual[file],
+      `${file} changed.\n\n` +
+        "Baseline specs are the contract the frontend revamp integration is " +
+        "verified against. If this edit is a deliberate behaviour change, put " +
+        "it in its own commit with the reason, re-bless with " +
+        "`BLESS_BASELINE=1 npm run test:unit`, and commit the manifest " +
+        "alongside it.",
+    ).toBe(recorded[file]);
+  });
+});

--- a/frontend/src/test/fixtures/index.ts
+++ b/frontend/src/test/fixtures/index.ts
@@ -607,10 +607,63 @@ export const packageMetadataFixture = {
   },
 };
 
+/**
+ * Cooking-domain browse fixtures.
+ *
+ * Shape is the paginated envelope `fetchAllRecipes`/`fetchAllKitchens` read
+ * (`items` + `pagination` at the top level, not nested under `data`), with
+ * `has_next: false` so the paging loop terminates on the first request.
+ */
+export const recipesFixture = {
+  items: [
+    {
+      id: "recipe-1",
+      name: "Sourdough Loaf",
+      ingredients: ["flour", "water", "salt", "starter"],
+      instructions: ["Mix", "Bulk ferment", "Shape", "Bake"],
+      equipment: ["oven", "dutch oven", "mixing bowl"],
+      domain: "cooking",
+    },
+    {
+      id: "recipe-2",
+      name: "Miso Soup",
+      ingredients: ["dashi", "miso paste", "tofu"],
+      instructions: ["Heat dashi", "Whisk in miso"],
+      equipment: ["saucepan"],
+      domain: "cooking",
+    },
+  ],
+  pagination: { has_next: false, total_items: 2 },
+};
+
+export const kitchensFixture = {
+  items: [
+    {
+      id: "kitchen-1",
+      name: "Community Kitchen",
+      appliances: ["oven", "stovetop"],
+      tools: ["dutch oven", "mixing bowl"],
+      ingredients: ["flour", "water", "salt"],
+      domain: "cooking",
+    },
+    {
+      id: "kitchen-2",
+      name: "Pop-Up Canteen",
+      appliances: ["stovetop"],
+      tools: ["saucepan"],
+      ingredients: ["dashi", "miso paste"],
+      domain: "cooking",
+    },
+  ],
+  pagination: { has_next: false, total_items: 2 },
+};
+
 /** Path-keyed lookup used by the Playwright interceptor (see e2e/mock-api.ts). */
 export const fixturesByPath: Record<string, unknown> = {
   "/health": healthFixture,
   "/v1/api/utility/domains": domainsFixture,
+  "/v1/api/okh/recipes": recipesFixture,
+  "/v1/api/okw/kitchens": kitchensFixture,
   "/v1/api/utility/metrics": metricsFixture,
   "/v1/api/okh": okhListFixture,
   "/v1/api/okh/okh-0001": okhDetailFixture,


### PR DESCRIPTION
## Why

We're integrating a large frontend contribution from a community fork
(`binaryLady/OHM`, 163 commits ahead of merge-base `c3572e3`). Investigating it
first changed what the work actually is:

- It is **not** just a design revamp. It bundles a **Vite → Next.js 16
  migration**, 21 files of Python backend changes, CI policy changes, and an
  optional **Supabase** "site layer".
- It **predates our last 19 commits**. `frontend/app/` contains zero references
  to recipes or kitchens, so the cooking domain has no route in the new shell.
  Git merges `DomainPanel.tsx` / `useDomainPreference.ts` cleanly regardless —
  the files arrive, the wiring doesn't, and nothing in the current suite notices.
- It **modifies every pre-existing e2e spec** (−122 lines), including removed
  assertions and at least one deleted test. Some is honest re-expression after a
  chrome redesign; some is coverage going away. **The fork's own tests therefore
  cannot be the safety net for integrating it.**

This PR is the contract that integration gets verified against, authored on
`main` before any fork code lands. It changes no application behaviour beyond
two accessibility fixes.

## What's here

| File | Content |
|---|---|
| `e2e/cooking-domain.spec.ts` | 8 specs — recipe/kitchen browse, recipe detail, both Run Match handoffs, match guards, domain toggle + persistence, stored preference beating the server default |
| `e2e/near-miss-tolerance.spec.ts` | 4 specs — #355/#356 regression cover for both domains |
| `src/test/baselineFreeze.test.ts` + `e2e/baseline.manifest.json` | sha256 freeze over the 14 pre-existing specs, `a11y.ts`, and the two above |
| `harness/proxy-contract.mjs` | 10 HTTP-only checks against the real container |
| `src/test/fixtures/index.ts` | `recipesFixture`, `kitchensFixture` wired into `fixturesByPath` |

Unit tests **350 → 368**.

**On the freeze guard:** it isn't immutability. Editing a baseline spec is a
deliberate behaviour change that should be stated in its own commit, rather than
riding along invisibly inside a diff that also touches 399 source files.
Re-bless with `npm run baseline:bless`.

**On the proxy contract:** no existing suite puts the proxy in the request path —
the mocked lane stubs the API in the browser. The fork deletes
`deploy/nginx.conf.template` and reimplements every guarantee it holds as Next
route handlers, so those guarantees need an executable record first. It speaks
only HTTP, so the same 10 assertions run unchanged against the Next image.

**On the near-miss specs:** this behaviour already has unit cover, but those
tests mount through `MemoryRouter` — the exact category the fork's own playbook
flags as needing a harness rewrite under the App Router. These are black-box, so
they keep proving the fix while the unit tests are being re-hosted.

## Verification

Both suites were verified **RED**, not merely green:

- Reintroducing the #356 bug (`rawView.solutions` → `view.solutions` in
  `MatchView.tsx:344`) fails the manufacturing tolerance spec — and correctly
  leaves the empty-result spec passing, since that path is genuinely unaffected.
- Appending one line to `smoke.spec.ts` fails the freeze guard by name.

`npm run frontend-ready` (84 e2e passed, 1 skipped), `make ready` (11/11), and
`npm run contract:proxy` (10/10 against the real nginx image) all green.

## Two real defects found and fixed (7bd4230)

`text-muted-foreground` (#737373) on indigo-tinted **selected** surfaces:

- `RecipePicker.tsx` selected option — **3.84:1** on `bg-indigo-100`
- `DomainPanel.tsx` selected radio description — **4.24:1** on `bg-indigo-50`

Both under WCAG AA 4.5:1. `DesignPicker.tsx` — the manufacturing twin — already
carried this fix with a comment naming the same 3.84 figure; `RecipePicker` was
copied from it when the cooking domain landed and the fix didn't carry across.
Found by the new specs' a11y assertions, which run axe over the cooking surfaces
for the first time.

Worth noting: the contributor's own Phase 3 describes exactly this failure mode
(*"a world's accent used as text on tinted surfaces sits between 3.8:1 and
4.5:1 — fine as a fill, failing as ink"*) and fixes it systemically via
`--color-primary-ink`. These two patches are the local version of their systemic
one and should be dropped in favour of it later — independent evidence their
token work is worth taking.

## Notes for review

- The full integration plan (slice ordering, the contributor punchlist, verified
  findings about the fork) lives in `notes/frontend-revamp-integration-plan.md`,
  which is **gitignored** and so not in this diff.
- Merging this unblocks the contributor: the punchlist is written against this
  baseline and can't start until it's on a fetchable ref.
- Unrelated pre-existing wart spotted: `make ready` rewrites
  `storage/**/.gitkeep{,.meta}` with fresh timestamps on every run, dirtying the
  tree. Left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)