### PR TITLE
docs: write the missing write-key guide, correct what protects writes, and gate broken links

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 642
+Total Python files: 643
 
 ├── deploy/
 │   ├── __init__.py
@@ -193,6 +193,11 @@ Total Python files: 642
 │   │       def _scan_site()
 │   │       def check()
 │   │       def bump()
+│   │       def main()
+│   ├── check_doc_links.py
+│   │       def nav_targets()
+│   │       def doc_pages()
+│   │       def sources()
 │   │       def main()
 │   ├── clear_storage.py
 │   ├── copy_container_blobs.py
@@ -3376,7 +3381,7 @@ Total Python files: 642
 
 ## Overview
 
-Total files analyzed: 642
+Total files analyzed: 643
 
 ## Entry Points
 
@@ -6707,6 +6712,20 @@ Copies ``docs-site/docs/`` (authored markdown) in...
 - `check(target)`
   - Fail if any registered site disagrees with `target` (pyproject version)....
 - `bump(new_version)`
+- `main()`
+
+### `scripts/check_doc_links.py`
+> Fail when a documentation link cannot be followed to a real page.
+
+Three classes of rot, none of whi...
+
+**Exports:** nav_targets, doc_pages, sources, main
+
+**Functions:**
+- `nav_targets()`
+  - Page paths named in mkdocs nav, which may be generated rather than on disk....
+- `doc_pages()`
+- `sources()`
 - `main()`
 
 ### `scripts/clear_storage.py`

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # pyproject.toml is caught there rather than hidden here.
 export UV_FROZEN := 1
 
-.PHONY: format format-check lint test check black ruff repo-map repo-map-check env-template env-template-check validate-docs version-check lock-check scripts scripts-check demo-world-check parity secrets-check ready setup verify-env frontend-setup frontend-ready seed-demo harness harness-probes match-harness docs-site docs-status taxonomy taxonomy-check
+.PHONY: format format-check lint test check black ruff repo-map repo-map-check links-check env-template env-template-check validate-docs version-check lock-check scripts scripts-check demo-world-check parity secrets-check ready setup verify-env frontend-setup frontend-ready seed-demo harness harness-probes match-harness docs-site docs-status taxonomy taxonomy-check
 
 # Web frontend verification harness (the frontend analogue of `ready`).
 # See frontend/harness/README.md. Runs typecheck, lint, unit, build, and the
@@ -87,6 +87,14 @@ check: lint format-check test
 repo-map:
 	uv run python scripts/generate_repo_map.py
 
+# Documentation link gate: every link into the docs must reach a real page, and
+# no link may name the host that does not serve them. mkdocs validates relative
+# links between pages and nothing validated the rest -- which is how the facility
+# form spent months pointing at docs.openhardwaremanager.org/auth/get-a-write-key/,
+# a wrong host and a page that was never written.
+links-check:
+	uv run python scripts/check_doc_links.py
+
 # Staleness gate (lockfile pattern): fails if .repo-map.md is out of date.
 repo-map-check:
 	uv run python scripts/generate_repo_map.py --check
@@ -161,17 +169,18 @@ secrets-check:
 # Definition of done. Green tests are not "ready to merge"; this is.
 # Each step verifies (does not mutate) and fails fast. Run before any MR.
 ready:
