### PR TITLE
Two developer-tooling fixes: doc-link scope, and a pre-commit hook that could destroy uncommitted work

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,16 +5,22 @@ repos:
       - id: black
         args: ["--config=pyproject.toml"]
 
-  - repo: local
-    hooks:
-      - id: update-repo-map
-        name: update repository map
-        # `uv run`, not bare `python`: the map is built by parsing every tracked
-        # source with ast, so an interpreter older than the project's
-        # requires-python (>=3.12) fails on newer syntax and silently writes
-        # "# Error:" placeholders instead of the symbols. That map then differs
-        # from the one CI regenerates, and the drift gate fails.
-        entry: bash -c 'uv run python scripts/generate_repo_map.py && git add .repo-map.md'
-        language: system
-        pass_filenames: false
-        always_run: true
+# There is deliberately no hook that regenerates .repo-map.md.
+#
+# It used to be one, and it could destroy uncommitted work. pre-commit stashes
+# unstaged changes before running hooks; a hook that rewrites a tracked file the
+# stash also touches makes the restore conflict, and pre-commit then rolls back,
+# leaving the changes only in ~/.cache/pre-commit/patch*. The map is exactly
+# that file: `make ready` tells you to run `make repo-map` when it is stale, so
+# it is routinely dirty in the worktree, and the hook ran on every commit.
+#
+# The map has one writer — `make repo-map`, which `make format` calls — and the
+# drift is caught three times over, all read-only:
+#
+#   * CI, on every push          .github/workflows/ci-cd.yml  (authoritative)
+#   * make ready [13/14]         repo-map-check
+#   * the unit suite             tests/unit/test_repo_map_generation.py
+#
+# A check-only hook is not the fix either: during the stash the tree is HEAD
+# plus staged files only, so a map generated then will not match one generated
+# from your full worktree, and every partial commit fails spuriously.

--- a/.repo-map.md
+++ b/.repo-map.md
@@ -197,6 +197,7 @@ Total Python files: 643
 │   ├── check_doc_links.py
 │   │       def nav_targets()
 │   │       def doc_pages()
+│   │       def git_ignored()
 │   │       def sources()
 │   │       def main()
 │   ├── clear_storage.py
@@ -6719,12 +6720,16 @@ Copies ``docs-site/docs/`` (authored markdown) in...
 
 Three classes of rot, none of whi...
 
-**Exports:** nav_targets, doc_pages, sources, main
+**Exports:** nav_targets, doc_pages, git_ignored, sources, main
 
 **Functions:**
 - `nav_targets()`
   - Page paths named in mkdocs nav, which may be generated rather than on disk....
 - `doc_pages()`
+- `git_ignored(paths)`
+  - The subset of ``paths`` that git ignores.
+
+Ignored files are scratch — `notes/` ...
 - `sources()`
 - `main()`
 

--- a/scripts/check_doc_links.py
+++ b/scripts/check_doc_links.py
@@ -13,6 +13,10 @@ Three classes of rot, none of which mkdocs catches on its own:
 3. **Repo-internal markdown links.** Cross-links between `docs/`, `deploy/` and
    the README point at files, not pages, and nothing validated them.
 
+Skips anything git ignores: `notes/` and friends are scratch, absent from CI,
+and letting them fail the gate makes it red for reasons the repository does not
+contain.
+
 Resolves against the SOURCE tree rather than a built site, so the gate needs no
 mkdocs run. Pages generated at build time (`reference/whats-built.md`) exist only
 in the output, so nav entries count as valid targets alongside files on disk.
@@ -26,6 +30,7 @@ from __future__ import annotations
 import argparse
 import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 from urllib.parse import unquote, urlparse
@@ -71,12 +76,41 @@ def doc_pages() -> set[str]:
     return pages
 
 
