### PR TITLE
chore: guard against measuring a test run on the wrong server

### DIFF
--- a/.claude/hooks/no-build-while-serving.sh
+++ b/.claude/hooks/no-build-while-serving.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) guard: refuse a frontend build while a server is serving the
+# build directory it is about to overwrite.
+#
+# `next build` rewrites .next in place. A `next dev` or `next start` already
+# serving from that directory does not reload cleanly when it is replaced mid-
+# flight; it keeps answering, but with a mixture of the old manifest and the new
+# chunks. Playwright then makes it worse: `reuseExistingServer: !CI` means the
+# next test run ATTACHES to that corrupted server instead of starting a clean
+# one, so the failures look like they belong to the code under test.
+#
+# This bit once, while verifying a fix: 18 specs "failed" across every run and
+# the change looked like a regression. The same suite against a freshly started
+# server passed 21/21. The code had never been wrong.
+#
+# Fix is to stop the server first, or build somewhere it is not serving from.
+set -euo pipefail
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | python3 -c \
+  "import sys,json; print(json.load(sys.stdin).get('tool_input',{}).get('command',''))" \
+  2>/dev/null || true)
+
+# Only guard commands that actually rebuild the frontend.
+if ! printf '%s' "$cmd" | grep -qE '(npm|pnpm|yarn)[[:space:]]+run[[:space:]]+build|next[[:space:]]+build'; then
+  exit 0
+fi
+
+# The port the app is served on. harness.config.json is the source of truth;
+# fall back to the Next/Vite default this repo uses.
+PORT=$(python3 -c "
+import json,re,sys
+try:
+    url = json.load(open('${CLAUDE_PROJECT_DIR:-.}/frontend/harness.config.json'))['appUrl']
+    m = re.search(r':(\d+)', url)
+    print(m.group(1) if m else 5173)
+except Exception:
+    print(5173)
+" 2>/dev/null || echo 5173)
+
+if lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+  holder=$(lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -Fc 2>/dev/null | sed -n 's/^c//p' | head -1)
+  echo "Blocked: a server (${holder:-unknown}) is listening on :$PORT, and this command rewrites the build directory it is serving from." >&2
+  echo "Overwriting .next under a running server leaves it answering with a mix of old and new output. Playwright's reuseExistingServer then attaches the NEXT test run to that server, and the failures read as though they belong to your change." >&2
+  echo "Fix: stop it first -> lsof -ti:$PORT | xargs kill -9   (then build, then let Playwright start a clean one)" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,10 @@
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/fetch-origin-before-worktree.sh",
             "statusMessage": "Refreshing origin/main",
             "timeout": 60
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/no-build-while-serving.sh"
           }
         ]
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,30 @@ docs land in the **same change**. If a service is intentionally not exposed,
 record it as a row in `tests/parity/manifest.py` rather than leaving it
 unaccounted for — `make parity` will fail until you do.
 
+## Measuring against a server
+
+`make ready` and `frontend-ready` start their own servers and are safe to trust.
+Anything you run by hand against `localhost:5173` is not, because Playwright's
+`reuseExistingServer` attaches to whatever is already there.
+
+**Before blaming the code for a test result, confirm the environment under test
+is the one you think it is.** Two specific traps, both of which have produced
+failures that read as regressions and were not:
+
+- **A build under a running server.** `next build` rewrites `.next` in place; a
+  server already serving it answers with a mix of old and new. A hook now blocks
+  this (`.claude/hooks/no-build-while-serving.sh`), but the shape generalises to
+  anything that regenerates what a running process is reading.
+
+- **Cold versus warm servers in a before/after comparison.** `next dev` compiles
+  routes on first hit, so a cold server under parallel load times out across
+  unrelated specs — 35 failures in one run here, none of them real. A
+  measurement is only a comparison when both sides had the same warm-up. Warm
+  the server with one discarded run, then measure.
+
+When a result is surprising, re-run it against a server you started yourself
+before reasoning about the diff.
+
 ## Skills
 
 - [Setup wizard](.claude/skills/setup/SKILL.md) — natural language setup, configuration Q&A, and documentation lookup for OHM


### PR DESCRIPTION
Tooling only — no application code. Turns two methodology mistakes from #367
into guards, so they cannot be repeated silently.

Both mistakes had the same shape: **a test suite run against a server whose
state I had not established, with the failures then attributed to the code.**
Neither was a real regression, and both cost a cycle to unwind.

## The hook — `no-build-while-serving.sh`

`next build` rewrites `.next` in place. A server already serving from that
directory does not fail; it keeps answering, with a mixture of the old manifest
and the new chunks. Playwright's `reuseExistingServer: !CI` then attaches the
*next* run to that server, so the failures arrive looking like they belong to
the change under test.

This cost **18 phantom spec failures** while verifying a fix. The same suite
against a freshly started server passed **21/21**. The code had never been
wrong.

The hook blocks a build command while something is listening on the app port,
reading that port from `frontend/harness.config.json` rather than hardcoding it.

Verified in both directions, because a guard that cannot fire is worse than
none:

| Command | No server | Server on :5173 |
|---|---|---|
| `npm run build` | pass | **blocked** |
| `cd frontend && npm run build` | pass | **blocked** |
| `npx next build` | pass | **blocked** |
| `git status`, `npm run test:unit` | pass | pass |

## The rule — `CLAUDE.md` § "Measuring against a server"

The second mistake resists a hook, and I want to be explicit that this is the
ladder's fallback rather than a shortcut past it: nothing in a single tool call
reveals that the *previous* measurement used a warm server and this one will
not.

A before/after comparison where one side hit a cold `next dev` server produced
**35 failures across unrelated specs** — lazy route compilation under parallel
load, none of them real. A measurement is only a comparison when both sides had
the same warm-up.

The rule says: warm the server with one discarded run, then measure; and re-run
a surprising result against a server you started yourself before reasoning about
the diff.

## Verification

`make ready` **14/14**, before and after rebasing onto current `main`.

Logged in `~/.claude/lessons/ledger.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xZwk3HaL58YzvYQF8KKJS
