### PR TITLE
ci: prove the site layer in both postures, and put an expiry on keeping it

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -198,7 +198,9 @@ jobs:
       # lane — which carries the 20-variant theme contrast matrix and the
       # chart-ramp distinctness check. The site layer is absent from this
       # environment on purpose: the default (disabled) deployment is what CI
-      # must prove, and e2e/site-layer.spec.ts asserts it.
+      # must prove, and e2e/site-layer.spec.ts asserts it. The opposite posture
+      # is proved by the site-layer-enabled job below; neither direction is
+      # allowed to be the untested one.
       - name: frontend-ready
         run: npm run frontend-ready
 
@@ -209,6 +211,73 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
+          path: |
+            frontend/artifacts/test-results
+            frontend/artifacts/playwright-report
+          retention-days: 7
+          if-no-files-found: ignore
+
+  site-layer-enabled:
+    name: Frontend (site layer enabled)
+    runs-on: ubuntu-latest
+    needs: quality
+    defaults:
+      run:
+        working-directory: frontend
+    # The site layer defaults to OFF and the job above proves that posture. This
+    # one proves the other, because "off is a first-class state" is a claim about
+    # a PAIR — it only means something if the enabled direction is also known to
+    # work. It was verified once by hand when the layer was written and then had
+    # no gate, which is the condition under which a capability rots silently and
+    # nobody finds out until the day they switch it on.
+    #
+    # The credentials are deliberately fake and point at a host that cannot
+    # resolve (.invalid is reserved by RFC 2606). That is not a shortcut around
+    # provisioning a project — it is the more interesting half of the contract.
+    # docs/architecture/site-layer.md promises that an unreachable or
+    # unprovisioned backend yields default gate copy rather than an error, and
+    # lib/site/stack.ts backs that with a catch on every call plus a dormant flag
+    # after the first failure. This job holds that promise to account. A live
+    # project would test the happy path and quietly stop testing this one.
+    env:
+      # NEXT_PUBLIC_* are inlined at BUILD time, so these must be set for the
+      # build, not merely for the test run.
+      NEXT_PUBLIC_OHM_SUPABASE_URL: https://ci-stub.supabase.invalid
+      NEXT_PUBLIC_OHM_SUPABASE_ANON_KEY: ci-stub-anon-key
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      # Fails loudly if the build did not take the env. A green suite against a
+      # disabled build proves nothing while looking exactly like proof, and that
+      # is the one failure mode this job cannot be allowed to have.
+      - name: Build, and confirm it is in the enabled posture
+        run: |
+          npm run build
+          grep -rq "ci-stub.supabase.invalid" .next/static/chunks/ \
+            || { echo "::error::site layer did not reach the client bundle — this job would be testing the disabled posture"; exit 1; }
+
+      - name: e2e (site layer enabled)
+        run: npm run e2e
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-site-layer-enabled
           path: |
             frontend/artifacts/test-results
             frontend/artifacts/playwright-report

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,6 +16,49 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect changed areas
+    runs-on: ubuntu-latest
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+    # Only one job reads this today (site-layer-enabled), and it exists to keep
+    # ~4 minutes of Playwright off every backend-only pull request.
+    #
+    # Deliberately NOT a third-party filter action: this is one git diff, and a
+    # dependency that can read the workflow context is a poor trade for six
+    # lines of shell in a repo that otherwise uses only first-party actions.
+    #
+    # Anything that is not a pull request — a push to main or dev, a tag, a
+    # manual dispatch — answers "true" without looking. Those are the runs where
+    # the full picture matters and where a wrong answer is expensive; the
+    # shortcut is for PR feedback speed, not for the record.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Which areas does this change touch?
+        id: filter
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "not a pull request — running everything"
+            echo "frontend=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # The workflow itself counts: editing the job that runs the suite has
+          # to re-run the suite, or the edit goes in unverified.
+          pattern='^(frontend/|\.github/workflows/ci-cd\.yml$)'
+          changed=$(git diff --name-only "$BASE...$HEAD")
+          echo "changed files:"; echo "$changed" | sed 's/^/  /'
+          if echo "$changed" | grep -qE "$pattern"; then touched=true; else touched=false; fi
+          echo "frontend touched: $touched"
+          echo "frontend=$touched" >> "$GITHUB_OUTPUT"
+
   quality:
     name: Quality (format, lint, repo-map)
     runs-on: ubuntu-latest