+def git_ignored(paths: list[Path]) -> set[Path]:
+    """The subset of ``paths`` that git ignores.
+
+    Ignored files are scratch — `notes/` is the case here — so they are not
+    part of the published documentation and CI never sees them. Checking them
+    makes the gate fail on a machine for reasons that do not exist in the
+    repository, which turns `make ready` red for every change regardless of
+    what the change did.
+
+    Fails open: if git is unavailable or this is not a checkout, everything is
+    checked, which is the safer direction for a gate.
+    """
+    if not paths:
+        return set()
+    try:
+        proc = subprocess.run(
+            ["git", "check-ignore", "--stdin"],
+            input="\n".join(p.relative_to(ROOT).as_posix() for p in paths),
+            capture_output=True,
+            text=True,
+            cwd=ROOT,
+            check=False,
+        )
+    except (OSError, ValueError):
+        return set()
+    # Exit 1 simply means nothing matched, which is not an error here.
+    return {ROOT / line for line in proc.stdout.splitlines() if line}
+
+
 def sources() -> list[tuple[Path, str]]:
-    out: list[tuple[Path, str]] = []
+    candidates: list[Path] = []
     for p in ROOT.rglob("*.md"):
         if SKIP_DIRS & set(p.relative_to(ROOT).parts):
             continue
-        out.append((p, p.read_text(errors="ignore")))
+        candidates.append(p)
     for base in (ROOT / "frontend" / "src", ROOT / "frontend" / "app"):
         if not base.exists():
             continue
@@ -84,8 +118,10 @@ def sources() -> list[tuple[Path, str]]:
             for p in base.glob(pat):
                 if SKIP_DIRS & set(p.relative_to(ROOT).parts):
                     continue
-                out.append((p, p.read_text(errors="ignore")))
-    return out
+                candidates.append(p)
+
+    ignored = git_ignored(candidates)
+    return [(p, p.read_text(errors="ignore")) for p in candidates if p not in ignored]
 
 
 def main() -> int:


### PR DESCRIPTION
Two independent fixes to shared developer tooling, both found while working on #369/#370. Neither changes product behaviour.

## 1. The doc-link check walked gitignored paths

`notes/` is gitignored scratch space, and the link checker scanned it anyway. Five stale links across three local notes files failed `make ready` at **[14/14] for every change on this machine**, regardless of what the change touched — a red gate saying nothing about the repository, because CI never sees those files.

Narrowed, not weakened: the checker now asks git which candidates are ignored and skips exactly those. A broken link in a tracked document still fails the gate — verified by adding one to `docs/architecture/` and watching it fail, then removing it. 63 links resolve.

Fails open: if git is unavailable or this is not a checkout, nothing is skipped and everything is checked, which is the safer direction for a gate.

## 2. The repo-map pre-commit hook could destroy uncommitted work

pre-commit stashes unstaged changes before running hooks. A hook that rewrites a tracked file the stash also touches makes the restore conflict; pre-commit then rolls back every fix, and the changes survive only in `~/.cache/pre-commit/patch*`. The working tree comes back missing them, and no commit is made.

`.repo-map.md` is precisely that file. `make ready` tells you to run `make repo-map` when it is stale, so it is routinely dirty in the worktree, and the hook ran on **every** commit (`always_run: true`). Staging any subset of files was enough.

This is not theoretical — it happened while committing #370. Ten files of work were rolled out of the tree and recovered by hand from the cache patch.

**Nothing is lost by removing it.** The map already had one writer (`make repo-map`, which `make format` calls), and drift is caught three times over, all read-only. Each was verified against a deliberately corrupted map:

| Guard | Result |
|---|---|
| CI on every push — `generate_repo_map.py --check` | exit 1, `DRIFT` |
| `make ready` [13/14] — `repo-map-check` | exit 2, `DRIFT` |
| unit suite — `test_committed_map_is_not_stale` | 1 failed |

**A check-only hook would not fix this either.** During the stash the tree is HEAD plus staged files only, so a map generated then cannot match one generated from the full worktree — every partial commit would fail spuriously. The reasoning is recorded in `.pre-commit-config.yaml` so the hook is not reintroduced.

**Verified fixed** by recreating the exact failure conditions — one staged file, two unstaged including `.repo-map.md` — and committing. pre-commit stashed and *restored* cleanly; both canary edits survived. The same shape previously rolled back ten files.

`black` stays a fixer: it rewrites only Python files you actually staged, a far narrower window than an `always_run` hook over a generated file.

## Verification

`make ready`: all 14 gates pass. Touches no `frontend/` file, so the frontend CI job is skipped by path filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qew1kZog2JA8AKCgLxzn5X
