### PR TITLE
chore(release): 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,82 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-29
+
+The web interface, rebuilt. Contributed as a 163-commit fork by
+[@binaryLady](https://github.com/binaryLady) and integrated over #358, #360 and
+#361. Also carries the cooking domain and three access-control fixes.
+
+A minor rather than a patch: the frontend is a different framework, the match
+surface has a second domain, and there is a new optional subsystem.
+
+### Added
+
+- **The cooking domain.** Recipes and kitchens are first-class alongside designs
+  and facilities: a domain toggle in Settings reshapes the primary nav, `/okh`
+  and `/facilities` browse the cooking catalog, recipe cards open a detail page
+  with ingredients, instructions and equipment, and "Run Match" hands a
+  preselected recipe to a cooking-aware match view. RFQ generation and coverage
+  explanations follow for cooking results. The choice is browser-local, and a
+  stored preference outranks the server default.
+- **A design system rather than a set of pages.** Colour, type and surfaces live
+  in one token layer, with guards asserting they stay there: no raw hex, no
+  hardcoded palette utilities, headings drawn from the type scale, panels from
+  named surface constants, one-of-N choices through a `SegmentedControl` that
+  implements the WAI-ARIA pattern once. A 20-variant theme matrix checks
+  contrast in every theme, and `--color-primary-ink` fixes the class of failure
+  where an accent used as text on a tinted surface sits between 3.8:1 and 4.5:1
+  — fine as a fill, failing as ink.
+- **New surfaces**: an assets register, a saved-solutions browse, a network map
+  with a mobile sheet, a demo mode with a deterministic world, an icon gallery,
+  a help page carrying the sitemap and keyboard chords, and real error and
+  loading states.
+- **An optional site layer**, off by default and quarantined behind a build-time
+  switch (`docs/architecture/site-layer.md`). With no Supabase configured the
+  instance is not degraded: no gate, no telemetry, `/operator-tools` 404s, and
+  the SDK is code-split out of the initial document. CI proves both postures.
+- **Federation** can fetch a package from a peer, and a facility can be
+  published to Maps of Making.
+
+### Fixed
+
+- **Federation routes authorized nothing.** Every route gated only on whether
+  the feature was enabled, never on who was calling, so `POST /sync/run` would
+  have auto-followed a supplied peer and ingested its manifests — an
+  unauthenticated write path into the object store, bypassing the gate
+  production security mode exists to apply. Write auth is now required.
+- **Private records were readable anonymously.** Visibility was enforced on the
+  federation plane and nowhere else, so a record the API itself reported as
+  `private` was listed, searchable and fetchable without credentials, address
+  included — contradicting our own published `who-can-see-your-data.md`. Read
+  paths now take a viewer and filter on shareability.
+- **Saved supply-tree solutions were listed to every caller.** The endpoint took
+  no user dependency and no owner filter against one shared storage prefix, so
+  any caller received every solution on the instance, each carrying a design
+  title and primary facility. Solutions now carry an owner and the listing is
+  scoped. This is the leak `df639dd` deferred rather than fixed.
+- **A default near-miss tolerance hid every match** in both domains, rendering
+  an empty state where the API had in fact returned results (#355, #356).
+- **The storage bootstrap restamped tracked placeholders on every startup** — it
+  probed a key the organizer never writes, so it re-seeded each time and left
+  `make ready` with a dirty tree.
+- Recipe manifests shaped like OKH are recognised by the discriminator; the
+  low-volatility cache refresh covers recipes and kitchens.
+
+### Changed
+
+- **The frontend is a Next.js standalone server, not a Vite SPA behind nginx.**
+  The container serves the same contract — `/v1` proxying with forwarding
+  headers, `/docs` terminating in a 404 rather than the app shell, `/healthz`,
+  `build-info.json` — through route handlers instead of an nginx config.
+  `frontend/harness/proxy-contract.mjs` asserts all ten behaviours against the
+  real image; the docs tree must be built (`make docs-site`) before the build.
+- `make ready` grows from 11 gates to 13, adding a repository-map staleness gate
+  and a demo-world drift gate.
+- Make targets are pinned to the committed lock (`UV_FROZEN`), so a gate run no
+  longer re-resolves a direct-URL dependency 13 times against the network.
+
+
 ### Added
 
 - **A facility can be published to Maps of Making.** The bridge only ran

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ OHM exposes a FastAPI HTTP API that can be run locally via Docker Compose, from 
 or deployed using the configurations in `deploy/`. A reference frontend ships in
 `frontend/`.
 
-**Current release:** `0.10.7` — see [CHANGELOG.md](CHANGELOG.md) and [Release process](docs/RELEASE.md).
+**Current release:** `0.11.0` — see [CHANGELOG.md](CHANGELOG.md) and [Release process](docs/RELEASE.md).
 
 ## Quick Start for New Users
 
@@ -274,11 +274,11 @@ After installing, open a new terminal so the tools are on your PATH.
 **Local storage (no credentials needed):**
 
 ```bash
-docker pull touchthesun/openhardwaremanager:0.10.7
+docker pull touchthesun/openhardwaremanager:0.11.0
 docker run -p 8001:8001 \
   -e STORAGE_PROVIDER=local \
   -e LLM_ENABLED=false \
-  touchthesun/openhardwaremanager:0.10.7
+  touchthesun/openhardwaremanager:0.11.0
 ```
 
 **Remote storage (Azure Blob, AWS S3, or GCS):**
@@ -289,7 +289,7 @@ The published image does not include a `.env` file — you must pass your storag
 # Copy the template, fill in your provider and credentials, then:
 docker run -p 8001:8001 \
   --env-file .env \
-  touchthesun/openhardwaremanager:0.10.7
+  touchthesun/openhardwaremanager:0.11.0
 ```
 
 The minimum `.env` keys for Azure Blob are:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@
 services:
   # Open Hardware Manager API Server
   ohm-api:
-    image: touchthesun/openhardwaremanager:${OHM_VERSION:-0.10.7}
+    image: touchthesun/openhardwaremanager:${OHM_VERSION:-0.11.0}
     build:
       context: .
       dockerfile: Dockerfile
@@ -132,7 +132,7 @@ services:
 
   # Celery worker sidecar (same image as ohm-api, worker entrypoint mode).
   ohm-worker:
-    image: touchthesun/openhardwaremanager:${OHM_VERSION:-0.10.7}
+    image: touchthesun/openhardwaremanager:${OHM_VERSION:-0.11.0}
     build:
       context: .
       dockerfile: Dockerfile
@@ -179,7 +179,7 @@ services:
   # Web UI. Serves the SPA and reverse-proxies /v1 to the API, so the browser
   # talks to one origin and there is no CORS configuration to get wrong.
   ohm-frontend:
-    image: touchthesun/openhardwaremanager-frontend:${OHM_VERSION:-0.10.7}
+    image: touchthesun/openhardwaremanager-frontend:${OHM_VERSION:-0.11.0}
     build: frontend
     container_name: ohm-frontend
     ports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "supply-graph-ai"
-version = "0.10.7"
+version = "0.11.0"
 description = "Open Hardware Manager (OHM) - A flexible, domain-agnostic framework for matching requirements with capabilities"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -3323,7 +3323,7 @@ wheels = [
 
 [[package]]
 name = "supply-graph-ai"
-version = "0.10.7"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Release prep for **0.11.0**. Version bump, lockfile, and the changelog entry —
no code changes.

Bumped with `scripts/bump_version.py`, so `pyproject.toml`, the README badge,
the quickstart docker tag and the Compose image tags move in lockstep.
`version-check` confirms 3 sites match; `uv.lock` re-synced.

`make ready` **13/13**.

## What 0.11.0 contains

666 files, +49 039 / −3 803 since `v0.10.7` — the frontend revamp (#360), its
characterization baseline (#358), the site-layer CI lane (#361), the cooking
domain, and three access-control fixes.

The changelog entry is written from the commit history rather than from
recollection. Highlights:

- **The cooking domain** — recipes and kitchens as first-class surfaces, a
  browser-local domain toggle, cooking match with RFQ and coverage explanations.
- **A design system** with guards that assert colour and type stay in the token
  layer, a 20-variant theme contrast matrix, and `--color-primary-ink` for the
  accent-as-ink contrast failure.
- **The frontend is now a Next.js standalone server, not a Vite SPA behind
  nginx** — same serving contract, different implementation, verified by
  `harness/proxy-contract.mjs` 10/10 against the real image.
- **Three access-control fixes**: federation routes required no write auth,
  private records were readable anonymously with their address, and saved
  supply-tree solutions were listed to every caller.
- `make ready` grows 11 → 13 gates; make targets pinned to the committed lock.

## Why minor, not patch

Originally opened as 0.10.8 (#362). Changed to **0.11.0** at Nathan's call: the
frontend is a different framework (Vite -> Next.js standalone), the match
surface has a second domain, and there is a new optional subsystem. A patch bump
would understate all three to anyone reading the tag list, and the number
reaches the Docker Hub tags and the Compose file self-hosters pull.

#362 was closed as a side effect of renaming the branch to match the version —
GitHub closed it rather than retargeting. Same content, one commit, re-verified.

## After merging

Tagging `v0.11.0` triggers `release.yml`, which builds multi-arch, pushes to
Docker Hub, and **deploys to Azure production** — `deploy-azure` is gated on
`github.event_name == 'push'`, so a version tag always deploys. The `production`
environment gate still applies.

Two things worth knowing for that run:

- `make docs-site` runs before the image build in `release.yml` (before Buildx),
  which is required: `docs-dist` is gitignored to a `.gitkeep`, and without
  `index.html` the docs route handler 302s the whole `/docs` space to the public
  site.
- The frontend image is the Next standalone server now. `API_UPSTREAM_URL` has
  no default on purpose — `entry.sh` refuses to start on an unset value rather
  than silently proxying nowhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xZwk3HaL58YzvYQF8KKJS