-	@echo "==> [1/13] env verify";      $(MAKE) verify-env
-	@echo "==> [2/13] format check";    $(MAKE) format-check
-	@echo "==> [3/13] lint";            $(MAKE) lint
-	@echo "==> [4/13] unit tests";      $(MAKE) test
-	@echo "==> [5/13] service parity";  $(MAKE) parity
-	@echo "==> [6/13] docs ↔ code";     $(MAKE) validate-docs
-	@echo "==> [7/13] site docs status";$(MAKE) docs-status
-	@echo "==> [8/13] taxonomy sync";   $(MAKE) taxonomy-check
-	@echo "==> [9/13] version sync";    $(MAKE) version-check
-	@echo "==> [10/13] lockfile sync";  $(MAKE) lock-check
-	@echo "==> [11/13] script registry";$(MAKE) scripts-check
-	@echo "==> [12/13] demo world sync";$(MAKE) demo-world-check
-	@echo "==> [13/13] repo map sync";  $(MAKE) repo-map-check
+	@echo "==> [1/14] env verify";      $(MAKE) verify-env
+	@echo "==> [2/14] format check";    $(MAKE) format-check
+	@echo "==> [3/14] lint";            $(MAKE) lint
+	@echo "==> [4/14] unit tests";      $(MAKE) test
+	@echo "==> [5/14] service parity";  $(MAKE) parity
+	@echo "==> [6/14] docs ↔ code";     $(MAKE) validate-docs
+	@echo "==> [7/14] site docs status";$(MAKE) docs-status
+	@echo "==> [8/14] taxonomy sync";   $(MAKE) taxonomy-check
+	@echo "==> [9/14] version sync";    $(MAKE) version-check
+	@echo "==> [10/14] lockfile sync";  $(MAKE) lock-check
+	@echo "==> [11/14] script registry";$(MAKE) scripts-check
+	@echo "==> [12/14] demo world sync";$(MAKE) demo-world-check
+	@echo "==> [13/14] repo map sync";  $(MAKE) repo-map-check
+	@echo "==> [14/14] doc links";      $(MAKE) links-check
 	@echo "==> READY: all gates passed."

