### PR TITLE
Gate frontend-called routes on declaring a response model (#374)

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 644
+Total Python files: 645
 
 ├── deploy/
 │   ├── __init__.py
@@ -2402,14 +2402,19 @@ Total Python files: 644
     │   │       def test_r9_deployed_capabilities_are_actually_called_by_the_frontend()
     │   │       def test_r7_about_pages_declare_a_valid_review_date()
     │   │       def test_r8_stale_narrative_pages_warn_but_do_not_fail()
-    │   └── test_parity.py
-    │           def _diff_message()
-    │           def test_services_match_manifest()
-    │           def test_api_tags_match_manifest()
-    │           def test_cli_groups_match_manifest()
-    │           def test_fe_routes_match_manifest()
-    │           def test_fe_api_prefixes_match_manifest()
-    │           def test_manifest_has_no_duplicate_slots()
+    │   ├── test_parity.py
+    │   │       def _diff_message()
+    │   │       def test_services_match_manifest()
+    │   │       def test_api_tags_match_manifest()
+    │   │       def test_cli_groups_match_manifest()
+    │   │       def test_fe_routes_match_manifest()
+    │   │       def test_fe_api_prefixes_match_manifest()
+    │   │       def test_manifest_has_no_duplicate_slots()
+    │   └── test_response_models.py
+    │           def _declares_a_response_model()
+    │           def _untyped_frontend_routes()
+    │           def test_no_new_untyped_frontend_route()
+    │           def test_allowlist_has_no_stale_rows()
     ├── performance/
     │   └── test_supply_tree_performance.py
     │           class TestSupplyTreePerformance (test_serialization_performance, test_set_operations_performance, test_memory_usage...)
@@ -3392,7 +3397,7 @@ Total Python files: 644
 
 ## Overview
 
-Total files analyzed: 644
+Total files analyzed: 645
 
 ## Entry Points
 
@@ -5446,6 +5451,21 @@ Naming convention
 Args...
 - `validate_okw_facility(content, quality_level, strict_mode)`
   - Validate OKW facility content against the canonical ManufacturingFacility datacl...
+
+### `tests/parity/test_response_models.py`
+> Every route the frontend calls must declare a response model.
+
+A route that returns a bare ``dict`` ...
+
+**Exports:** test_no_new_untyped_frontend_route, test_allowlist_has_no_stale_rows
+
+**Functions:**
+- `test_no_new_untyped_frontend_route()`
+  - A frontend-called route without a response model must be declared....
+- `test_allowlist_has_no_stale_rows()`
+  - A row that is now typed, or no longer called, must be removed....
+
+**Internal Dependencies:** 1 imports
 
 ### `tests/unit/test_asset_model.py`
 > Unit tests for the AssetRecord domain model....

--- a/docs/architecture/api-response-contracts.md
+++ b/docs/architecture/api-response-contracts.md
@@ -65,6 +65,22 @@ against the old code — if it doesn't, it isn't testing the contract.
 
 ## Enforcement
 
-`make ready` fails when a route the frontend calls has no response model, with
-an allowlist for routes not yet converted (#374). An intentional exception is a
-recorded row, not an absence — the same pattern as `tests/parity/manifest.py`.
+`make ready` fails when a route the frontend calls has no response model. The
+gate is `tests/parity/test_response_models.py`, run by `make parity`
+(`make ready` step [5/14]).
+
+It is a ratchet and fails in both directions, like `tests/parity/manifest.py`:
+
+- a frontend-called route that is untyped and unlisted fails the build, so the
+  class cannot reopen through a new endpoint;
+- a listed route that has since been typed also fails, so the list shrinks as
+  the work lands rather than rotting.
+
+"Frontend-called" is not re-derived there. It comes from
+`inventory.fe_api_call_sites`, the same source the API-coverage gate uses, so
+there is one definition of the question and a failure names the call site.
+
+`ALLOWLIST` holds the routes untyped at the time the gate was added — 34
+operations across 28 paths, which is the real scope of the conversion work. A
+row is a debt, not an exemption: adding one to get a build green is how the
+list stops shrinking.

--- a/tests/parity/test_response_models.py
+++ b/tests/parity/test_response_models.py
@@ -1,0 +1,148 @@
+"""Every route the frontend calls must declare a response model.
+
+A route that returns a bare ``dict`` produces no response schema, so
+``openapi-typescript`` generates no type for it and the frontend fills the gap
+with a hand-written guess the compiler cannot check. That is the mechanism
+behind #369: ``root_components`` was typed ``string[]`` against a list of
+objects, and rendering it threw React #31 in front of a user.
+
+This is a *ratchet*, not a cleanup. ``ALLOWLIST`` records the routes that are
+untyped today so the gate can be added before the work of converting them is
+done (#373). It fails in both directions, like ``manifest.py``:
+
+  * a frontend-called route that is untyped and unlisted fails the build, so
+    the class cannot quietly reopen through a new endpoint; and
+  * a listed route that has since been typed fails the build, so the list
+    shrinks as the work lands instead of rotting.
+
+"Frontend-called" is not re-derived here. It comes from
+``inventory.fe_api_call_sites``, the same source the API-coverage gate uses, so
+there is one definition of the question and failures can name the call site.
+
+The procedure for converting a route is in
+``docs/architecture/api-response-contracts.md``. Do not add rows to shorten
+that work — a row is a debt, and the golden-capture step exists because
+``response_model`` silently filters undeclared fields.
+"""
+
+from __future__ import annotations
+
+import json
+
+from .inventory import fe_api_call_sites
+
+HTTP_METHODS = {"get", "post", "put", "delete", "patch"}
+
+# (METHOD, path) pairs that are called by the frontend and still untyped.
+# Each row is a debt to be removed by #373, not a permanent exemption.
+ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("DELETE", "/api/asset/{id}"),
+        ("POST", "/api/convert/to-datasheet"),
+        ("GET", "/api/file-types"),
+        ("GET", "/api/file-types/validate"),
+        ("GET", "/api/identity/security-policy"),
+        ("POST", "/api/match"),
+        ("POST", "/api/match/facility"),
+        ("POST", "/api/okh/diff-collection"),
+        ("GET", "/api/okh/export-collection"),
+        ("POST", "/api/okh/import-collection"),
+        ("GET", "/api/okh/template"),
+        ("GET", "/api/okw/spaces"),
+        ("GET", "/api/okw/template"),
+        ("POST", "/api/package/build/{manifest_id}"),
+        ("POST", "/api/package/download-zip"),
+        ("GET", "/api/package/remote"),
+        ("GET", "/api/package/{org}/{project}/{version}"),
+        ("DELETE", "/api/package/{org}/{project}/{version}"),
+        ("GET", "/api/package/{org}/{project}/{version}/download"),
+        ("POST", "/api/package/{org}/{project}/{version}/pin"),
+        ("GET", "/api/package/{org}/{project}/{version}/verify"),
+        ("GET", "/api/package/{org}/{project}/{version}/verify-pin"),
+        ("GET", "/api/package/{org}/{project}/{version}/verify-signature"),
+        ("GET", "/api/supply-tree/solution/{solution_id}"),
+        ("DELETE", "/api/supply-tree/solution/{solution_id}"),
+        ("POST", "/api/supply-tree/solution/{solution_id}/extend"),
+        ("GET", "/api/supply-tree/solution/{solution_id}/staleness"),
+        ("GET", "/api/supply-tree/solution/{solution_id}/visualization"),
+        ("GET", "/api/supply-tree/solutions"),
+        ("GET", "/api/taxonomy"),
+        ("POST", "/api/taxonomy/reload"),
+        ("GET", "/api/taxonomy/validate"),
+        ("GET", "/api/utility/domains"),
+        ("GET", "/api/utility/metrics"),
+    }
+)
+
+
+def _declares_a_response_model(operation: dict) -> bool:
+    """Does this operation's success response carry a real schema?
+
+    A declared ``response_model`` renders as a ``$ref`` — directly, or inside
+    ``items`` for a list return. Without one FastAPI emits a placeholder with
+    only an auto-generated ``title``, or ``additionalProperties: true`` for a
+    ``Dict[str, Any]`` annotation. Neither gives codegen anything to name, which
+    is the property this gate is about.
+
+    An operation with no JSON success body (204, a file download) has nothing to
+    type and is not a debt.
+    """
+    for code in ("200", "201"):
+        response = (operation.get("responses") or {}).get(code) or {}
+        schema = ((response.get("content") or {}).get("application/json") or {}).get(
+            "schema"
+        )
+        if schema is None:
+            continue
+        return "$ref" in json.dumps(schema)
+    return True
+
+
+def _untyped_frontend_routes() -> dict[tuple[str, str], str]:
+    """Frontend-called operations with no response model, mapped to a call site."""
+    from src.core.main import api_v1
+
+    spec = api_v1.openapi()
+    call_sites = fe_api_call_sites()
+    found: dict[tuple[str, str], str] = {}
+    for path, site in call_sites.items():
+        for method, operation in (spec["paths"].get(path) or {}).items():
+            if method.lower() not in HTTP_METHODS:
+                continue
+            if not _declares_a_response_model(operation):
+                found[(method.upper(), path)] = site
+    return found
+
+
+def test_no_new_untyped_frontend_route():
+    """A frontend-called route without a response model must be declared."""
+    untyped = _untyped_frontend_routes()
+    undeclared = {
+        route: site for route, site in untyped.items() if route not in ALLOWLIST
+    }
+    assert not undeclared, (
+        "These routes are called by the frontend and declare no response_model, "
+        "so codegen cannot type them and the client must guess:\n"
+        + "\n".join(
+            f"  {method} {path}\n      called from {site}"
+            for (method, path), site in sorted(undeclared.items())
+        )
+        + "\n\nAdd a response model — the procedure, including the golden-capture "
+        "step that proves the model filters nothing, is in "
+        "docs/architecture/api-response-contracts.md.\n"
+        "If it genuinely cannot be typed, add a row to ALLOWLIST in "
+        "tests/parity/test_response_models.py with the reason."
+    )
+
+
+def test_allowlist_has_no_stale_rows():
+    """A row that is now typed, or no longer called, must be removed."""
+    stale = ALLOWLIST - set(_untyped_frontend_routes())
+    assert not stale, (
+        "These ALLOWLIST rows are no longer untyped frontend-called routes — "
+        "they have been given a response model, or the frontend stopped calling "
+        "them:\n"
+        + "\n".join(f"  {method} {path}" for method, path in sorted(stale))
+        + "\n\nRemove them. The list is a shrinking debt (#373); leaving a row "
+        "behind hides the next regression at that route."
+    )


