### PR TITLE
fix(frontend): build the image natively instead of under emulation (0.11.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-08-29
+
+Ships the 0.11.0 frontend, which 0.11.0 itself could not.
+
+### Fixed
+
+- **The frontend image is built natively instead of under emulation.** The build
+  stage was unpinned, so Buildx ran the whole of it — `npm ci` and `next build` —
+  once per target architecture, with the `linux/arm64` pass emulated through
+  QEMU on an amd64 runner. Emulated `npm ci` is syscall-bound single-threaded
+  work and does not finish in a useful time: the 0.11.0 release sat on it for 52
+  minutes before it was cancelled, against 7 minutes for the Vite image it
+  replaced. The API, worker and GitHub Release published; the frontend did not.
+
+  The build stage is now pinned to `BUILDPLATFORM`. `next build` emits portable
+  JavaScript, so one native build serves both architectures and only the runtime
+  stage varies — and it does nothing but `COPY`. Measured locally: **2m33s for
+  both architectures**, with the build stage running once. The cross-built
+  `linux/amd64` image was verified to boot and serve, and `contract:proxy`
+  passes 10/10 against the result.
+
+### Changed
+
+- Image optimisation is declared off (`images: { unoptimized: true }`). Next
+  pulls `sharp` into the standalone output, and sharp ships a platform-specific
+  binary that is now the *build* architecture's. Nothing loads it — `next/image`
+  appears only in two comments explaining it has no meaning inside an
+  `ImageResponse` — so this states the existing property rather than changing
+  behaviour. A future change wanting `next/image` needs sharp for the target
+  architecture, installed in the runtime stage.
+
+
 ## [0.11.0] - 2026-08-29
 
 The web interface, rebuilt. Contributed as a 163-commit fork by

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ OHM exposes a FastAPI HTTP API that can be run locally via Docker Compose, from 
 or deployed using the configurations in `deploy/`. A reference frontend ships in
 `frontend/`.
 
-**Current release:** `0.11.0` — see [CHANGELOG.md](CHANGELOG.md) and [Release process](docs/RELEASE.md).
+**Current release:** `0.11.1` — see [CHANGELOG.md](CHANGELOG.md) and [Release process](docs/RELEASE.md).
 
 ## Quick Start for New Users
 
@@ -274,11 +274,11 @@ After installing, open a new terminal so the tools are on your PATH.
 **Local storage (no credentials needed):**
 
 ```bash
-docker pull touchthesun/openhardwaremanager:0.11.0
+docker pull touchthesun/openhardwaremanager:0.11.1
 docker run -p 8001:8001 \
   -e STORAGE_PROVIDER=local \
   -e LLM_ENABLED=false \
-  touchthesun/openhardwaremanager:0.11.0
+  touchthesun/openhardwaremanager:0.11.1
 ```
 
 **Remote storage (Azure Blob, AWS S3, or GCS):**
@@ -289,7 +289,7 @@ The published image does not include a `.env` file — you must pass your storag
 # Copy the template, fill in your provider and credentials, then:
 docker run -p 8001:8001 \
   --env-file .env \
-  touchthesun/openhardwaremanager:0.11.0
+  touchthesun/openhardwaremanager:0.11.1
 ```
 
 The minimum `.env` keys for Azure Blob are:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@
 services:
   # Open Hardware Manager API Server
   ohm-api:
-    image: touchthesun/openhardwaremanager:${OHM_VERSION:-0.11.0}
+    image: touchthesun/openhardwaremanager:${OHM_VERSION:-0.11.1}
     build:
       context: .
       dockerfile: Dockerfile
@@ -132,7 +132,7 @@ services:
 
   # Celery worker sidecar (same image as ohm-api, worker entrypoint mode).
   ohm-worker:
-    image: touchthesun/openhardwaremanager:${OHM_VERSION:-0.11.0}
+    image: touchthesun/openhardwaremanager:${OHM_VERSION:-0.11.1}
     build:
       context: .
       dockerfile: Dockerfile
@@ -179,7 +179,7 @@ services:
   # Web UI. Serves the SPA and reverse-proxies /v1 to the API, so the browser
   # talks to one origin and there is no CORS configuration to get wrong.
   ohm-frontend:
-    image: touchthesun/openhardwaremanager-frontend:${OHM_VERSION:-0.11.0}
+    image: touchthesun/openhardwaremanager-frontend:${OHM_VERSION:-0.11.1}
     build: frontend
     container_name: ohm-frontend
     ports:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,18 @@
 # syntax=docker/dockerfile:1
 
 # ---- Build stage: compile the Next.js app to a standalone server ----
-FROM node:22-alpine AS build
+#
+# Pinned to BUILDPLATFORM so this stage runs once, natively, instead of once per
+# target architecture under QEMU. `next build` emits portable JavaScript, so one
+# build serves both architectures; only the runtime stage below has to vary, and
+# it does nothing but COPY.
+#
+# This is not a micro-optimisation. Emulated `npm ci` is syscall-bound
+# single-threaded work and it does not finish in a useful time: the v0.11.0
+# release sat on it for 52 minutes and was cancelled, against 7 minutes for the
+# Vite image this replaced. Dropping the emulated pass is the difference between
+# a release that ships and one that does not.
+FROM --platform=$BUILDPLATFORM node:22-alpine AS build
 WORKDIR /app
 
 # Install deps against the committed lockfile (reproducible, matches CI).

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -9,6 +9,20 @@ const nextConfig: NextConfig = {
   // fails with ENOENT there. So the flag is for our own image only; on Vercel
   // the default output is correct.
   output: process.env.VERCEL ? undefined : "standalone",
+  // No runtime image optimisation, declared rather than left to chance.
+  //
+  // Next pulls `sharp` into the standalone output as an optional dependency,
+  // and sharp ships a platform-specific .node binary. The build stage is now
+  // pinned to BUILDPLATFORM (see frontend/Dockerfile), so that binary is the
+  // BUILD architecture's — harmless only for as long as nothing loads it.
+  //
+  // Nothing does: next/image appears in exactly two files, both of which are
+  // comments noting it has no meaning inside an ImageResponse, and both use a
+  // plain <img>. Saying so here turns that from an accident into a contract. If
+  // a future change wants next/image, it needs sharp for the TARGET
+  // architecture, which means installing it in the runtime stage — not simply
+  // deleting this line.
+  images: { unoptimized: true },
   // Trailing slashes are policy-per-surface (docs keep them, app routes drop
   // them); proxy.ts owns the split, so the global redirect is off.
   skipTrailingSlashRedirect: true,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "supply-graph-ai"
-version = "0.11.0"
+version = "0.11.1"
 description = "Open Hardware Manager (OHM) - A flexible, domain-agnostic framework for matching requirements with capabilities"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -3323,7 +3323,7 @@ wheels = [
 
 [[package]]
 name = "supply-graph-ai"
-version = "0.11.0"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Release **0.11.1**. Ships the 0.11.0 frontend, which 0.11.0 itself could not.

## What happened

The 0.11.0 release published the API, the worker and the GitHub Release, then
sat on `Publish frontend multi-arch to Docker Hub` for **52 minutes** and was
cancelled. Production is currently serving the 0.11.0 API behind the 0.10.7 UI.

The job hung on `RUN npm ci`.

## Root cause

The build stage was unpinned:

```dockerfile
FROM node:22-alpine AS build      # runs once PER TARGET ARCH
```

With `PLATFORMS: linux/amd64,linux/arm64`, Buildx ran the whole stage twice, and
the arm64 pass emulated `npm ci` and `next build` through QEMU on an amd64
runner. `npm ci` is syscall-bound single-threaded work — the worst case for
emulation.

Docker's [multi-platform
guidance](https://docs.docker.com/build/building/multi-platform/) names this
directly: *"Emulation with QEMU can be much slower than native builds,
especially for compute-heavy tasks like compilation and compression or
decompression."* Its recommended alternatives are native builder nodes or
cross-compilation via `BUILDPLATFORM` / `TARGETPLATFORM`.

**This is a Dockerfile bug, not a Next.js property.** It would bite any Node
app. What changed between releases is the payload being emulated — a Vite SPA's
small dependency tree became 758 packages. Same broken pattern, ~7x the work.

## The fix

```dockerfile
FROM --platform=$BUILDPLATFORM node:22-alpine AS build
```

Node has it easier than Docker's Go example: JavaScript is interpreted, so
nothing needs cross-compiling. One native build serves both architectures, and
only the runtime stage varies — it does nothing but `COPY`.

| | Before | After |
|---|---|---|
| Both architectures | 52 min, cancelled | **2m 33s** |
| Build stage runs | once per arch | **once** |
| `npm ci` invocations | 2 (one emulated) | **1** |

For scale: this is now **faster than the Vite image it replaced** (7 min), which
was paying the same tax on less work.

Verified beyond timing — the cross-built **`linux/amd64`** image, the one Azure
needs, boots, serves `/` and `/healthz`, and passes `contract:proxy` **10/10**.

## Why `images: { unoptimized: true }`

Next bundles `sharp` into the standalone output, and sharp ships a
platform-specific `.node` binary — which, with a native build stage, is now the
*build* architecture's. Nothing loads it: `next/image` appears in exactly two
files, `app/apple-icon.tsx` and `app/opengraph-image.tsx`, both as comments
noting it has no meaning inside an `ImageResponse`, both using a plain `<img>`.

Declaring it makes that a contract rather than an accident. A future change
wanting `next/image` needs sharp for the **target** architecture, installed in
the runtime stage — not simply this line deleted.

## Verification

- `make ready` **13/13**
- `npm run frontend-ready` **5/5** (692 unit, 237 e2e)
- multi-arch build, both platforms: 2m33s, build stage once
- cross-built amd64 image: boots, serves, `contract:proxy` 10/10

## After merging

Tag `v0.11.1` to release. The API and worker are already on 0.11.0 and this
carries no backend change, so the meaningful delta is the frontend image
finally publishing and deploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xZwk3HaL58YzvYQF8KKJS