--- a/deploy/terraform/azure/examples/single-peer/README.md
+++ b/deploy/terraform/azure/examples/single-peer/README.md
@@ -57,4 +57,4 @@ output "api_key" {
 }
 ```
 
-See the parent [README.md](../README.md) for the full multi-peer federation lab.
+See the parent [README.md](../../README.md) for the full multi-peer federation lab.

--- a/docs-site/docs/guides/enable-the-site-layer.md
+++ b/docs-site/docs/guides/enable-the-site-layer.md
@@ -13,7 +13,7 @@ that never enables it is not degraded; it is the normal deployment.
 
 It never grants application permissions. Whether you may create a design or
 manage API keys comes from your OHM API key, not from anything here. See
-[the architecture note](https://github.com/binaryLady/OHM/blob/main/docs/architecture/site-layer.md)
+[the architecture note](https://github.com/helpfulengineering/supply-graph-ai/blob/main/docs/architecture/site-layer.md)
 for why that boundary matters.
 
 Everything below runs in the Supabase **SQL editor**. None of it is reachable
@@ -22,7 +22,7 @@ from a browser client — that is deliberate.
 ## 1. Create a project and run the schema
 
 Create a Supabase project, open the SQL editor, and run
-[`supabase/schema.sql`](https://github.com/binaryLady/OHM/blob/main/supabase/schema.sql)
+[`supabase/schema.sql`](https://github.com/helpfulengineering/supply-graph-ai/blob/main/supabase/schema.sql)
 in full.
 
 It creates four tables — `ohmgr_visitors`, `ohmgr_telemetry_events`,

--- a/docs-site/docs/guides/get-a-write-key.md
+++ b/docs-site/docs/guides/get-a-write-key.md
@@ -1,0 +1,200 @@
+---
+title: Get a write key
+area: identity
+surface: api
+---
+
+# Get a write key
+
+Reading OHM needs nothing. Browsing designs, searching facilities, running a
+match — all of it works with no credential at all. **Writing is the part that
+needs a key**: saving a facility, adding a design, importing a collection.
+
+This page is about getting that key on a node you run.
+
+## Which node are you writing to?
+
+Two very different situations, and the difference matters more than anything
+else on this page.
+
+**Someone else's node** — you need a key from whoever runs it. There is no
+self-service signup; a node operator issues credentials. Ask them.
+
+**Your own node** — you already have everything you need. The rest of this page
+is for you.
+
+## First, a warning worth reading
+
+`API_KEYS` is not, on its own, a switch that turns write protection on.
+
+Whether writes are checked depends on the node's **posture**, which comes from
+`ENVIRONMENT`:
+
+| `ENVIRONMENT` | Anonymous write | Why |
+|---|---|---|
+| `development` (the default) | **Accepted** | Dev and test flows stay frictionless |
+| `production` | Rejected, `401` | Write auth enforced |
+
+That first row surprises people. On a development node, an anonymous `POST`
+succeeds **even with `API_KEYS` set** — the key is accepted if you send it, and
+not required if you don't.
+
+So if your node is reachable by anyone but you, setting a key is not enough:
+
+```bash
+ENVIRONMENT=production
+```
+
+Crisis and shielded security modes always enforce writes, whatever `ENVIRONMENT`
+says. See [Security Modes](https://github.com/helpfulengineering/supply-graph-ai/blob/main/docs/architecture/security-modes.md).
+
+!!! note "One more thing production needs"
+
+    A node in `production` refuses to start without `LLM_ENCRYPTION_SALT` and
+    `LLM_ENCRYPTION_PASSWORD`, which protect stored language-model credentials.
+    Generate them once:
+
+    ```bash
+    echo "LLM_ENCRYPTION_SALT=$(openssl rand -hex 16)" >> .env
+    echo "LLM_ENCRYPTION_PASSWORD=$(openssl rand -hex 32)" >> .env
+    ```
+
+    Without them the container exits on boot with a message naming both.
+
+## Step 1 — the bootstrap credential
+
+A new node has no users, so the first credential comes from the environment:
+
+```bash
+echo "API_KEYS=$(openssl rand -hex 32)" >> .env
+docker compose up -d
+```
+
+Check it worked. `whoami` tells you who the node thinks you are:
+
+```bash
+curl -s http://localhost:8001/v1/api/identity/whoami \
+  -H "Authorization: Bearer $YOUR_API_KEY"
+```
+
+```json
+{
+  "key_id": "00000000-0000-0000-0000-000000000000",
+  "name": "Environment Key",
+  "permissions": ["read", "write", "admin"],
+  "account_id": "00000000-0000-0000-0000-000000000001",
+  "subject_did": null
+}
+```
+
+The all-zero `key_id` is the tell: this credential comes from the environment,
+not from storage. It carries `admin`, so it can create everything else.
+
+Without a token the same call returns:
+
+```json
+{"detail":"Missing authentication token. Expected 'Authorization: Bearer <token>' header"}
+```
+
+## Step 2 — create a named key
+
+You *can* write with the bootstrap token. You should not, for the same reason
+you don't hand out the root password: it is admin-scoped, it lives in your
+`.env`, and rotating it means restarting the node.
+
+Make a narrower key instead:
+
+```bash
+curl -s -X POST http://localhost:8001/v1/api/identity/keys \
+  -H "Authorization: Bearer $YOUR_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"name": "facility-editor", "permissions": ["read", "write"]}'
+```
+
+```json
+{
+  "key_id": "e987bb03-98dc-4562-bd8c-1be360998b2b",
+  "name": "facility-editor",
+  "permissions": ["read", "write"],
+  "created_at": "2026-08-29T04:04:08.532361",
+  "revoked": false,
+  "token": "cG0D1wKnYMwClHWv-Xw4yLYEwhhVyEWEfOdf3R5kD3Q"
+}
+```
+
+**Copy `token` now.** It is returned exactly once. Ask for the key again and the
+field is empty:
+
+```bash
+curl -s http://localhost:8001/v1/api/identity/keys \
+  -H "Authorization: Bearer $YOUR_API_KEY"
+```
+
+```json
+[{"key_id": "e987bb03-…", "name": "facility-editor", "revoked": false, "token": null}]
+```
+
+That is deliberate — the node stores a hash, not the secret. Lose it and you
+create another key; there is no recovery path, and that is the point.
+
+In the web interface the same thing lives under **Settings → Keys & accounts**,
+visible when your current credential carries `admin`.
+
+## Step 3 — use it
+
+Send it as a bearer token:
+
+```bash
+curl -s -X POST http://localhost:8001/v1/api/okw/create \
+  -H "Authorization: Bearer $WRITE_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"content": {
+        "name": "Lab Test Workshop",
+        "location": {"address": {"city": "Portland", "country": "US"}},
+        "facility_status": "Active"
+      }}'
+```
+
+`201` and the stored facility comes back with its `id`. Note the `content`
+wrapper — the facility goes inside it.
+
+In the web interface, paste the token into **Settings → Session** and the
+browser sends it for you. That is what the facility form means when it says you
+need a write key before saving.
+
+## Step 4 — revoke it when you're done
+
+```bash
+curl -s -X DELETE http://localhost:8001/v1/api/identity/keys/$KEY_ID \
+  -H "Authorization: Bearer $YOUR_API_KEY"
+```
+
+The next write with that token is refused:
+
+```
+401
+```
+
+and the key stays in the listing with `"revoked": true`, so the record of what
+existed does not disappear along with the access.
+
+## What to expect, in one table
+
+Measured on a node running 0.11.1 with `ENVIRONMENT=production`:
+
+| Request | Result |
+|---|---|
+| Read, no credential | `200` — reads are open |
+| Write, no credential | `401` |
+| Write, invalid token | `401` |
+| Write, valid write key | `201` |
+| Write, revoked key | `401` |
+
+On `ENVIRONMENT=development`, the second row is `201` instead. If that is not
+what you want, see the warning above.
+
+## Where to go next
+
+- [Use the OHM API](use-the-api.md#authenticating) — the wider API surface
+- [Run your own node](run-your-own-node.md#before-anyone-else-can-reach-it) — securing a node before it is reachable
+- [Who can see your data](who-can-see-your-data.md) — visibility, which is a separate question from write access

--- a/docs-site/docs/guides/run-your-own-node.md
+++ b/docs-site/docs/guides/run-your-own-node.md
@@ -50,21 +50,47 @@ that matters more than it sounds.
 
 ## Before anyone else can reach it
 
-**A node with no `API_KEYS` set accepts anonymous writes.** Anyone who can reach
-the port can create and delete designs. That is fine on a laptop and dangerous on
-a public IP.
+**A node in its default configuration accepts anonymous writes.** Anyone who can
+reach the port can create and delete designs. That is fine on a laptop and
+dangerous on a public IP.
 
-Set a credential before the node is reachable by anyone but you:
+Closing that takes **two** settings, and this is the part that catches people:
 
 ```bash
 echo "API_KEYS=$(openssl rand -hex 32)" >> .env