### PR DESCRIPTION
Closes #374.

A route returning a bare `dict` produces no response schema, so `openapi-typescript` emits no type and the frontend fills the gap with a guess the compiler cannot check. That is the mechanism behind #369. #370 fixed one route and wrote down the procedure; this stops the class reopening through the next one.

## A ratchet, not a cleanup

`ALLOWLIST` records what is untyped today, so the gate can land *before* the conversion work in #373. It fails in both directions, like `manifest.py`:

- an untyped, unlisted frontend-called route fails the build — the class cannot reopen through a new endpoint;
- a listed route that has since been typed **also** fails — the list shrinks as the work lands instead of rotting.

Both verified by breaking them. Removing a row:

```
GET /api/utility/metrics
    called from frontend/src/api/ohm/utility.ts:50
```

Adding a route that #370 already typed:

```
GET /api/supply-tree/solution/{solution_id}/hierarchy
Remove them. The list is a shrinking debt (#373)…
```

## Where it lives, and why not a new step

In `tests/parity/`, run by `make parity` (`make ready` step [5/14]) rather than as its own numbered step. The issue sketched a separate step; a test in the existing parity suite reuses that invocation instead of adding a script, a make target and a `scripts/registry.toml` entry that would run the same check twice. `make ready` fails either way, which is the acceptance criterion.

## It corrected the scope of #373

"Frontend-called" is not re-derived here — it comes from `inventory.fe_api_call_sites`, the same source the API-coverage gate uses, so there is one definition of the question and a failure names the call site.

That reuse changed the numbers. Scanning only `frontend/src/api/ohm` gives 22 operations; the inventory also covers `frontend/app`, `.tsx` call sites, and the separate `frontend/src/api/package.ts` client. **The real figure is 34 operations across 28 paths**, including eight `/api/package/**` endpoints the narrower scan never saw. #373 estimates "15-18 routes" and needs updating — I will correct its body once this merges.

## What counts as typed

The success response carries a `$ref`, directly or inside `items` for a list return. A bare auto-generated `title`, or `additionalProperties` from a `Dict[str, Any]` annotation, gives codegen nothing to name. An operation with no JSON success body (204, a file download) has nothing to type and is not counted as debt.

## Verification

`make ready`: all 14 gates pass, with the new tests visible inside the parity step. Touches no `frontend/` file, so the frontend CI job is skipped by path filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qew1kZog2JA8AKCgLxzn5X
