### PR TITLE
Fix domain-aware matching and the supply-tree render crash (#369)

### DIFF
--- a/frontend/e2e/baseline.manifest.json
+++ b/frontend/e2e/baseline.manifest.json
@@ -13,7 +13,7 @@
   "e2e/okw-detail.spec.ts": "84672b2fa941991a5ca8b9d955b78a4fb965765b4670a84d0636b36023c78611",
   "e2e/packages.spec.ts": "699c2925d6fe9d7c92d3953d01c60fe14413f492bdf8d91d98d6deaf1826d3c2",
   "e2e/screenshots.spec.ts": "eb4008838981492fb137297ed9d19d8963d749ec70be8e36d740d49368819fe6",
-  "e2e/settings.spec.ts": "fdfcd3fae302bda0419d66e68cbd60475f4a2557b5addc1837dee786e2987d03",
+  "e2e/settings.spec.ts": "0b7c44c1fc789635b8bc04f52f608c442e522cd3df4bcfa7484227df736f4310",
   "e2e/smoke.spec.ts": "1cb24ba4497809473f8fc6f20e8e3ba95f1e17c65a9072b4e2eada0cab04fce8",
   "e2e/visualization.spec.ts": "c77b98b75805bc08c941f7039a4666525c055938c669d54413f5a6fde2b36128"
 }