+echo "ENVIRONMENT=production" >> .env
 docker compose up -d
 ```
 
-Requests then carry it as `Authorization: Bearer <token>`, the same way the CLI
-and web interface do. This is also how you bootstrap the first credential on a
-new instance: there are no users yet, so `API_KEYS` is what you authenticate with
-to create everything else.
+`API_KEYS` supplies the credential. `ENVIRONMENT` decides whether one is
+*demanded*. Setting the key alone does not protect the node:
+
+| `ENVIRONMENT` | Anonymous write | Why |
+|---|---|---|
+| `development` (the default) | **Accepted, even with `API_KEYS` set** | Keeps dev and test flows frictionless |
+| `production` | Rejected, `401` | Write auth enforced |
+
+A key on a development node is accepted when you send it and not required when
+you don't — so if the node is reachable by anyone but you, `ENVIRONMENT` is the
+setting that matters. The `crisis` and `shielded` security modes enforce writes
+whatever `ENVIRONMENT` says.
+
+Reads stay open in every posture. It is writes that are gated.
+
+Requests carry the credential as `Authorization: Bearer <token>`, the same way
+the CLI and web interface do. This is also how you bootstrap the first
+credential on a new instance: there are no users yet, so `API_KEYS` is what you
+authenticate with to create everything else — see
+[get a write key](get-a-write-key.md) for creating narrower, revocable keys from
+it, which is what you want for anything beyond the first few minutes.
+
+A node in `production` also refuses to start without `LLM_ENCRYPTION_SALT` and
+`LLM_ENCRYPTION_PASSWORD`, which protect stored language-model credentials:
+
+```bash
+echo "LLM_ENCRYPTION_SALT=$(openssl rand -hex 16)" >> .env
+echo "LLM_ENCRYPTION_PASSWORD=$(openssl rand -hex 32)" >> .env
+```
 
 Redis is deliberately **not** published to your host — nothing outside the stack
 needs it, and an unauthenticated Redis reachable from the internet is a

--- a/docs-site/docs/guides/use-the-api.md
+++ b/docs-site/docs/guides/use-the-api.md
@@ -48,10 +48,15 @@ Authorization: Bearer <your-token>
 ```
 
 Read operations are generally open. Writes are checked against the credentials an