@@ -220,7 +263,11 @@ jobs:
   site-layer-enabled:
     name: Frontend (site layer enabled)
     runs-on: ubuntu-latest
-    needs: quality
+    needs: [quality, changes]
+    # Skipped on a pull request that touches no frontend file. GitHub reports a
+    # skipped job as successful to branch protection, so this stays safe to make
+    # a required check.
+    if: needs.changes.outputs.frontend == 'true' 
     defaults:
       run:
         working-directory: frontend

--- a/docs/architecture/site-layer.md
+++ b/docs/architecture/site-layer.md
@@ -8,6 +8,47 @@ This follows the same idiom as [`OHM_SECURITY_MODE`](security-modes.md): a
 posture selected by environment variable, read through config, never
 hard-coded.
 
+## Status: conditional keep, review by 2027-02-28
+
+No environment enables this layer. `config/environments/*.toml` does not mention
+Supabase, no deploy step sets the two `NEXT_PUBLIC_OHM_SUPABASE_*` variables,
+and no project is provisioned — so on every deployment that exists today, this
+is code that does not run.
+
+It is kept anyway, deliberately, on measured grounds rather than optimism:
+
+- **It costs nothing to carry.** The Supabase SDK is code-split into a chunk the
+  initial document never references — verified against a production build, not
+  assumed. `track()` returns immediately when the layer is off, `/operator-tools`
+  is a real 404, and the whole suite is 93 unit tests adding ~3s.
+- **It is finished, not a stub.** Both postures were verified against real
+  builds when it was written, and CI now proves both on every run
+  (`site-layer-enabled` in `ci-cd.yml`).
+- **Cutting is a one-way door.** Roughly 3,900 lines with tests, plus a
+  428-line schema. "We can add it back later" is not a thing anyone does.
+
+**The condition.** This is a keep with an expiry, not a park. If the hosted
+instance has not enabled the layer by **2027-02-28**, cut it — at that point the
+"we might want it" argument has failed its own test, and what remains is code
+that reads as live to every contributor who opens it while never having run.
+
+Whoever cuts it: delete `src/features/site/`, `src/lib/site/`, `supabase/`,
+`app/operator-tools/`, `e2e/site-layer.spec.ts`, the `site-layer-enabled` CI job
+and this document, and drop `@supabase/supabase-js`. Three files outside the
+layer then need an edit, and one needs a glance:
+
+| File | What to remove |
+|---|---|
+| `src/features/match/MatchView.tsx` | the `track(EVENTS.matchRun, …)` call and both `lib/site` imports |
+| `src/components/layout/NavDrawer.tsx` | `useSiteLayer()` and the `site.enabled &&` guard around the Operator group |
+| `app/providers.tsx` | `siteConfig` (the `data-site-layer` attribute) and `<RouteTelemetry />` |
+| `src/api/ohm/federation.ts` | a comment pointing at `lib/site/stack.ts` as prior art — prose, not a dependency |
+
+Note the last one: `e2e/site-layer.spec.ts` and `app/providers.tsx` are a pair.
+The spec reads the posture from the `data-site-layer` attribute that
+`providers.tsx` publishes, so removing one without the other leaves a spec
+asserting against an attribute nothing writes.
+
 ## Off is a first-class state
 
 With no Supabase configured, an instance is **not degraded**. It is the default


### PR DESCRIPTION
Two commits, both about the optional site layer. No application code changes —
this is a CI job and a decision record.

## Why

