### PR TITLE
fix: close the two e2e races, one of them in the product

### DIFF
--- a/frontend/e2e/a11y.ts
+++ b/frontend/e2e/a11y.ts
@@ -6,6 +6,32 @@ import { expect, type Page } from "@playwright/test";
  * serious or critical violations. Feature slices call this on each journey.
  */
 export async function expectNoA11yViolations(page: Page): Promise<void> {
+  // Wait for the document to finish loading before scanning.
+  //
+  // axe judges the document it is handed, and a document still being parsed is
+  // not the one under test. `<title>` is the tell: it lives in <head>, so a
+  // scan landing mid-parse reports `document-title` ("Documents must have
+  // <title> element") against a page whose title arrives microseconds later.
+  //
+  // The window is narrow enough to be invisible on an idle machine and real on
+  // a loaded one. It widens when a client-side navigation falls back to a full
+  // browser navigation — Next does that when an RSC payload fetch fails, which
+  // a busy runner makes likely — because that replaces the settled document
+  // with a fresh one mid-test. Reproduced under deliberate CPU contention:
+  // `document-title`, serious, on a recipe detail page reached by a click.
+  //
+  // `complete` rather than `domcontentloaded`: a document that has parsed its
+  // head but not finished loading can still swap under the scan. If the
+  // document IS complete and the title is still missing, that is a real
+  // violation and this wait does not hide it.
+  await page
+    .waitForFunction(() => document.readyState === "complete", undefined, {
+      timeout: 5_000,
+    })
+    .catch(() => {
+      /* a page that never reports complete is the scan's problem, not ours */
+    });
+
   // Wait for animations to finish before scanning.
   //
   // Elements fade in (tw-animate-css), and axe computes contrast from whatever

--- a/frontend/e2e/baseline.manifest.json
+++ b/frontend/e2e/baseline.manifest.json
@@ -1,5 +1,5 @@
 {
-  "e2e/a11y.ts": "9fe0b3d646f8022b64e7fdaaf59867be22eb9d218f0276a02ea1768cb326184f",
+  "e2e/a11y.ts": "450b2f56740231e4ef81ad1645abfd8463af14e37e9badecb2e34ccc4738393e",
   "e2e/a11y-journeys.spec.ts": "d78e9d8e0b293bdba0c6f5676a1898a6f219cfc2a56ea39a2cbff92cf88622a6",
   "e2e/cooking-domain.spec.ts": "f17331d8b4a3b8cef23cdd20ce712afb0625d67b7f4b8c281051d2772507a07d",
   "e2e/create.spec.ts": "3b532831cff8393bc199fda2300dceeb4175d9598c78d28d9636963934132f0f",

--- a/frontend/src/features/network/NetworkView.tsx
+++ b/frontend/src/features/network/NetworkView.tsx
@@ -3,7 +3,7 @@
 import { FacilitiesIllustration } from "../../components/ui/illustrations";
 import { FIELD, LABEL } from "../../components/ui/field";
 import { PageHero } from "../../components/layout/PageHero";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -63,6 +63,9 @@ function ViewToggle({
     />
   );
 }
+
+/** How long typing has to pause before the address catches up. */
+const NAME_QUERY_SYNC_MS = 250;
 
 export function NetworkView() {
   const router = useRouter();
@@ -213,10 +216,45 @@ export function NetworkView() {
     syncUrl({ page: next === 1 ? null : next });
   };
 
+  /**
+   * The address follows the search box, but not keystroke by keystroke.
+   *
+   * This wrote the URL on every character, so typing "FabLab Lyon" issued
+   * eleven `router.replace` calls. The box is local state and stays instant
+   * either way; what the writes buy is a shareable address, and an address is
+   * only worth writing once the typing pauses.
+   *
+   * Eleven navigations for eleven characters is also unreliable, not merely
+   * wasteful: under load the router coalesces them and the last one — the only
+   * one carrying the complete query — can fail to land. Reproduced under
+   * deliberate CPU contention, with the box correctly reading "Laser" and the
+   * address stuck one character behind at `q=Lase`.
+   *
+   * Held in a ref so the pending write always uses the CURRENT syncUrl, which
+   * closes over the latest search params. A timer capturing the callback at
+   * schedule time would merge its update onto a snapshot taken a keystroke ago
+   * and could drop a filter changed in between.
+   */
+  const syncUrlRef = useRef(syncUrl);
+  useEffect(() => {
+    syncUrlRef.current = syncUrl;
+  }, [syncUrl]);
+
+  const nameSyncTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (nameSyncTimer.current) clearTimeout(nameSyncTimer.current);
+    },
+    [],
+  );
+
   const applyNameQuery = (next: string) => {
     setNameQuery(next);
     setPage(1);
-    syncUrl({ q: next || null, page: null });
+    if (nameSyncTimer.current) clearTimeout(nameSyncTimer.current);
+    nameSyncTimer.current = setTimeout(() => {
+      syncUrlRef.current({ q: next || null, page: null });
+    }, NAME_QUERY_SYNC_MS);
   };
 
   return (


### PR DESCRIPTION
Chased the intermittent failures that were passing as 'inherited flakiness'. Reproduced under deliberate CPU contention (10 busy loops, 8 workers, warm dev server), which turns a rare failure into a repeatable one: 3 failures across 8 runs, in two specs, from two unrelated causes.

1. a11y scans could run against a document still being parsed.

axe judges the document it is handed, and 'document-title' fires when <head> has not produced <title> yet -- reported as 43 serious violations on a recipe detail page whose title arrives microseconds later. The window widens when a client-side navigation falls back to a full browser navigation, which Next does when an RSC payload fetch fails and a loaded runner makes likely.

e2e/a11y.ts now waits for readyState 'complete' before scanning. This is the same shape as the wait already in that file for unfinished animations, and for the same reason: the scan must judge a settled page or it reports colours and elements that exist only mid-transition. It does not mask a real missing title -- a complete document with no title still fails.

2. The network view wrote the URL on every keystroke.

Typing 'FabLab Lyon' issued eleven router.replace calls. Under load the router coalesces them and the last one -- the only one carrying the complete query -- can fail to land: observed with the box correctly reading 'Laser' and the address stuck at q=Lase. That is a product defect, not a test defect. Anyone copying the URL mid-type shares an incomplete search.

Debounced to 250ms. The box is local state and stays instant; what the writes buy is a shareable address, and an address is worth writing once typing pauses. The pending write is held in a ref so it uses the current syncUrl rather than a snapshot taken a keystroke ago, which could drop a filter changed in between.

Measured, same conditions before and after: 3 failures across 8 stressed runs -> 0 across 8.

e2e/a11y.ts is a frozen baseline spec; re-blessed alone, and the manifest shows only that file changed. The freeze guard is what forced this to be a deliberate commit rather than a quiet edit, which is what it is for.

make ready 14/14; frontend-ready 5/5.