-instance is configured with — but note that **an instance started with no
-`API_KEYS` configured accepts anonymous writes**, so on a node you run, setting
-one is what turns write protection on. See
-[run your own node](run-your-own-node.md#before-anyone-else-can-reach-it).
+instance is configured with — but **whether they are checked at all depends on
+the node's posture**. A node running with the default `ENVIRONMENT=development`
+accepts anonymous writes even when `API_KEYS` is set; `ENVIRONMENT=production`
+returns `401` without a valid credential.
+
+So on a node you run, protecting writes takes both settings. See
+[get a write key](get-a-write-key.md) for the credential, and
+[run your own node](run-your-own-node.md#before-anyone-else-can-reach-it) for
+the posture.
 
 ## Two things worth knowing before you build
 

--- a/docs-site/mkdocs.yml
+++ b/docs-site/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
       - Run your own node: guides/run-your-own-node.md
       - Deploy a node on Azure: guides/deploy-a-node-on-azure.md
       - Deploy a cooking-domain instance: guides/deploy-a-cooking-domain-instance.md
+      - Get a write key: guides/get-a-write-key.md
       - Use the OHM API: guides/use-the-api.md
   - Contact: contact.md
   - Reference:

--- a/docs/architecture/federation-mvp-adr.md
+++ b/docs/architecture/federation-mvp-adr.md
@@ -10,7 +10,29 @@ Accepted
 
 ## Context
 
-OHM requires federated OKH design synchronization. Prior art ([notes/federation-prior-art-and-recommendations.md](../../notes/federation-prior-art-and-recommendations.md)) recommends a three-tier stack (physical mesh → LAN → internet). We need a minimal, testable slice before relay/registry, IPFS, or ActivityPub.
+OHM requires federated OKH design synchronization.
+
+A prior-art survey (OAI-PMH, Secure Scuttlebutt, IPFS, ActivityPub, CouchDB
+replication, Kademlia, mDNS/Zeroconf, disaster mesh networking, DIDs) pointed at
+a **three-tier discovery architecture**, each tier independent of the ones above
+it so the system degrades rather than fails:
+
+| Tier | Transport | Propagates |
+|---|---|---|
+| 1 — physical mesh | LoRa / Serval | content hashes, node names, summaries |
+| 2 — local LAN | mDNS / Zeroconf | full manifests, design metadata, replication sync |
+| 3 — internet | DHT + ActivityPub | full manifests and files, globally searchable |
+
+A node in a total blackout still propagates design hashes to neighbours over
+Tier 1; when WiFi returns, Tier 2 syncs manifests; when the internet returns,
+Tier 3 makes them globally discoverable.
+
+This ADR takes a minimal, testable slice of that before committing to relay,
+registry, IPFS, or ActivityPub.
+
+*The survey lives in the maintainers' working notes, which are not tracked in
+this repository — its conclusions are summarised above so this decision can be
+read and challenged without them.*
 
 ## Decision
 

--- a/docs/architecture/identity-model.md
+++ b/docs/architecture/identity-model.md
@@ -23,7 +23,7 @@ signature against the issuer's DID — no network, no central authority.
 ## Identities
 
 An identity is a keypair whose public half is encoded as a
-[`did:key`](https://w3c-ccg.github.io/did-method-key/) (the same primitive the
+[`did:key`](https://w3c-ccg.github.io/did-key-spec/) (the same primitive the
 federation node uses). Identities are minted for an **account** (person or space)
 and are **custodial** at first — the node holds the private key on the owner's
 behalf until they claim it.

--- a/frontend/src/features/okw/FacilityForm.tsx
+++ b/frontend/src/features/okw/FacilityForm.tsx
@@ -197,15 +197,14 @@ export function FacilityForm({ mode, facilityId, initialFacility }: Props) {
           <p className="mt-2 text-xs">
             Details:{" "}
             <a
-              href="https://docs.openhardwaremanager.org/auth/get-a-write-key/"
+              href="https://www.openhardwaremanager.org/docs/guides/get-a-write-key/"
               className="underline"
               target="_blank"
               rel="noreferrer"
             >
               Get a write key
-            </a>{" "}
-            (local:{" "}
-            <code className="text-xs">docs/auth/get-a-write-key.md</code>).
+            </a>
+            .
           </p>
         </div>
       )}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,6 +31,7 @@ A ✎ marks a script that **writes** files / storage / remote state; the rest ar
 
 | Script | What it does | Run |
 | --- | --- | --- |
+| `check_doc_links` | Fail when a documentation link cannot be followed: wrong host, an absolute link to a docs page that does not exist, or a repo-internal markdown link to a missing file. | `uv run python scripts/check_doc_links.py [--list]` |
 | `local_async_generation_e2e` | Localhost Compose e2e for async generate-from-url jobs, progress, revoke, and LLM credential gates. | `uv run python scripts/local_async_generation_e2e.py` |
 | `validate_docs` | Validate documentation claims against the code implementation. | `uv run python scripts/validate_docs.py` |
 | `validate_okw_in_storage` | Read configured storage (local or remote) and report the OKW facilities found — quick config sanity check. | `uv run python scripts/validate_okw_in_storage.py` |

--- a/scripts/check_doc_links.py
+++ b/scripts/check_doc_links.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Fail when a documentation link cannot be followed to a real page.
+
+Three classes of rot, none of which mkdocs catches on its own:
+
+1. **Wrong host.** `docs.openhardwaremanager.org` does not resolve; the docs are
+   served at `www.openhardwaremanager.org/docs/`. The facility form pointed at
+   the former for months.
+2. **Absolute links into our own docs.** mkdocs validates relative links between
+   pages and treats anything with a scheme as external, so a link to
+   `www.openhardwaremanager.org/docs/guides/nope/` is never checked — including
+   from the frontend, which is where most of them live.
+3. **Repo-internal markdown links.** Cross-links between `docs/`, `deploy/` and
+   the README point at files, not pages, and nothing validated them.
+
+Resolves against the SOURCE tree rather than a built site, so the gate needs no
+mkdocs run. Pages generated at build time (`reference/whats-built.md`) exist only
+in the output, so nav entries count as valid targets alongside files on disk.
+
+    python scripts/check_doc_links.py            # check
+    python scripts/check_doc_links.py --list     # print every link it resolved
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs-site" / "docs"
+SITE_HOSTS = {"openhardwaremanager.org", "www.openhardwaremanager.org"}
+WRONG_HOSTS = {"docs.openhardwaremanager.org"}
+SKIP_DIRS = {
+    ".git",
+    "node_modules",
+    ".venv",
+    "docs-dist",
+    ".next",
+    "site",
+    "artifacts",
+    "storage",
+}
+
+MD_LINK = re.compile(r"\[[^\]]*\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
+HREF = re.compile(r"href=[\"']([^\"']+)[\"']")
+
+
+def nav_targets() -> set[str]:
+    """Page paths named in mkdocs nav, which may be generated rather than on disk."""
+    cfg = ROOT / "docs-site" / "mkdocs.yml"
+    if not cfg.exists():
+        return set()
+    return {
+        m.group(1).removesuffix(".md")
+        for m in re.finditer(r":\s*([A-Za-z0-9_\-/]+\.md)\s*$", cfg.read_text(), re.M)
+    }
+
+
+def doc_pages() -> set[str]:
+    pages = (
+        {p.relative_to(DOCS).as_posix().removesuffix(".md") for p in DOCS.rglob("*.md")}
+        if DOCS.exists()
+        else set()
+    )
+    pages |= nav_targets()
+    pages |= {"", "index"}
+    return pages
+
+
+def sources() -> list[tuple[Path, str]]:
+    out: list[tuple[Path, str]] = []
+    for p in ROOT.rglob("*.md"):
+        if SKIP_DIRS & set(p.relative_to(ROOT).parts):
+            continue
+        out.append((p, p.read_text(errors="ignore")))
+    for base in (ROOT / "frontend" / "src", ROOT / "frontend" / "app"):
+        if not base.exists():
+            continue
+        for pat in ("**/*.ts", "**/*.tsx"):
+            for p in base.glob(pat):
+                if SKIP_DIRS & set(p.relative_to(ROOT).parts):
+                    continue
+                out.append((p, p.read_text(errors="ignore")))
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--list", action="store_true", help="print every resolved link")
+    args = ap.parse_args()
+
+    pages = doc_pages()
+    problems: list[str] = []
+    checked = 0
+
+    for f, text in sources():
+        rel_f = f.relative_to(ROOT).as_posix()
+        in_docs = rel_f.startswith("docs-site/docs/")
+        for m in list(MD_LINK.finditer(text)) + list(HREF.finditer(text)):
+            raw = m.group(1).strip()
+            if (
+                raw.startswith(("mailto:", "tel:", "data:", "#", "{"))
+                or "${" in raw
+                or "<" in raw
+            ):
+                continue
+            line = text.count("\n", 0, m.start()) + 1
+            where = f"{rel_f}:{line}"
+            u = urlparse(raw)
+            host = u.netloc.lower()
+
+            if host in WRONG_HOSTS:
+                problems.append(
+                    f"{where}\n      {raw}\n"
+                    f"      -> {host} does not serve the docs; use www.openhardwaremanager.org/docs/"
+                )
+                continue
+
+            if host and host not in SITE_HOSTS:
+                continue  # genuinely external; not this gate's business
+
+            if host in SITE_HOSTS:
+                path = unquote(u.path)
+                if not path.startswith("/docs"):
+                    continue  # an app route, not a docs link
+                target = path[len("/docs") :].strip("/")
+                checked += 1
+                if target not in pages:
+                    problems.append(
+                        f"{where}\n      {raw}\n      -> no docs page {target!r}"
+                    )
+                continue
+
+            if raw.startswith(("http://", "https://")):
+                continue
+
+            if in_docs:
+                continue  # relative links between docs pages: mkdocs validates these
+
+            if f.suffix != ".md":
+                # A bare path in application source is a ROUTE, not a file --
+                # `/settings/session` is a page the router serves. Only the two
+                # checks above (wrong host, absolute docs link) apply to code.
+                continue
+
+            # repo-internal markdown link -> a real file on disk
+            path = unquote(u.path)
+            if not path:
+                continue
+            target_p = (
+                (ROOT / path.lstrip("/")) if raw.startswith("/") else (f.parent / path)
+            )
+            target_p = Path(os.path.normpath(target_p))
+            checked += 1
+            if target_p.exists():
+                continue
+            if any(Path(f"{target_p}{ext}").exists() for ext in (".md", ".html")):
+                continue
+            if (target_p / "index.md").exists() or (target_p / "README.md").exists():
+                continue
+            problems.append(f"{where}\n      {raw}\n      -> missing file")
+
+    if args.list:
+        print(f"checked {checked} link(s) across {len(sources())} file(s)")
+
+    if problems:
+        print(f"Broken documentation links ({len(problems)}):\n", file=sys.stderr)
+        for p in problems:
+            print(f"  {p}\n", file=sys.stderr)
+        return 1
+
+    print(f"OK: {checked} documentation link(s) resolve")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/registry.toml
+++ b/scripts/registry.toml
@@ -43,6 +43,13 @@ run = "uv run python scripts/generate_env_template.py [--check]"
 mutates = true
 used_by = ["make ready (env-template-check)", "ci: quality"]
 
+[scripts.check_doc_links]
+category = "verify"
+summary = "Fail when a documentation link cannot be followed: wrong host, an absolute link to a docs page that does not exist, or a repo-internal markdown link to a missing file."
+run = "uv run python scripts/check_doc_links.py [--list]"
+mutates = false
+used_by = ["make ready (links-check)", "ci: quality"]
+
 [scripts.generate_repo_map]
 category = "generate"
 summary = "Generate .repo-map.md (Aider + Sourcegraph styles) for codebase navigation; --check gates staleness."

--- a/tests/parity/manifest.py
+++ b/tests/parity/manifest.py
@@ -845,6 +845,12 @@ SITE_DOCS: tuple[SiteDoc, ...] = (
         path="guides/deploy-a-cooking-domain-instance.md",
     ),
     SiteDoc(
+        "identity",
+        "Get a write key",
+        "deployed",
+        path="guides/get-a-write-key.md",
+    ),
+    SiteDoc(
         "api",
         "Use the OHM API from your own software",
         "deployed",


### PR DESCRIPTION
Closes the documentation-link inventory: writes the guide the app was already
linking to, corrects a security claim that was wrong in two places, fixes the
remaining broken links, and adds a gate so this class of rot fails CI.

Found while testing the new facility workflow — the "get a write key" link on
`/facilities/new` pointed at `docs.openhardwaremanager.org/auth/get-a-write-key/`.
That host does not resolve, and the page did not exist on the host that does.

## 1. The guide, written from a live transcript

`docs-site/docs/guides/get-a-write-key.md`. The page was never written; only the
links to it were, in two forms — the dead URL, and a local path
(`docs/auth/get-a-write-key.md`) that also does not exist.

Built against a real 0.11.1 node in Docker, then **verified by tearing that node
down with its volumes, starting a fresh one, and replaying the page's own
commands**:

```
STEP 1  whoami with bootstrap    ✓ Environment Key, ✓ all-zero key_id
STEP 1b whoami with no token     ✓ error text matches
STEP 2  create named key         ✓ token returned
STEP 2b list keys                ✓ token is null
STEP 3  write with named key     ✓ 201
STEP 4  revoke                   ✓ 200
STEP 4b write with revoked key   ✓ 401
STEP 4c listing                  ✓ revoked=true
REPLAY RESULT: every documented step reproduced
```

Every JSON response in the page is pasted from a real call.

## 2. A security claim that was wrong — in two places

**`API_KEYS` alone does not turn write protection on.** With `API_KEYS` set and
the default `ENVIRONMENT=development`, an anonymous `POST /okw/create` returns
**201**. `require_write` consults
`get_security_policy().require_auth_for_writes`, which in peacetime resolves
from `is_production_like(ENVIRONMENT)`.

Measured on the same node under `ENVIRONMENT=production`:

| Request | Result |
|---|---|
| read, no credential | `200` |
| write, no credential | **`401`** |
| write, invalid token | `401` |
| write, valid key | `201` |
| write, revoked key | `401` |

`run-your-own-node.md` said setting `API_KEYS` is what turns write protection
on. That page is specifically about making a node safe to expose, so an operator
following it would have set a key, believed the node closed, and left it open.

`use-the-api.md` said the same thing in different words. My first sweep missed
it because the phrasing differed — it was caught by re-reading the page rather
than trusting one grep.

Both now name both settings. `run-your-own-node.md` also documents the
`LLM_ENCRYPTION_*` pair a production node needs to boot, which is how the test
node first failed to start.

Headings are unchanged: two pages link to `#before-anyone-else-can-reach-it`,
and the anchor is verified present in the built HTML.

## 3. The remaining broken links

- **`did:key`** — `w3c-ccg.github.io/did-method-key/` 404s. The CCG renamed the
  project: the old GitHub repo redirects to `did-key-spec`, and the new URL
  serves *"The did:key Method v0.9"*. Confirmed by reading the document, not by
  inferring from the URL.
- **Terraform example** — pointed at `../README.md` for "the full multi-peer
  federation lab". That parent exists one level up and does document the lab.
  Off-by-one path, not a missing document.
- **Federation ADR** — cited `notes/…` for its prior art, but `notes/` is
  gitignored, so the evidence was unreadable by anyone but the maintainer. The
  survey's conclusion is now inlined, checked against the note itself. *(Open
  question for review: the alternative was committing the note. Inlining assumes
  `notes/` should stay scratch space — say if you'd rather it were public.)*
- **`enable-the-site-layer.md`** — sent readers to `github.com/binaryLady/OHM`
  for two files that have been ours since #360. Both links resolved, which is
  why no checker flagged them. Historical references in
  `docs/design/ux-overhaul-playbook.md` are deliberately left: those are about
  the contributor's own PR history.

## 4. The gate

`scripts/check_doc_links.py`, wired in as **step 14/14** of `make ready`.

mkdocs validates relative links between pages and treats anything with a scheme
as external — which is exactly the gap the facility form fell through. This
catches the three classes nothing was checking: the wrong host, absolute links
into our own docs, and repo-internal markdown links to missing files.

Resolves against the source tree, so it needs no mkdocs build; nav entries count
as targets alongside files on disk, because `reference/whats-built.md` is
generated.

**Verified it fails, not just passes** — injecting one of each class produced
exactly three findings and exit 1. Worth recording that its first draft reported
**17 false positives**, reading frontend route hrefs like `/settings/session` as
file paths; the file rule now applies to markdown only, since a bare path in
application source is a route. Wiring it in before running it would have shipped
a gate that failed on correct code.

## Verification

- `make ready` **14/14**
- link checker: 153 links resolve
- both anchors the new guide depends on confirmed in the built HTML
- docs build clean under mkdocs with `unrecognized_links`/`anchors`/
  `absolute_links` forced to `warn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xZwk3HaL58YzvYQF8KKJS