--- a/frontend/e2e/settings.spec.ts
+++ b/frontend/e2e/settings.spec.ts
@@ -88,7 +88,10 @@ test("settings identities / grants / spaces tabs (F3)", async ({
   await expect(page.getByText("vouch")).toBeVisible();
   await expectNoA11yViolations(page);
 
+  // Same race as the Grants transition above — these three were left without
+  // the wait when it was added.
   await page.getByRole("link", { name: "Bindings" }).click();
+  await page.waitForURL(/\/settings\/bindings(\?|$)/);
   await expect(
     page.getByRole("heading", { name: "Domain bind" }),
   ).toBeVisible();
@@ -106,6 +109,7 @@ test("settings identities / grants / spaces tabs (F3)", async ({
   await expectNoA11yViolations(page);
 
   await page.getByRole("link", { name: "Directory" }).click();
+  await page.waitForURL(/\/settings\/directory(\?|$)/);
   await expect(
     page.getByRole("heading", { name: "Directory", exact: true }),
   ).toBeVisible();
@@ -113,6 +117,7 @@ test("settings identities / grants / spaces tabs (F3)", async ({
   await expectNoA11yViolations(page);
 
   await page.getByRole("link", { name: "Federation" }).click();
+  await page.waitForURL(/\/settings\/federation(\?|$)/);
   await expect(
     page.getByRole("heading", { name: "Node status" }),
   ).toBeVisible();

--- a/frontend/src/api/ohm/match.ts
+++ b/frontend/src/api/ohm/match.ts
@@ -191,6 +191,9 @@ export async function fetchDesignsForFacility(
 }
 
 export interface MatchDomain {
+  /** The key the API matches on ("manufacturing"). */
+  id: string;
+  /** Display label ("Manufacturing & Hardware Production"). Not a valid `domain`. */
   name: string;
   status?: string | null;
   version?: string | null;

--- a/frontend/src/api/ohm/supply-tree.ts
+++ b/frontend/src/api/ohm/supply-tree.ts
@@ -129,8 +129,15 @@ export async function extendSolutionTtl(
   }
 }
 
+/** A top-level component in a solution's hierarchy — an object, not an id. */
+export interface RootComponent {
+  component_id: string;
+  component_name: string;
+  tree_id: string;
+}
+
 export interface SolutionHierarchy {
-  root_components: string[];
+  root_components: RootComponent[];
   component_details: Record<string, unknown>;
   summary: {
     total_components?: number;
@@ -166,7 +173,11 @@ export async function fetchSolutionHierarchy(
   const body = (data ?? {}) as Record<string, unknown>;
   const payload = (body.data as Record<string, unknown>) ?? body;
   return {
-    root_components: (payload.root_components as string[]) ?? [],
+    // Still an assertion, now of the shape the API really returns. The route
+    // has no response model, so codegen types nothing here and the compiler
+    // cannot check this. Replaced by a generated type and a parsed boundary
+    // in #370/#373 — until then this is the seam a drift comes through.
+    root_components: (payload.root_components as RootComponent[]) ?? [],
     component_details:
       (payload.component_details as Record<string, unknown>) ?? {},
     summary: (payload.summary as SolutionHierarchy["summary"]) ?? {},

--- a/frontend/src/components/ui/PanelBoundary.test.tsx
+++ b/frontend/src/components/ui/PanelBoundary.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { PanelBoundary } from "./PanelBoundary";
+
+function Throws(): never {
+  throw new Error("bad payload shape");
+}
+
+describe("PanelBoundary", () => {
+  beforeEach(() => {
+    // React logs the caught error itself; the boundary logs it again on
+    // purpose. Neither is a test failure, and both are noise here.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders its children when nothing throws", () => {
+    render(
+      <PanelBoundary label="Components">
+        <p>the panel</p>
+      </PanelBoundary>,
+    );
+    expect(screen.getByText("the panel")).toBeInTheDocument();
+  });
+
+  it("names the failed panel and leaves its siblings standing", () => {
+    render(
+      <div>
+        <p>the graph</p>
+        <PanelBoundary label="Components">
+          <Throws />
+        </PanelBoundary>
+      </div>,
+    );
+    expect(screen.getByText("Components")).toBeInTheDocument();
+    expect(screen.getByText(/could not be displayed/i)).toBeInTheDocument();
+    // The whole point: a panel costs a panel, not the view.
+    expect(screen.getByText("the graph")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/PanelBoundary.tsx
+++ b/frontend/src/components/ui/PanelBoundary.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Component, type ReactNode } from "react";
+import { PANEL, PANEL_BODY } from "./surface";
+import { BODY_MUTED, CARD_TITLE } from "./typography";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  /** Names the panel in the fallback, so a reader knows what is missing. */
+  label: string;
+  children: ReactNode;
+}
+
+interface State {
+  failed: boolean;
+}
+
+/**
+ * A boundary around one optional panel.
+ *
+ * `app/error.tsx` catches a throw already, but it is route-scoped: it replaces
+ * the whole view, so one secondary panel costs the graph and the KPIs with it.
+ * A panel's own `isError` handling covers only *fetch* failure — a render that
+ * throws is above it.
+ *
+ * No retry, deliberately: re-rendering the same bad payload throws again. The
+ * route boundary's "Try again" re-fetches, which can actually change it.
+ */
+export class PanelBoundary extends Component<Props, State> {
+  state: State = { failed: false };
+
+  static getDerivedStateFromError(): State {
+    return { failed: true };
+  }
+
+  componentDidCatch(error: Error) {
+    // The console is this app's only sink (see app/error.tsx). Containing a
+    // failure silently would be a worse trade than the crash it replaces.
+    console.error(`Panel "${this.props.label}" failed to render:`, error);
+  }
+
+  render() {
+    if (!this.state.failed) return this.props.children;
+
+    // role="status" already implies a polite live region, which is what
+    // announces a panel that fails on a re-render rather than on mount.
+    return (
+      <section role="status" className={cn(PANEL, PANEL_BODY)}>
+        {/* Not SectionHeading: that renders a permalink, and a failure state
+            is not a destination. */}
+        <h2 className={CARD_TITLE}>{this.props.label}</h2>
+        <p className={cn(BODY_MUTED, "mt-2")}>
+          This panel could not be displayed. The rest of the page is unaffected.
+        </p>
+      </section>
+    );
+  }
+}

--- a/frontend/src/features/match/MatchView.domainSelector.test.tsx
+++ b/frontend/src/features/match/MatchView.domainSelector.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+vi.mock("../../api/ohm/network", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/ohm/network")>();
+  return { ...actual, fetchNetworkSpaces: vi.fn() };
+});
+vi.mock("../../api/ohm/okh", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/ohm/okh")>();
+  return { ...actual, fetchAllOkhList: vi.fn() };
+});
+
+import { MatchView } from "./MatchView";
+import type { MatchDomain } from "../../api/ohm/match";
+import { fetchNetworkSpaces, type NetworkData } from "../../api/ohm/network";
+import { fetchAllOkhList } from "../../api/ohm/okh";
+
+/**
+ * The domains the API really returns: `id` is the key it matches on, `name` is
+ * a human label, and the two are different strings.
+ */
+const domains: MatchDomain[] = [
+  {
+    id: "manufacturing",
+    name: "Manufacturing & Hardware Production",
+    status: "available",
+  },
+  { id: "cooking", name: "Cooking & Food Preparation", status: "available" },
+];
+
+function renderView() {
+  const emptyNetwork: NetworkData = {
+    spaces: [],
+    total: 0,
+    local_count: 0,
+    mom_count: 0,
+    dropped_no_coords: 0,
+    mom_available: false,
+  };
+  vi.mocked(fetchNetworkSpaces).mockResolvedValue(emptyNetwork);
+  vi.mocked(fetchAllOkhList).mockResolvedValue({
+    items: [],
+    pagination: {
+      page: 1,
+      page_size: 100,
+      total_items: 0,
+      total_pages: 0,
+      has_next: false,
+      has_previous: false,
+    },
+  });
+
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  client.setQueryData(["match-domains"], domains);
+  return render(
+    <QueryClientProvider client={client}>
+      <MatchView />
+    </QueryClientProvider>,
+  );
+}
+
+describe("MatchView domain selector", () => {
+  it("submits the domain key while showing the display name", async () => {
+    renderView();
+
+    const select = (await screen.findByLabelText(/Domain/i)) as HTMLSelectElement;
+    const options = Array.from(select.options);
+
+    // The regression: the option value must be the key the API matches on.
+    // Binding it to the label sent "Manufacturing & Hardware Production" as
+    // `domain` and the server answered "Unsupported domain".
+    expect(options.map((o) => o.value)).toEqual([
+      "",
+      "manufacturing",
+      "cooking",
+    ]);
+    expect(options.map((o) => o.textContent?.trim())).toEqual([
+      "Detect automatically",
+      "Manufacturing & Hardware Production",
+      "Cooking & Food Preparation",
+    ]);
+  });
+
+  it("keeps an empty value for automatic detection, which the server treats as absent", async () => {
+    renderView();
+    const select = (await screen.findByLabelText(/Domain/i)) as HTMLSelectElement;
+    expect(select.value).toBe("");
+  });
+});

--- a/frontend/src/features/match/MatchView.tsx
+++ b/frontend/src/features/match/MatchView.tsx
@@ -326,7 +326,7 @@ export function MatchView({
                 >
                   <option value="">Detect automatically</option>
                   {domains.data?.map((d) => (
-                    <option key={d.name} value={d.name}>
+                    <option key={d.id} value={d.id}>
                       {d.name}
                       {d.status && d.status !== "available"
                         ? ` (${d.status})`

--- a/frontend/src/features/visualization/ComponentsPanel.test.tsx
+++ b/frontend/src/features/visualization/ComponentsPanel.test.tsx
@@ -1,0 +1,65 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { SolutionHierarchy } from "../../api/ohm/supply-tree";
+import { ComponentsPanel } from "./ComponentsPanel";
+
+/**
+ * The shape the API actually returns.
+ *
+ * Root components are objects, not ids. Rendering one directly puts an object
+ * where React expects a node, which is error #31 — the crash that took down
+ * the whole visualization view.
+ */
+const hierarchy: SolutionHierarchy = {
+  root_components: [
+    {
+      component_id: "frame",
+      component_name: "Frame",
+      tree_id: "11111111-1111-1111-1111-111111111111",
+    },
+    {
+      component_id: "pump",
+      component_name: "Pump assembly",
+      tree_id: "22222222-2222-2222-2222-222222222222",
+    },
+  ],
+  component_details: {},
+  summary: {
+    total_components: 2,
+    root_components: 2,
+    total_trees: 2,
+    max_depth: 3,
+  },
+};
+
+function renderPanel(data: SolutionHierarchy) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  client.setQueryData(["solution-hierarchy", "sol-1"], data);
+  return render(
+    <QueryClientProvider client={client}>
+      <ComponentsPanel solutionId="sol-1" />
+    </QueryClientProvider>,
+  );
+}
+
+describe("ComponentsPanel", () => {
+  it("renders each root component's name", () => {
+    renderPanel(hierarchy);
+    expect(screen.getByText("Frame")).toBeInTheDocument();
+    expect(screen.getByText("Pump assembly")).toBeInTheDocument();
+  });
+
+  it("shows the summary counts", () => {
+    renderPanel(hierarchy);
+    expect(screen.getByText("Max depth")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("explains an empty root list rather than rendering nothing", () => {
+    renderPanel({ ...hierarchy, root_components: [] });
+    expect(screen.getByText(/No root components/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/visualization/ComponentsPanel.tsx
+++ b/frontend/src/features/visualization/ComponentsPanel.tsx
@@ -65,8 +65,8 @@ export function ComponentsPanel({ solutionId }: { solutionId: string }) {
               <p className={CAPTION}>Starts from</p>
               <ul className="mt-1 space-y-0.5">
                 {roots.map((root) => (
-                  <li key={root} className="text-sm text-foreground">
-                    {root}
+                  <li key={root.tree_id} className="text-sm text-foreground">
+                    {root.component_name}
                   </li>
                 ))}
               </ul>

--- a/frontend/src/features/visualization/VisualizationView.tsx
+++ b/frontend/src/features/visualization/VisualizationView.tsx
@@ -26,6 +26,7 @@ const FacilityChart = dynamic(
 );
 import { ArtifactLinks } from "./ArtifactLinks";
 import { ComponentsPanel } from "./ComponentsPanel";
+import { PanelBoundary } from "@/components/ui/PanelBoundary";
 import { downloadSolutionJson } from "./downloadSolution";
 import {
   LoadingState,
@@ -94,13 +95,21 @@ export function VisualizationView({ solutionId }: { solutionId: string }) {
         }
       />
 
-      <StalenessBanner solutionId={solutionId} />
+      <PanelBoundary label="Staleness">
+        <StalenessBanner solutionId={solutionId} />
+      </PanelBoundary>
 
       <KpiCards kpis={deriveKpis(data)} />
 
+      {/* Bounded separately: two third-party canvases over one payload, so a
+          failure in either should not take the other. */}
       <div className="grid gap-6 lg:grid-cols-2">
-        <SupplyTreeGraph data={data} />
-        <FacilityChart data={data} />
+        <PanelBoundary label="Supply tree">
+          <SupplyTreeGraph data={data} />
+        </PanelBoundary>
+        <PanelBoundary label="Facilities">
+          <FacilityChart data={data} />
+        </PanelBoundary>
       </div>
 
       {(() => {
@@ -159,9 +168,13 @@ export function VisualizationView({ solutionId }: { solutionId: string }) {
         );
       })()}
 
-      <ComponentsPanel solutionId={solutionId} />
+      <PanelBoundary label="Components">
+        <ComponentsPanel solutionId={solutionId} />
+      </PanelBoundary>
 
-      <ArtifactLinks data={data} solutionId={solutionId} />
+      <PanelBoundary label="Artifacts">
+        <ArtifactLinks data={data} solutionId={solutionId} />
+      </PanelBoundary>
     </div>
   );
 }

--- a/frontend/src/test/fixtures/index.ts
+++ b/frontend/src/test/fixtures/index.ts
@@ -1264,7 +1264,15 @@ export const solutionHierarchyFixture = {
   message: "Hierarchy retrieved",
   data: {
     hierarchy: {},
-    root_components: ["frame"],
+    // Objects, not ids — matching the API. A fixture of bare strings is what
+    // let a render of `{root}` pass its tests and throw React #31 for a user.
+    root_components: [
+      {
+        component_id: "frame",
+        component_name: "Frame",
+        tree_id: "11111111-1111-1111-1111-111111111111",
+      },
+    ],
     component_details: { frame: { name: "Frame" } },
     summary: {
       total_components: 1,
@@ -1295,13 +1303,18 @@ export const matchDomainsFixture = {
   data: {
     domains: [
       {
-        name: "manufacturing",
+        // `id` and `name` are deliberately different strings. A fixture that
+        // used the key for both made binding the selector to `name` look
+        // correct while it sent an unmatchable value to the server.
+        id: "manufacturing",
+        name: "Manufacturing & Hardware Production",
         status: "available",
         version: "1.0",
         supported_input_types: ["okh"],
       },
       {
-        name: "cooking",
+        id: "cooking",
+        name: "Cooking & Food Preparation",
         status: "available",
         version: "0.1",
         supported_input_types: ["recipe"],


### PR DESCRIPTION
Closes #369.

Two reported failures, one cause: the frontend's assumed shape of an API response had diverged from what the API returns, and both divergences were hidden by fixtures that encoded the same wrong guess.

## The bugs

**Domain-aware matching returned 400.** `/api/match/domains` returns `{id, name}` — `id` is the key the API matches on (`manufacturing`), `name` is the display label (`Manufacturing & Hardware Production`). The selector bound its option value to `name` and sent that as `domain`, which the API rejects. Auto-detect worked only because the field is then absent.

The `MatchDomain` interface had **no `id` field at all**, so binding to the label was the only thing the type permitted — the type was part of the drift, not just the call site.

**Supply tree crashed with React #31.** The hierarchy client asserted `root_components` was `string[]`; the API returns `{component_id, component_name, tree_id}` objects. The panel rendered the value directly, so React threw on an object child and — the error boundary being route-scoped — took the entire visualization page with it.

## Both fixtures lied in the same direction

`matchDomainsFixture` used the domain key for *both* `id` and `name`, so label and key were one string and either binding looked correct. `solutionHierarchyFixture` listed bare strings.

Corrected, they fail against the old code. Reverting either fix now reproduces the user-visible error in the suite, including React's `object with keys {component_id, component_name, tree_id}` verbatim — verified by reverting each fix in turn.

## Per-panel error boundaries

`app/error.tsx` already catches a throw, but it is route-scoped, which is why one bad `<li>` cost the whole page. `ComponentsPanel`'s docstring has always claimed a failure should "cost a panel, not the view"; its `isError` branch covers only *fetch* failure, not *render* failure. The five optional panels are now individually bounded, so that claim is true.

## Also included

A test fix for a pre-existing race. `b963561` diagnosed it — every `/settings/*` route renders the same `SettingsPage`, which picks its panel from `usePathname()`, so between a tab click and the route committing the previous tab's panel is still on screen — and added `waitForURL` to three of the six transitions. Bindings, Directory and Federation were left without it.

The Directory one loses. The full mocked suite failed it twice in a row on this work, and the captured DOM shows the Bindings panel still rendered while the assertion waited for the Directory heading. It is timing-sensitive rather than wrong: it passes in isolation, and an unmodified tree passes 237/237 — this change shifts render timing enough to lose it consistently. It is here rather than in the tooling PR because these frontend changes need it to pass CI.

Baseline re-blessed for `settings.spec.ts` alone.

## Verification

`frontend-ready`: all stages green — 699 unit, 237 e2e.

## Note

`payload.root_components as RootComponent[]` survives, now asserting the real shape. The route has no response model, so codegen types nothing there and the compiler cannot check it. #370 replaces it with a generated type and a parsed boundary; the seam is marked in place until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qew1kZog2JA8AKCgLxzn5X
