### PR TITLE
Fail repo-map-check on untracked sources instead of passing falsely

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -223,6 +223,7 @@ Total Python files: 644
 │   ├── generate_repo_map.py
 │   │       def repo_identity()
 │   │       def get_git_files()
+│   │       def untracked_python_files()
 │   │       def parse_failures_in()
 │   │       def extract_symbols()
 │   │       def build_tree_structure()
@@ -3293,6 +3294,9 @@ Total Python files: 644
         │       def test_committed_map_is_not_stale()
         │       def test_committed_map_records_no_parse_failures()
         │       def test_committed_map_names_the_project_not_a_directory()
+        │       def test_staged_sources_are_not_reported_as_untracked()
+        │       def test_an_unstaged_source_is_reported()
+        │       def test_ignored_sources_are_not_reported()
         ├── test_reverse_facility_matching.py
         │       def _manifest()
         │       def _sol()
@@ -6840,7 +6844,7 @@ The process taxonomy ...
 > Generate repository maps in both Aider and Sourcegraph styles.
 Combines both approaches into a singl...
 
-**Exports:** repo_identity, get_git_files, parse_failures_in, extract_symbols, build_tree_structure
+**Exports:** repo_identity, get_git_files, untracked_python_files, parse_failures_in, extract_symbols
 
 **Functions:**
 - `repo_identity(repo_path)`
@@ -6851,14 +6855,16 @@ The direc...
   - Every tracked Python file, tests included.
 
 This used to claim it dropped test f...
+- `untracked_python_files(repo_path)`
+  - Python files present in the working tree but not in the index.
+
+The map is gener...
 - `parse_failures_in(map_content)`
   - Placeholders left where a source file could not be parsed.
 
 Both extractors reco...
 - `extract_symbols(file_path)`
   - Extract classes and functions from a Python file using AST....
-- `build_tree_structure(files, repo_path)`
-  - Build a hierarchical tree structure of the repository....
 
 ### `scripts/generate_scripts_index.py`
 > Generate scripts/README.md from scripts/registry.toml.

--- a/scripts/generate_repo_map.py
+++ b/scripts/generate_repo_map.py
@@ -63,6 +63,33 @@ def get_git_files(repo_path: Path) -> List[Path]:
     return files
 
 
+def untracked_python_files(repo_path: Path) -> List[str]:
+    """Python files present in the working tree but not in the index.
+
+    The map is generated from ``git ls-files``, i.e. the index. A file that has
+    been written but not staged is invisible to the generator, so regenerating
+    now yields a map that goes stale the instant that file is committed: the
+    local gate passes and CI then fails on the same commit.
+
+    That false green is worse than either honest outcome, so ``--check`` refuses
+    to pass while any exist. Ignored files are excluded — scratch space is not a
+    contribution.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "--others", "--exclude-standard", "*.py"],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, ValueError):
+        # Not a git checkout, or git is unavailable. get_git_files falls back to
+        # walking the tree in that case, where the index does not apply.
+        return []
+    return [line for line in result.stdout.splitlines() if line]
+
+
 def parse_failures_in(map_content: str) -> List[str]:
     """Placeholders left where a source file could not be parsed.
 
@@ -520,6 +547,20 @@ def main():
         return 1
 
     if args.check:
+        untracked = untracked_python_files(target_path)
+        if untracked:
+            print(
+                f"UNTRACKED: {len(untracked)} Python file(s) are not staged, so "
+                f"{args.filename} cannot account for them yet:"
+            )
+            for path in sorted(untracked):
+                print(f"    {path}")
+            print(
+                "The map is built from the git index, not the working tree. "
+                "`git add` them, then run `make repo-map`."
+            )
+            return 1
+
         current = (
             output_file.read_text(encoding="utf-8") if output_file.exists() else ""
         )

--- a/tests/unit/test_repo_map_generation.py
+++ b/tests/unit/test_repo_map_generation.py
@@ -256,3 +256,35 @@ def test_committed_map_names_the_project_not_a_directory():
         "the map header must come from pyproject.toml; a checkout-derived name "
         "makes the drift gate unpassable for every other checkout."
     )
+
+
+# --------------------------------------------------------------------------
+# Untracked sources
+# --------------------------------------------------------------------------
+
+
+def test_staged_sources_are_not_reported_as_untracked(tmp_path):
+    repo = _make_repo(tmp_path, "staged")
+    assert gen.untracked_python_files(repo) == []
+
+
+def test_an_unstaged_source_is_reported(tmp_path):
+    """The false-green case: written, not staged, therefore not in the map.
+
+    `git ls-files` reads the index, so a file in this state is invisible to the
+    generator. Regenerating would produce a map that goes stale the moment the
+    file is committed — the local gate passing and CI then failing on the same
+    commit.
+    """
+    repo = _make_repo(tmp_path, "unstaged")
+    (repo / "pkg" / "new_module.py").write_text("def added():\n    return 1\n")
+    assert gen.untracked_python_files(repo) == ["pkg/new_module.py"]
+
+
+def test_ignored_sources_are_not_reported(tmp_path):
+    """Scratch space is not a contribution, so it must not fail the gate."""
+    repo = _make_repo(tmp_path, "ignored")
+    (repo / ".gitignore").write_text("scratch/\n", encoding="utf-8")
+    (repo / "scratch").mkdir()
+    (repo / "scratch" / "throwaway.py").write_text("x = 1\n", encoding="utf-8")
+    assert gen.untracked_python_files(repo) == []


### PR DESCRIPTION
The repository map is generated from `git ls-files` — the **index**, not the working tree. A Python file that has been written but not staged is invisible to the generator, so regenerating produces a map that goes stale the instant that file is committed: `make ready` [13/14] passes, the commit lands, and CI fails the same check on the same commit.

That is not hypothetical. It happened on #374 (PR #388): the new parity test was unstaged when `make repo-map` ran, the local gate went green, and CI reported `DRIFT: .repo-map.md is stale`.

**A false green is worse than either honest outcome** — it is the one result that stops you looking.

## The change

`--check` now refuses to pass while untracked, non-ignored Python files exist, naming them and the remedy:

```
UNTRACKED: 1 Python file(s) are not staged, so .repo-map.md cannot
account for them yet:
    tests/parity/test_response_models.py
The map is built from the git index, not the working tree.
`git add` them, then run `make repo-map`.
```

Ignored files are excluded. Scratch space is not a contribution, and failing on a throwaway `.py` is the kind of noise that gets a gate switched off.

## Tests

Three cases pin the contract, using the existing `_make_repo` fixture:

| Case | Reported? |
|---|---|
| staged sources | no — the normal case |
| written but unstaged | **yes** — the false green |
| gitignored | no — scratch is not a contribution |

## Where this came from, and a correction

This became reachable when the mutating pre-commit hook was removed in #386. That hook regenerated the map *during* the commit — after staging — so new files were already tracked and the gap never showed.

Removing it was still right: it could destroy uncommitted work, and did. But my claim in that PR that **"nothing is lost by removing it" was wrong.** What was lost is exactly this: the post-staging regeneration that made the gate satisfiable. This restores the guarantee without restoring the hazard — the check tells you what to do instead of silently rewriting a file mid-commit.

## Verification

`make ready`: all 14 gates pass. Verified by hand against the real scenario — clean tree passes, an unstaged `.py` fails with the message above, and staging then regenerating passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qew1kZog2JA8AKCgLxzn5X
