### PR TITLE
Response-model convention on the hierarchy route (#370) — re-land onto main

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 643
+Total Python files: 644
 
 ├── deploy/
 │   ├── __init__.py
@@ -772,7 +772,12 @@ Total Python files: 643
 │       │   │   │           class ValidationIssue
 │       │   │   │           class ValidationResult
 │       │   │   │           class SupplyTreeListResponse
-│       │   │   │           class SuccessResponse
+│       │   │   │           class HierarchyNode
+│       │   │   │           class RootComponentRef
+│       │   │   │           class ComponentDetail
+│       │   │   │           class HierarchySummary
+│       │   │   │           class SolutionHierarchyData
+│       │   │   │           class SolutionHierarchyResponse
 │       │   │   ├── utility/
 │       │   │   │   ├── request.py
 │       │   │   │   │       class DomainFilterRequest
@@ -2025,6 +2030,11 @@ Total Python files: 643
     │   │       def _service()
     │   ├── test_space_routes.py
     │   │       def _get_app()
+    │   ├── test_supply_tree_hierarchy_contract.py
+    │   │       def _solution()
+    │   │       def _app()
+    │   │       def _stub_timestamps()
+    │   │       def _normalise()
     │   ├── test_utility_default_domain.py
     │   │       def _get_app()
     │   │       def _isolate_cache()
@@ -3382,7 +3392,7 @@ Total Python files: 643
 
 ## Overview
 
-Total files analyzed: 643
+Total files analyzed: 644
 
 ## Entry Points
 
@@ -4525,8 +4535,24 @@ Extends SuccessResponse with scaffo...
   - Response model for validation results...
 - `SupplyTreeListResponse` (inherits: BaseModel)
   - Response model for listing supply trees...
-- `SuccessResponse` (inherits: BaseModel)
-  - Response model for successful operations...
+- `HierarchyNode` (inherits: BaseModel)
+  - One node of the component tree, with its children inline.
+
+Recursive: ``children...
+- `RootComponentRef` (inherits: BaseModel)
+  - A top-level component — an object, not an id.
+
+Named explicitly because the fron...
+- `ComponentDetail` (inherits: BaseModel)
+  - Per-component summary, plus the serialised trees that produced it....
+- `HierarchySummary` (inherits: BaseModel)
+  - Counts the UI shows as KPIs above the component list....
+- `SolutionHierarchyData` (inherits: BaseModel)
+  - The ``data`` payload of the component-hierarchy route....
+- `SolutionHierarchyResponse` (inherits: SuccessResponse)
+  - Envelope for the component-hierarchy route.
+
+Declaring this is what makes ``open...
 
 ### `src/core/api/models/utility/request.py`
 
@@ -10066,6 +10092,13 @@ The Solutions browse was ...
 
 ### `tests/api/test_space_routes.py`
 > Contract tests for space claim + edge bootstrap routes (Slice 5)....
+
+**Internal Dependencies:** 6 imports
+
+### `tests/api/test_supply_tree_hierarchy_contract.py`
+> Contract: GET /v1/api/supply-tree/solution/{id}/hierarchy is shape-frozen.
+
+This route returned a ba...
 
 **Internal Dependencies:** 6 imports
 

--- a/docs/architecture/api-response-contracts.md
+++ b/docs/architecture/api-response-contracts.md
@@ -1,0 +1,70 @@
+# API response contracts
+
+How a route's response shape reaches the frontend without anyone guessing it.
+
+## The problem this exists to prevent
+
+A route that returns a bare `dict` produces no response schema. `openapi-typescript`
+then generates no type for it, and the frontend fills the vacuum with a
+hand-written one — a guess, written from reading the route, that the compiler
+cannot check against anything.
+
+That guess goes wrong silently. In #369 the hierarchy route returned
+`root_components` as a list of objects while the frontend had typed it as a list
+of strings; rendering an entry threw React error #31 and took down the whole
+visualization page. The test fixture had been hand-written from the same wrong
+guess, so the suite was green against a shape the API had never returned.
+
+Three things had to fail together, and all three were avoidable:
+
+- the route declared no response model, so codegen had nothing to emit;
+- the client used an unchecked `as` cast, so TypeScript could not object;
+- the fixture encoded the same guess, so tests agreed with the bug.
+
+## The procedure
+
+For any route the frontend calls:
+
+**1. Capture the real response first.** Exercise the route against a seeded
+server or a `TestClient` and keep the JSON. Write the model from what the route
+actually returns, not from reading its code.
+
+**2. Test-lock the capture before you add the model.** This is the step that
+cannot be skipped, because **`response_model` filters**: FastAPI drops any field
+the model does not declare, silently, from the JSON. A model written by reading
+the route can therefore delete a field a client depends on — the same class of
+bug the model is meant to close, introduced by the fix for it.
+
+The lock is a test asserting the payload is field-identical before and after.
+`tests/api/test_supply_tree_hierarchy_contract.py` is the worked example: it
+freezes a golden capture and fails loudly if the model filters anything.
+
+**3. Keep free-form sub-payloads free-form.** Where a route embeds an arbitrary
+serialised object (`SupplyTree.to_dict()`, for instance), model it as
+`Dict[str, Any]`. A strict model there filters any field that dict later grows —
+the same trap, one level down.
+
+**4. Regenerate and delete the cast.** Run `npm run gen:api`, then remove the
+hand-written type the missing model had forced. If a cast survives, say in a
+comment why.
+
+**5. Parse at the client boundary.** Generated types close the *authoring* gap;
+they say nothing about the *deployment* gap, where a server changes after the
+bundle was built. `parsePayload` in `src/api/ohm/parse.ts` turns that drift into
+an error naming the endpoint and the field, instead of a minified React error
+inside a render.
+
+Use `z.looseObject`, never bare `z.object` — the latter strips undeclared keys,
+which rebuilds the filtering hazard at the client. Describe only the fields the
+UI reads; restating the whole generated type in a second place just creates
+something else that can go stale.
+
+**6. Derive fixtures from the capture.** A fixture written by hand is a second
+guess, and it will agree with the first one. The corrected fixture must fail
+against the old code — if it doesn't, it isn't testing the contract.
+
+## Enforcement
+
+`make ready` fails when a route the frontend calls has no response model, with
+an allowlist for routes not yet converted (#374). An intentional exception is a
+recorded row, not an absence — the same pattern as `tests/parity/manifest.py`.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,7 +41,8 @@
         "remark-gfm": "^4.0.1",
         "shadcn": "^4.12.0",
         "tailwind-merge": "^3.6.0",
-        "tw-animate-css": "^1.4.0"
+        "tw-animate-css": "^1.4.0",
+        "zod": "^4.5.4"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.12.1",
@@ -11869,9 +11870,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,7 +55,8 @@
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.12.0",
     "tailwind-merge": "^3.6.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zod": "^4.5.4"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -3050,7 +3050,9 @@ export interface paths {
          * @description Generate RFQ documents for selected match solutions.
          *
          *     Accepts a subset of match results (as returned by POST /api/match) plus
-         *     OKH design metadata. Returns one RFQ document per selected solution.
+         *     either OKH design metadata (domain="manufacturing", the default) or
+         *     recipe metadata (domain="cooking"). Returns one RFQ document per selected
+         *     solution.
          */
         post: operations["generate_rfq_api_rfq_generate_post"];
         delete?: never;
@@ -4667,6 +4669,28 @@ export interface components {
             before_date?: string | null;
         };
         /**
+         * ComponentDetail
+         * @description Per-component summary, plus the serialised trees that produced it.
+         */
+        ComponentDetail: {
+            /** Component Id */
+            component_id: string;
+            /** Component Name */
+            component_name: string;
+            /** Tree Count */
+            tree_count: number;
+            /** Depth */
+            depth: number;
+            /** Production Stage */
+            production_stage: string;
+            /** Component Path */
+            component_path: string[];
+            /** Trees */
+            trees: {
+                [key: string]: unknown;
+            }[];
+        };
+        /**
          * ConvertFromDatasheetResponse
          * @description Response model for MSF datasheet → OKH conversion.
          *
@@ -5391,6 +5415,44 @@ export interface components {
         HTTPValidationError: {
             /** Detail */
             detail?: components["schemas"]["ValidationError"][];
+        };
+        /**
+         * HierarchyNode
+         * @description One node of the component tree, with its children inline.
+         *
+         *     Recursive: ``children`` holds the same shape, which is how the hierarchy
+         *     carries parent/child structure the visualization bundle does not have.
+         */
+        HierarchyNode: {
+            /** Component Id */
+            component_id: string;
+            /** Component Name */
+            component_name: string;
+            /** Tree Id */
+            tree_id: string;
+            /** Depth */
+            depth: number;
+            /** Production Stage */
+            production_stage: string;
+            /**
+             * Children
+             * @default []
+             */
+            children: components["schemas"]["HierarchyNode"][];
+        };
+        /**
+         * HierarchySummary
+         * @description Counts the UI shows as KPIs above the component list.
+         */
+        HierarchySummary: {
+            /** Total Components */
+            total_components: number;
+            /** Root Components */
+            root_components: number;
+            /** Total Trees */
+            total_trees: number;
+            /** Max Depth */
+            max_depth: number;
         };
         /** IdentifyResponse */
         IdentifyResponse: {
@@ -7863,14 +7925,31 @@ export interface components {
         };
         /** RFQGenerateRequest */
         RFQGenerateRequest: {
+            /**
+             * Domain
+             * @default manufacturing
+             */
+            domain: string;
             /** Okh Id */
-            okh_id: string;
+            okh_id?: string | null;
             /** Okh Title */
-            okh_title: string;
+            okh_title?: string | null;
             /** Okh Function */
             okh_function?: string | null;
             /** Okh Version */
             okh_version?: string | null;
+            /** Okh Manifest */
+            okh_manifest?: {
+                [key: string]: unknown;
+            } | null;
+            /** Recipe Id */
+            recipe_id?: string | null;
+            /** Recipe Title */
+            recipe_title?: string | null;
+            /** Recipe */
+            recipe?: {
+                [key: string]: unknown;
+            } | null;
             /**
              * Quantity
              * @default 1
@@ -7878,10 +7957,6 @@ export interface components {
             quantity: number;
             /** Solutions */
             solutions: components["schemas"]["RFQSolutionInput"][];
-            /** Okh Manifest */
-            okh_manifest?: {
-                [key: string]: unknown;
-            } | null;
         };
         /** RFQGenerateResponse */
         RFQGenerateResponse: {
@@ -7925,6 +8000,8 @@ export interface components {
             facility: {
                 [key: string]: unknown;
             };
+            /** Explanation Human */
+            explanation_human?: string | null;
         };
         /**
          * RecordProvenance
@@ -7944,6 +8021,21 @@ export interface components {
              * @default
              */
             signature: string;
+        };
+        /**
+         * RootComponentRef
+         * @description A top-level component — an object, not an id.
+         *
+         *     Named explicitly because the frontend assumed this was a bare string and
+         *     rendered it directly, which threw React #31 and took down the page (#369).
+         */
+        RootComponentRef: {
+            /** Component Id */
+            component_id: string;
+            /** Component Name */
+            component_name: string;
+            /** Tree Id */
+            tree_id: string;
         };
         /**
          * RuleCompareRequest
@@ -8875,6 +8967,73 @@ export interface components {
             resource_availability?: {
                 [key: string]: unknown;
             };
+        };
+        /**
+         * SolutionHierarchyData
+         * @description The ``data`` payload of the component-hierarchy route.
+         */
+        SolutionHierarchyData: {
+            /** Hierarchy */
+            hierarchy: components["schemas"]["HierarchyNode"][];
+            /** Root Components */
+            root_components: components["schemas"]["RootComponentRef"][];
+            /** Component Details */
+            component_details: {
+                [key: string]: components["schemas"]["ComponentDetail"];
+            };
+            summary: components["schemas"]["HierarchySummary"];
+        };
+        /**
+         * SolutionHierarchyResponse
+         * @description Envelope for the component-hierarchy route.
+         *
+         *     Declaring this is what makes ``openapi-typescript`` generate a response
+         *     type for the route. Without it the endpoint returned a bare ``dict``, the
+         *     generated schema said nothing, and the frontend filled the gap with a
+         *     hand-written type that was wrong.
+         *
+         *     ``response_model`` filters undeclared fields, so this model is frozen
+         *     against a golden capture in
+         *     ``tests/api/test_supply_tree_hierarchy_contract.py``.
+         * @example {
+         *       "data": {},
+         *       "message": "Operation completed successfully",
+         *       "metadata": {},
+         *       "request_id": "req_123456789",
+         *       "status": "success",
+         *       "timestamp": "2024-01-01T12:00:00Z"
+         *     }
+         */
+        SolutionHierarchyResponse: {
+            /**
+             * @description Success status
+             * @default success
+             */
+            status: components["schemas"]["APIStatus"];
+            /**
+             * Message
+             * @description Human-readable response message
+             */
+            message: string;
+            /**
+             * Timestamp
+             * Format: date-time
+             * @description Response timestamp
+             */
+            timestamp?: string;
+            /**
+             * Request Id
+             * @description Request identifier if provided
+             */
+            request_id?: string | null;
+            data: components["schemas"]["SolutionHierarchyData"];
+            /**
+             * Metadata
+             * @description Additional response metadata
+             */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * SolutionLoadRequest
@@ -14041,7 +14200,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["SolutionHierarchyResponse"];
                 };
             };
             /** @description Bad Request */

--- a/frontend/src/api/ohm/parse.test.ts
+++ b/frontend/src/api/ohm/parse.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { ApiError } from "./client";
+import { parsePayload } from "./parse";
+
+const schema = z.looseObject({
+  root_components: z.array(z.looseObject({ component_name: z.string() })),
+});
+
+describe("parsePayload", () => {
+  it("returns the payload when it matches", () => {
+    const payload = { root_components: [{ component_name: "Frame" }] };
+    expect(parsePayload("/x", schema, payload)).toEqual(payload);
+  });
+
+  it("names the endpoint and the field when the shape drifts", () => {
+    // The #369 payload: objects where the client expected strings. Before, this
+    // surfaced as a minified React error deep in a render.
+    expect(() =>
+      parsePayload("/api/hierarchy", schema, {
+        root_components: ["frame"],
+      }),
+    ).toThrow(/\/api\/hierarchy.*root_components\.0/);
+  });
+
+  it("throws ApiError naming the missing key, so callers handle it like any other API failure", () => {
+    expect(() => parsePayload("/api/hierarchy", schema, {})).toThrow(ApiError);
+    expect(() => parsePayload("/api/hierarchy", schema, {})).toThrow(
+      /root_components/,
+    );
+  });
+
+  it("keeps fields the schema does not describe", () => {
+    // Load-bearing. A stripping parse would silently drop server data at the
+    // client — the same failure mode that makes response_model dangerous to
+    // hand-write, rebuilt one layer down.
+    const payload = {
+      root_components: [{ component_name: "Frame", tree_id: "t-1" }],
+      component_details: { frame: { anything: true } },
+    };
+    expect(parsePayload("/x", schema, payload)).toEqual(payload);
+  });
+});

--- a/frontend/src/api/ohm/parse.ts
+++ b/frontend/src/api/ohm/parse.ts
@@ -1,0 +1,40 @@
+import { ZodType } from "zod";
+import { ApiError } from "./client";
+
+/**
+ * Parse a response payload at the client boundary.
+ *
+ * Generated types close the *authoring* gap: with a response model declared,
+ * the compiler knows the shape at build time. They do nothing about the
+ * *deployment* gap — a server that changes after this bundle was built still
+ * hands it a payload the types promise cannot happen.
+ *
+ * That gap is what produced #369. A drift arrived as React error #31 thrown
+ * deep inside a render, with a minified component name and no mention of the
+ * endpoint or the field. This turns the same drift into a message that names
+ * both, at the seam it entered through.
+ *
+ * Reserved for routes whose shape the compiler cannot vouch for. Parsing every
+ * response would mean a hand-maintained schema beside every generated type —
+ * two sources of truth for ninety endpoints, which is its own drift risk.
+ */
+export function parsePayload<T>(
+  endpoint: string,
+  schema: ZodType<T>,
+  payload: unknown,
+): T {
+  const result = schema.safeParse(payload);
+  if (result.success) return result.data;
+
+  const [issue] = result.error.issues;
+  const field = issue.path.join(".") || "(root)";
+  // Status 200 because that is what the server actually sent: the request
+  // succeeded, its body is wrong. It also keeps userMessage on the branch that
+  // shows this message and marks it non-retryable, which is right — repeating
+  // the request cannot change a shape mismatch. A 5xx here would replace the
+  // endpoint and field with generic "the server hit a problem" copy.
+  throw new ApiError(
+    200,
+    `${endpoint} returned an unexpected shape: ${field} — ${issue.message}`,
+  );
+}

--- a/frontend/src/api/ohm/supply-tree.ts
+++ b/frontend/src/api/ohm/supply-tree.ts
@@ -1,4 +1,7 @@
+import { z } from "zod";
 import { apiClient, ApiError, errorMessage } from "./client";
+import { parsePayload } from "./parse";
+import type { components } from "../generated/schema";
 import type { VisualizationData } from "../../types/supply-tree";
 
 /** One row of the caller's saved supply-tree history. */
@@ -130,22 +133,41 @@ export async function extendSolutionTtl(
 }
 
 /** A top-level component in a solution's hierarchy — an object, not an id. */
-export interface RootComponent {
-  component_id: string;
-  component_name: string;
-  tree_id: string;
-}
+export type RootComponent = components["schemas"]["RootComponentRef"];
 
-export interface SolutionHierarchy {
-  root_components: RootComponent[];
-  component_details: Record<string, unknown>;
-  summary: {
-    total_components?: number;
-    root_components?: number;
-    total_trees?: number;
-    max_depth?: number;
-  };
-}
+/** The hierarchy payload, as the route's response model declares it. */
+export type SolutionHierarchy = components["schemas"]["SolutionHierarchyData"];
+
+/**
+ * Runtime shape check for the fields this app reads.
+ *
+ * `looseObject` throughout, deliberately. A plain `z.object` strips keys it
+ * does not declare, which would rebuild — at the client, one layer down — the
+ * very filtering hazard that makes `response_model` dangerous to write by
+ * hand. Nothing here may remove a field the server sent.
+ *
+ * Only the fields the UI actually renders are described. The point is to name
+ * the endpoint and field when a drift arrives, not to restate the whole
+ * generated type in a second place that can itself go stale.
+ */
+const HIERARCHY_PATH = "/api/supply-tree/solution/{solution_id}/hierarchy";
+
+const hierarchySchema = z.looseObject({
+  root_components: z.array(
+    z.looseObject({
+      component_id: z.string(),
+      component_name: z.string(),
+      tree_id: z.string(),
+    }),
+  ),
+  component_details: z.record(z.string(), z.unknown()),
+  summary: z.looseObject({
+    total_components: z.number(),
+    root_components: z.number(),
+    total_trees: z.number(),
+    max_depth: z.number(),
+  }),
+});
 
 /**
  * Component parent/child structure.
@@ -157,10 +179,9 @@ export interface SolutionHierarchy {
 export async function fetchSolutionHierarchy(
   solutionId: string,
 ): Promise<SolutionHierarchy> {
-  const { data, error, response } = await apiClient.GET(
-    "/api/supply-tree/solution/{solution_id}/hierarchy",
-    { params: { path: { solution_id: solutionId } } },
-  );
+  const { data, error, response } = await apiClient.GET(HIERARCHY_PATH, {
+    params: { path: { solution_id: solutionId } },
+  });
   if (error || !response.ok) {
     throw new ApiError(
       response.status,
@@ -170,16 +191,14 @@ export async function fetchSolutionHierarchy(
       ),
     );
   }
-  const body = (data ?? {}) as Record<string, unknown>;
-  const payload = (body.data as Record<string, unknown>) ?? body;
-  return {
-    // Still an assertion, now of the shape the API really returns. The route
-    // has no response model, so codegen types nothing here and the compiler
-    // cannot check this. Replaced by a generated type and a parsed boundary
-    // in #370/#373 — until then this is the seam a drift comes through.
-    root_components: (payload.root_components as RootComponent[]) ?? [],
-    component_details:
-      (payload.component_details as Record<string, unknown>) ?? {},
-    summary: (payload.summary as SolutionHierarchy["summary"]) ?? {},
-  };
+  // The widening is the one assertion left, and it is a much smaller one than
+  // the cast it replaces. The schema deliberately describes only what the UI
+  // reads, so its inferred type is narrower than the contract; the rest of the
+  // type comes from codegen, generated from the server's own schema, rather
+  // than from someone reading the route and guessing.
+  return parsePayload(
+    HIERARCHY_PATH,
+    hierarchySchema,
+    data?.data,
+  ) as SolutionHierarchy;
 }

--- a/frontend/src/features/visualization/ComponentsPanel.test.tsx
+++ b/frontend/src/features/visualization/ComponentsPanel.test.tsx
@@ -12,6 +12,9 @@ import { ComponentsPanel } from "./ComponentsPanel";
  * the whole visualization view.
  */
 const hierarchy: SolutionHierarchy = {
+  // Required by the response model, and unread by this panel — the tree
+  // structure lives here, the panel only shows roots and counts.
+  hierarchy: [],
   root_components: [
     {
       component_id: "frame",

--- a/frontend/src/features/visualization/ComponentsPanel.tsx
+++ b/frontend/src/features/visualization/ComponentsPanel.tsx
@@ -28,7 +28,9 @@ export function ComponentsPanel({ solutionId }: { solutionId: string }) {
 
   if (query.isError) return null;
 
-  const summary = query.data?.summary ?? {};
+  // The response model makes these required, so the old `?? {}` fallback now
+  // widens the type to something with no fields. Optional access instead.
+  const summary = query.data?.summary;
   const roots = query.data?.root_components ?? [];
 
   return (
@@ -43,10 +45,10 @@ export function ComponentsPanel({ solutionId }: { solutionId: string }) {
         <>
           <dl className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-4">
             {[
-              ["Components", summary.total_components],
-              ["Roots", summary.root_components],
-              ["Trees", summary.total_trees],
-              ["Max depth", summary.max_depth],
+              ["Components", summary?.total_components],
+              ["Roots", summary?.root_components],
+              ["Trees", summary?.total_trees],
+              ["Max depth", summary?.max_depth],
             ].map(([label, value]) => (
               <div key={String(label)}>
                 <dt className={CAPTION}>{label}</dt>

--- a/frontend/src/test/fixtures/index.ts
+++ b/frontend/src/test/fixtures/index.ts
@@ -1263,7 +1263,9 @@ export const solutionHierarchyFixture = {
   status: "success",
   message: "Hierarchy retrieved",
   data: {
-    hierarchy: {},
+    // A list, as the API returns. Nothing in the app reads it yet, which is
+    // exactly why it drifted to `{}` unnoticed.
+    hierarchy: [],
     // Objects, not ids — matching the API. A fixture of bare strings is what
     // let a render of `{root}` pass its tests and throw React #31 for a user.
     root_components: [

--- a/src/core/api/models/supply_tree/response.py
+++ b/src/core/api/models/supply_tree/response.py
@@ -104,8 +104,77 @@ class SupplyTreeListResponse(BaseModel):
     page_size: int
 
 
-class SuccessResponse(BaseModel):
-    """Response model for successful operations"""
+class HierarchyNode(BaseModel):
+    """One node of the component tree, with its children inline.
 
-    success: bool
-    message: str
+    Recursive: ``children`` holds the same shape, which is how the hierarchy
+    carries parent/child structure the visualization bundle does not have.
+    """
+
+    component_id: str
+    component_name: str
+    tree_id: str
+    depth: int
+    production_stage: str
+    children: List["HierarchyNode"] = []
+
+
+class RootComponentRef(BaseModel):
+    """A top-level component — an object, not an id.
+
+    Named explicitly because the frontend assumed this was a bare string and
+    rendered it directly, which threw React #31 and took down the page (#369).
+    """
+
+    component_id: str
+    component_name: str
+    tree_id: str
+
+
+class ComponentDetail(BaseModel):
+    """Per-component summary, plus the serialised trees that produced it."""
+
+    component_id: str
+    component_name: str
+    tree_count: int
+    depth: int
+    production_stage: str
+    component_path: List[str]
+    # Free-form on purpose. These are ``SupplyTree.to_dict()`` payloads, and a
+    # strict model here would silently filter any field that dict grows —
+    # reintroducing the drift this model exists to prevent, one level down.
+    trees: List[Dict[str, Any]]
+
+
+class HierarchySummary(BaseModel):
+    """Counts the UI shows as KPIs above the component list."""
+
+    total_components: int
+    root_components: int
+    total_trees: int
+    max_depth: int
+
+
+class SolutionHierarchyData(BaseModel):
+    """The ``data`` payload of the component-hierarchy route."""
+
+    hierarchy: List[HierarchyNode]
+    root_components: List[RootComponentRef]
+    component_details: Dict[str, ComponentDetail]
+    summary: HierarchySummary
+
+
+class SolutionHierarchyResponse(SuccessResponse):
+    """Envelope for the component-hierarchy route.
+
+    Declaring this is what makes ``openapi-typescript`` generate a response
+    type for the route. Without it the endpoint returned a bare ``dict``, the
+    generated schema said nothing, and the frontend filled the gap with a
+    hand-written type that was wrong.
+
+    ``response_model`` filters undeclared fields, so this model is frozen
+    against a golden capture in
+    ``tests/api/test_supply_tree_hierarchy_contract.py``.
+    """
+
+    data: SolutionHierarchyData

--- a/src/core/api/routes/supply_tree.py
+++ b/src/core/api/routes/supply_tree.py
@@ -44,6 +44,7 @@ from ..models.supply_tree.request import (
     SupplyTreeOptimizeRequest,
     SupplyTreeValidateRequest,
 )
+from ..models.supply_tree.response import SolutionHierarchyResponse
 
 logger = get_logger(__name__)
 
@@ -2082,6 +2083,7 @@ async def get_solution_visualization_report(
 @router.get(
     "/solution/{solution_id}/hierarchy",
     status_code=status.HTTP_200_OK,
+    response_model=SolutionHierarchyResponse,
     summary="Get Component Hierarchy",
     description="""
     Get the component hierarchy for a supply tree solution.

--- a/tests/api/golden/supply_tree_hierarchy.json
+++ b/tests/api/golden/supply_tree_hierarchy.json
@@ -1,0 +1,113 @@
+{
+  "data": {
+    "component_details": {
+      "frame": {
+        "component_id": "frame",
+        "component_name": "Frame",
+        "component_path": [],
+        "depth": 0,
+        "production_stage": "fabrication",
+        "tree_count": 1,
+        "trees": [
+          {
+            "assembly_location": null,
+            "capabilities_used": [],
+            "child_tree_ids": [],
+            "component_id": "frame",
+            "component_name": "Frame",
+            "component_path": [],
+            "component_quantity": null,
+            "component_unit": null,
+            "confidence_score": 0.95,
+            "creation_time": "<timestamp>",
+            "depends_on": [],
+            "depth": 0,
+            "estimated_cost": null,
+            "estimated_time": null,
+            "facility_name": "FabLab Drome",
+            "id": "11111111-1111-1111-1111-111111111111",
+            "match_type": "direct",
+            "materials_required": [],
+            "metadata": {},
+            "okh_reference": "okh-vent",
+            "okw_reference": "okw-drome",
+            "parent_tree_id": null,
+            "production_stage": "fabrication",
+            "required_by": []
+          }
+        ]
+      },
+      "pump": {
+        "component_id": "pump",
+        "component_name": "Pump assembly",
+        "component_path": [],
+        "depth": 1,
+        "production_stage": "assembly",
+        "tree_count": 1,
+        "trees": [
+          {
+            "assembly_location": null,
+            "capabilities_used": [],
+            "child_tree_ids": [],
+            "component_id": "pump",
+            "component_name": "Pump assembly",
+            "component_path": [],
+            "component_quantity": null,
+            "component_unit": null,
+            "confidence_score": 0.8,
+            "creation_time": "<timestamp>",
+            "depends_on": [],
+            "depth": 1,
+            "estimated_cost": null,
+            "estimated_time": null,
+            "facility_name": "FabLab Drome",
+            "id": "22222222-2222-2222-2222-222222222222",
+            "match_type": "direct",
+            "materials_required": [],
+            "metadata": {},
+            "okh_reference": "okh-vent",
+            "okw_reference": "okw-drome",
+            "parent_tree_id": "11111111-1111-1111-1111-111111111111",
+            "production_stage": "assembly",
+            "required_by": []
+          }
+        ]
+      }
+    },
+    "hierarchy": [
+      {
+        "children": [
+          {
+            "children": [],
+            "component_id": "pump",
+            "component_name": "Pump assembly",
+            "depth": 1,
+            "production_stage": "assembly",
+            "tree_id": "22222222-2222-2222-2222-222222222222"
+          }
+        ],
+        "component_id": "frame",
+        "component_name": "Frame",
+        "depth": 0,
+        "production_stage": "fabrication",
+        "tree_id": "11111111-1111-1111-1111-111111111111"
+      }
+    ],
+    "root_components": [
+      {
+        "component_id": "frame",
+        "component_name": "Frame",
+        "tree_id": "11111111-1111-1111-1111-111111111111"
+      }
+    ],
+    "summary": {
+      "max_depth": 1,
+      "root_components": 1,
+      "total_components": 2,
+      "total_trees": 2
+    }
+  },
+  "message": "Hierarchy retrieved successfully",
+  "metadata": {},
+  "status": "success"
+}

--- a/tests/api/test_supply_tree_hierarchy_contract.py
+++ b/tests/api/test_supply_tree_hierarchy_contract.py
@@ -1,0 +1,165 @@
+"""Contract: GET /v1/api/supply-tree/solution/{id}/hierarchy is shape-frozen.
+
+This route returned a bare ``dict``, so ``openapi-typescript`` generated no
+response type for it and the frontend hand-wrote one. The guess was wrong —
+``root_components`` was typed ``string[]`` against objects — and rendering it
+threw React #31 in front of a user (#369).
+
+Adding a ``response_model`` is what lets codegen type the route. But FastAPI's
+``response_model`` *filters*: any field the model does not declare is silently
+dropped from the JSON. A model written by reading the route can therefore
+delete a field a client reads, which is the same class of bug the model is
+meant to close.
+
+So the payload is frozen against a golden capture taken from the route BEFORE
+the model existed. The model is correct exactly when this test passes: same
+keys, same values, nothing filtered.
+
+To change the contract deliberately:
+    BLESS_HIERARCHY_CONTRACT=1 .venv/bin/python -m pytest \
+        tests/api/test_supply_tree_hierarchy_contract.py
+and commit the regenerated golden with the reason in the message.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from uuid import uuid4
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from src.core.models.supply_trees import SupplyTree, SupplyTreeSolution
+from src.core.services.storage_service import StorageService
+from src.core.storage.base import StorageConfig
+
+GOLDEN = Path(__file__).parent / "golden" / "supply_tree_hierarchy.json"
+
+# Fixed so the capture is byte-stable across runs: the payload embeds tree ids
+# and the solution id, and random UUIDs would make every run a diff.
+ROOT_TREE_ID = "11111111-1111-1111-1111-111111111111"
+CHILD_TREE_ID = "22222222-2222-2222-2222-222222222222"
+
+
+def _solution() -> SupplyTreeSolution:
+    """A solution with a parent and a child, so every payload key is non-empty.
+
+    A single-tree solution leaves ``children`` empty everywhere and would let a
+    model that drops nested nodes pass.
+    """
+    root = SupplyTree(
+        id=ROOT_TREE_ID,
+        facility_name="FabLab Drome",
+        okh_reference="okh-vent",
+        okw_reference="okw-drome",
+        confidence_score=0.95,
+        match_type="direct",
+        component_id="frame",
+        component_name="Frame",
+        depth=0,
+        production_stage="fabrication",
+    )
+    child = SupplyTree(
+        id=CHILD_TREE_ID,
+        facility_name="FabLab Drome",
+        okh_reference="okh-vent",
+        okw_reference="okw-drome",
+        confidence_score=0.80,
+        match_type="direct",
+        component_id="pump",
+        component_name="Pump assembly",
+        depth=1,
+        production_stage="assembly",
+        parent_tree_id=ROOT_TREE_ID,
+    )
+    return SupplyTreeSolution(all_trees=[root, child], score=0.9, metadata={})
+
+
+def _app():
+    """The mounted app plus the sub-app that owns the dependency overrides."""
+    from src.core.main import api_v1
+
+    app = FastAPI()
+    app.mount("/v1", api_v1)
+    return app, api_v1
+
+
+def _stub_timestamps(node):
+    """Replace per-run clock values wherever they appear in the payload.
+
+    ``creation_time`` is stamped on every serialised tree, so without this the
+    test would fail on a clock tick rather than on a contract change. Recursive
+    because the trees are nested inside ``component_details``.
+    """
+    if isinstance(node, dict):
+        return {
+            k: ("<timestamp>" if k == "creation_time" else _stub_timestamps(v))
+            for k, v in node.items()
+        }
+    if isinstance(node, list):
+        return [_stub_timestamps(v) for v in node]
+    return node
+
+
+def _normalise(payload: dict) -> dict:
+    """Drop the envelope fields that legitimately differ every run.
+
+    ``timestamp``, ``request_id`` and the processing metrics are per-request by
+    design; freezing them would make the test fail on a clock tick rather than
+    on a contract change.
+    """
+    body = _stub_timestamps(payload)
+    body.pop("timestamp", None)
+    body.pop("request_id", None)
+    body["metadata"] = {
+        k: v
+        for k, v in (body.get("metadata") or {}).items()
+        if k not in {"processing_time", "timestamp"}
+    }
+    return body
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_hierarchy_payload_is_field_identical_to_the_golden(tmp_path):
+    storage = StorageService()
+    await storage.configure(StorageConfig(provider="local", bucket_name=str(tmp_path)))
+    assert storage._configured
+
+    solution_id = await storage.save_supply_tree_solution(
+        _solution(), ttl_days=1, tags=["hierarchy-contract"]
+    )
+
+    app, api_v1 = _app()
+    from src.core.api.routes import supply_tree as route_module
+
+    api_v1.dependency_overrides[route_module.get_storage_service] = lambda: storage
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            f"/v1/api/supply-tree/solution/{solution_id}/hierarchy"
+        )
+
+    assert response.status_code == 200, response.text
+    body = _normalise(response.json())
+    # The solution id is generated per run; the golden holds a placeholder.
+    body = json.loads(json.dumps(body).replace(str(solution_id), "<solution-id>"))
+
+    if os.getenv("BLESS_HIERARCHY_CONTRACT"):
+        GOLDEN.parent.mkdir(parents=True, exist_ok=True)
+        GOLDEN.write_text(json.dumps(body, indent=2, sort_keys=True) + "\n")
+        pytest.skip("golden re-blessed")
+
+    assert GOLDEN.exists(), (
+        f"No golden at {GOLDEN}. Capture one with "
+        "BLESS_HIERARCHY_CONTRACT=1 before adding a response_model."
+    )
+    expected = json.loads(GOLDEN.read_text())
+    assert body == expected, (
+        "The hierarchy payload changed. If a response_model was just added, it "
+        "is filtering a field the route used to return."
+    )


### PR DESCRIPTION
Closes #370.

## Why this PR exists

**#385 never reached `main`.** It was based on `fix-369-contract-drift` (necessarily — both changes edit the same three frontend files). #384 merged into `main` at 21:03:57 and #385 merged 17 seconds later at 21:04:14, so GitHub had no opportunity to retarget it. #385 reads as MERGED, but its content went into that now-orphaned branch, and issue #370 stayed OPEN because a PR merged into a non-default branch does not auto-close its issue.

This is the same commit, cherry-picked onto current `main`. It applied cleanly — `main` already has #369, which was the only reason for the original stacking. **No content changes**; review of #385 still stands.

Base is `main`, so this cannot recur.

## What it does

Establishes on one route the pattern that closes the contract-drift class behind #369, so the remaining ~15 frontend-called routes (#373) and every new route can follow it.

`get_solution_hierarchy` returned a bare `dict`, so `openapi-typescript` emitted no response type and the frontend hand-wrote one from reading the route. That guess was wrong, and an `as` cast is not a check.

**The order of operations is the point.** `response_model` *filters*: FastAPI silently drops any field the model does not declare, so a model written by reading the route can delete a field a client reads — the same bug class, introduced by its own fix. The payload is therefore frozen against a golden captured from the route **before** the model existed. Nothing was dropped: field-identical either way.

`component_details[*].trees` stays `Dict[str, Any]` deliberately — those are `SupplyTree.to_dict()` payloads, and a strict model there would filter whatever that dict grows next.

**What the test-lock caught:** `models/supply_tree/response.py` defined a second `SuccessResponse` shadowing the one imported at the top of the same file, so every class below it silently inherited the wrong base. Nothing imported it. Without the contract test this would have shipped as a 500 on a route the visualization page calls.

**Frontend:** hand-written types replaced by generated ones, which surfaced that `summary`'s fields are required and `?? {}` had been widening them to a type with no fields. `parsePayload` guards the runtime seam — generated types say nothing about a server that changes after the bundle was built, which is how #369 reached a user. `z.looseObject` throughout, never bare `z.object`, which would strip undeclared keys and rebuild the filtering hazard at the client; a test asserts unknown fields survive.

Procedure written up in `docs/architecture/api-response-contracts.md` for #373.

## Verification on this branch

`make ready`: 14/14. `frontend-ready`: all stages — 703 unit, 237 e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qew1kZog2JA8AKCgLxzn5X