The site layer defaults to off, and CI proved only that direction. But *"off is
a first-class state"* is a claim about a **pair**: it means nothing unless the
enabled direction is also known to work. That direction was verified once by
hand when the layer was written (#16), and then had no gate — the condition
under which a capability rots silently and nobody finds out until the day they
switch it on.

Meanwhile nothing enables the layer: no `config/environments/*.toml` mentions
Supabase, no deploy step sets the two `NEXT_PUBLIC_OHM_SUPABASE_*` variables,
and no project is provisioned. So it sat in the worst state available —
present, plausible, and unverified in the direction that matters.

## 1. `site-layer-enabled` job

Builds with the layer on and runs the full e2e suite. **238 passed** locally,
against credentials that deliberately cannot resolve (`.invalid`, RFC 2606).

The fake credentials are the point, not a shortcut around provisioning a
project. `docs/architecture/site-layer.md` promises that an unreachable or
unprovisioned backend yields default gate copy rather than an error, and
`lib/site/stack.ts` backs that with a `catch` on every call plus a dormant flag
after the first failure. This job holds that promise to account. A live Supabase
would test the happy path and quietly stop testing this one.

**The job guards itself.** It greps the built chunks for the stub URL and fails
the run if the build did not take the env — because a green suite against a
*disabled* build proves nothing while looking exactly like proof, and that is the
one failure mode this job cannot be allowed to have. Verified in both
directions: the marker is present when the env is set, absent when it is not.

Note `NEXT_PUBLIC_*` are inlined at **build** time, so the env is set on the job
rather than only on the test step.

## 2. Gated on frontend changes

The job costs ~4 minutes, and a backend-only change cannot affect what it
proves. A small `changes` job runs one `git diff` and exposes a `frontend`
output; `site-layer-enabled` gates on it.

Verified rather than assumed:

| Change | Result |
|---|---|
| `src/core/api/routes/okh.py` | skip |
| `frontend/src/App.tsx` | run |
| `.github/workflows/ci-cd.yml` | run |
| `.github/workflows/release.yml` | skip |
| mixed backend + frontend | run |

- The workflow file is in the pattern on purpose: editing the job that runs the
  suite has to re-run the suite, or the edit lands unverified.
- Non-PR events (push to main/dev, tags, manual dispatch) answer `true` without
  looking. Those are the runs where a wrong answer is expensive; the shortcut is
  for PR feedback speed, not for the record.
- `supabase/schema.sql` deliberately does not trigger it — the job runs against
  unreachable credentials and never touches the schema.
- A skipped job reports success to branch protection, so this stays safe to make
  a required check.

## 3. Decision record: conditional keep, review by 2027-02-28

`docs/architecture/site-layer.md` gains a status section. The layer is kept on
measured grounds rather than optimism:

- **Carrying cost is zero.** The Supabase SDK is a 125 KB chunk the initial
  document never references — checked against a production build; the 22 KB
  chunk that *is* referenced holds only the dynamic-import specifier, not the
  SDK. `track()` returns immediately when off, `/operator-tools` is a real 404,
  and the tests add ~3s.
- **It is finished, not a stub.** Both postures verified; now on every run.
- **Cutting is a one-way door.** ~2 160 source + ~1 700 test lines across 25
  files, plus a 428-line schema.

**The condition:** if the hosted instance has not enabled the layer by
**2027-02-28**, cut it — at that point "we might want it" has failed its own
test. Cut instructions are in the doc, verified against the tree rather than
recalled, including the trap that `e2e/site-layer.spec.ts` and
`app/providers.tsx` are a pair (the spec reads the `data-site-layer` attribute
the provider publishes).

Two claims in the integration plan were wrong and are corrected in the doc: the
layer is ~3 900 lines, not "~1 500"; and it is not fully confined — four files
outside it reach in, though shallowly (one `track()` call, one nav guard, two
provider imports).

## Verification

- `make ready` **13/13**
- `npm run frontend-ready` **5/5** in the default posture (692 unit, 237 e2e),
  re-run with the env explicitly unset so a stale environment could not make the
  default look green
- enabled posture: **238 passed** against `.invalid` credentials
- self-guard: verified red and green

## For review

- **Shell over `dorny/paths-filter`** was a judgment call. One `git diff` versus
  a third-party action that can read the workflow context, in a repo that
  otherwise uses only first-party actions. Easy to swap if you disagree.
- **The skip path is not exercised by this PR.** This branch touches
  `ci-cd.yml`, so the job runs rather than skips here. The skip gets its first
  real test on the next backend-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xZwk3HaL58YzvYQF8KKJS
