### PR TITLE
Append-only stage log for generate-from-url runs (#375)

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 645
+Total Python files: 646
 
 ├── deploy/
 │   ├── __init__.py
@@ -701,6 +701,8 @@ Total Python files: 645
 │       │   │   │           class OKHGenerateJobRef
 │       │   │   │           class OKHGenerateJobsResponse
 │       │   │   │           class OKHGenerateJobStatus
+│       │   │   │           class OKHGenerateJobEvent
+│       │   │   │           class OKHGenerateJobEvents
 │       │   │   │           class OKHExportResponse
 │       │   │   │           class OKHHarvestResponse
 │       │   │   │           class OKHRepairExtractResponse
@@ -1283,6 +1285,7 @@ Total Python files: 645
 │       │   │       def enforce_job_capacity()
 │       │   │       def enqueue_generate_jobs()
 │       │   │       def get_job_status()
+│       │   │       def get_job_events()
 │       │   │       def revoke_job()
 │       │   └── tasks.py
 │       │           def generate_from_url_task()
@@ -2753,6 +2756,18 @@ Total Python files: 645
         │       def test_generate_from_url_task_failure_is_marked_failed()
         │       def test_celery_app_expires_results()
         │       def test_job_settings_read_from_env()
+        ├── test_generation_job_events.py
+        │       class _FakeResult (__init__)
+        │       def _run_emitting_stages()
+        │       def test_a_poll_at_any_moment_sees_every_stage_so_far()
+        │       def test_the_log_survives_completion()
+        │       def test_events_are_ordered_and_numbered()
+        │       def _events()
+        │       def test_since_returns_only_what_the_caller_has_not_seen()
+        │       def test_next_cursor_spans_the_whole_log_not_the_page()
+        │       def test_reading_past_the_end_is_an_empty_page_not_an_error()
+        │       def test_events_are_read_from_the_result_once_the_job_succeeds()
+        │       def test_a_job_with_no_events_yet_reports_an_empty_log()
         ├── test_generation_jobs.py
         │       def test_enforce_job_capacity_rejects_when_active_cap_exceeded()
         │       def test_enqueue_deduplicates_urls()
@@ -3401,7 +3416,7 @@ Total Python files: 645
 
 ## Overview
 
-Total files analyzed: 645
+Total files analyzed: 646
 
 ## Entry Points
 
@@ -4358,6 +4373,12 @@ This module provides Pydantic models for LLM API responses....
   - Accepted async generation batch....
 - `OKHGenerateJobStatus` (inherits: BaseModel)
   - Status of a single generate-from-url job....
+- `OKHGenerateJobEvent` (inherits: BaseModel)
+  - One stage transition in a generate-from-url run....
+- `OKHGenerateJobEvents` (inherits: BaseModel)
+  - An ordered page of a run's stage events.
+
+``next_cursor`` is what to pass as ``s...
 - `OKHExportResponse` (inherits: BaseModel)
   - Response model for OKH schema export...
 - `OKHHarvestResponse` (inherits: BaseModel)
@@ -7679,7 +7700,7 @@ This module combines the functionality fr...
 
 ### `src/core/api/routes/okh.py`
 
-**Internal Dependencies:** 6 imports
+**Internal Dependencies:** 7 imports
 
 ### `src/core/api/routes/okw.py`
 
@@ -11503,6 +11524,30 @@ Cloning replaces one HTTP ...
 - `test_job_settings_read_from_env(monkeypatch)`
 
 **Internal Dependencies:** 4 imports
+
+### `tests/unit/test_generation_job_events.py`
+> The generate-from-url run log: every stage survives, whatever the poll rate.
+
+Job status reports the...
+
+**Exports:** test_a_poll_at_any_moment_sees_every_stage_so_far, test_the_log_survives_completion, test_events_are_ordered_and_numbered, test_since_returns_only_what_the_caller_has_not_seen, test_next_cursor_spans_the_whole_log_not_the_page
+
+**Classes:**
+- `_FakeResult`
+
+**Functions:**
+- `test_a_poll_at_any_moment_sees_every_stage_so_far()`
+  - The regression: a slow poller must not miss a short stage.
+
+Reading only the las...
+- `test_the_log_survives_completion()`
+  - Celery replaces meta with the return value, so the log rides in both....
+- `test_events_are_ordered_and_numbered()`
+- `test_since_returns_only_what_the_caller_has_not_seen()`
+- `test_next_cursor_spans_the_whole_log_not_the_page()`
+  - Otherwise a caller that skipped ahead would re-read events it has....
+
+**Internal Dependencies:** 2 imports
 
 ### `tests/unit/test_generation_jobs.py`
 > Unit tests for generate-from-url job enqueue helpers....

--- a/docs/ops/async-generation.md
+++ b/docs/ops/async-generation.md
@@ -136,6 +136,41 @@ app looks wrong** — you only see it by comparing the two.
 
 Generated manifests are held in the result backend for 24 hours and then expire.
 
+## Reading what a run actually did
+
+`GET /api/okh/generate-from-url/jobs/{job_id}/events` returns the run's stage
+log, in order:
+
+```json
+{
+  "job_id": "…", "state": "PROGRESS", "next_cursor": 4,
+  "events": [
+    {"seq": 0, "stage": "clone",     "fraction": 0.0,  "message": "…", "ts": "…"},
+    {"seq": 1, "stage": "direct",    "fraction": 0.12, "message": "…", "ts": "…"},
+    {"seq": 2, "stage": "heuristic", "fraction": 0.17, "message": "…", "ts": "…"},
+    {"seq": 3, "stage": "nlp",       "fraction": 0.25, "message": "…", "ts": "…"}
+  ]
+}
+```
+
+Or `ohm okh generate-jobs events <job_id> --since 0`.
+
+**Why this exists alongside the status endpoint.** Status reports the stage a
+run is *on*. Celery's `update_state` overwrites its meta, so polling that field
+*samples* the timeline rather than receiving it: any stage shorter than the
+interval between two polls is never observed. The early stages carry small
+weights against `llm`'s dominant one, so on a fast repository several can pass
+between polls and no client learns they ran. "Progress looked like it skipped
+from 0% to 40%" is that, not a fault.
+
+The log avoids it by being cumulative — the worker republishes the whole list on
+every update — so a poll at any interval sees every stage. Pass the previous
+response's `next_cursor` as `since` to fetch only what is new.
+
+It shares the result backend's 24-hour retention, and rides in the job result
+once the run finishes, so it remains readable after completion rather than
+vanishing at the moment it becomes worth reading.
+
 ## Generation quality
 
 Generation prefers an LLM layer but degrades to direct + heuristic + NLP when no

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -713,6 +713,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/okh/generate-from-url/jobs/{job_id}/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Read a generate-from-url job's stage events
+         * @description Return the run's stage events in order, from ``since`` onward.
+         *
+         *     Job status reports the *current* stage, which a poll can only sample: a
+         *     stage shorter than the poll interval is never seen. This returns the log
+         *     instead, so a client at any interval receives every stage that ran.
+         */
+        get: operations["get_generate_from_url_job_events_api_okh_generate_from_url_jobs__job_id__events_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/okh/generate-from-url/jobs/{job_id}/revoke": {
         parameters: {
             query?: never;
@@ -6281,6 +6305,40 @@ export interface components {
             manifest_id: string;
         };
         /**
+         * OKHGenerateJobEvent
+         * @description One stage transition in a generate-from-url run.
+         */
+        OKHGenerateJobEvent: {
+            /** Seq */
+            seq: number;
+            /** Stage */
+            stage: string;
+            /** Fraction */
+            fraction: number;
+            /** Message */
+            message?: string | null;
+            /** Ts */
+            ts?: string | null;
+        };
+        /**
+         * OKHGenerateJobEvents
+         * @description An ordered page of a run's stage events.
+         *
+         *     ``next_cursor`` is what to pass as ``since`` on the following poll. It is
+         *     the length of the whole log rather than of this page, so a caller that skips
+         *     ahead does not silently re-read events it already has.
+         */
+        OKHGenerateJobEvents: {
+            /** Job Id */
+            job_id: string;
+            /** State */
+            state: string;
+            /** Events */
+            events: components["schemas"]["OKHGenerateJobEvent"][];
+            /** Next Cursor */
+            next_cursor: number;
+        };
+        /**
          * OKHGenerateJobRef
          * @description One job within a submitted batch.
          */
@@ -11274,6 +11332,60 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["OKHGenerateJobStatus"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    get_generate_from_url_job_events_api_okh_generate_from_url_jobs__job_id__events_get: {
+        parameters: {
+            query?: {
+                /** @description Return events after this offset; pass back next_cursor. */
+                since?: number;
+            };
+            header?: never;
+            path: {
+                /** @description Celery task id */
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OKHGenerateJobEvents"];
                 };
             };
             /** @description Bad Request */

--- a/src/cli/okh.py
+++ b/src/cli/okh.py
@@ -1775,6 +1775,46 @@ async def generate_jobs_status(
     cli_ctx.end_command_tracking()
 
 
+@generate_jobs_group.command("events")
+@click.argument("job_id", type=str)
+@click.option(
+    "--since",
+    default=0,
+    show_default=True,
+    type=int,
+    help="Return events after this offset; pass back next_cursor to tail a run.",
+)
+@standard_cli_command(
+    help_text="List the stage events of an async generate-from-url job.",
+    async_cmd=True,
+    track_performance=True,
+    handle_errors=True,
+    format_output=True,
+    add_llm_config=False,
+)
+@click.pass_context
+async def generate_jobs_events(
+    ctx,
+    job_id: str,
+    since: int,
+    verbose: bool,
+    output_format: str,
+):
+    """Read the run's stage log.
+
+    `status` reports the stage a run is on now, which a poll can only sample —
+    a stage shorter than the interval between polls is never seen. This returns
+    every stage that ran, in order.
+    """
+    cli_ctx = ctx.obj
+    cli_ctx.start_command_tracking("okh-generate-jobs-events")
+    response = await cli_ctx.api_client.request(
+        "GET", f"/api/okh/generate-from-url/jobs/{job_id}/events?since={since}"
+    )
+    click.echo(json.dumps(response, indent=2, default=str))
+    cli_ctx.end_command_tracking()
+
+
 @generate_jobs_group.command("wait")
 @click.argument("job_id", type=str)
 @click.option(

--- a/src/core/api/models/okh/response.py
+++ b/src/core/api/models/okh/response.py
@@ -213,6 +213,30 @@ class OKHGenerateJobStatus(BaseModel):
     quality_report: Optional[Dict[str, Any]] = None
 
 
+class OKHGenerateJobEvent(BaseModel):
+    """One stage transition in a generate-from-url run."""
+
+    seq: int
+    stage: str
+    fraction: float
+    message: Optional[str] = None
+    ts: Optional[str] = None
+
+
+class OKHGenerateJobEvents(BaseModel):
+    """An ordered page of a run's stage events.
+
+    ``next_cursor`` is what to pass as ``since`` on the following poll. It is
+    the length of the whole log rather than of this page, so a caller that skips
+    ahead does not silently re-read events it already has.
+    """
+
+    job_id: str
+    state: str
+    events: List[OKHGenerateJobEvent]
+    next_cursor: int
+
+
 class OKHExportResponse(BaseModel):
     """Response model for OKH schema export"""
 

--- a/src/core/api/routes/okh.py
+++ b/src/core/api/routes/okh.py
@@ -85,6 +85,7 @@ from ..models.okh.response import (
     OKHExtractResponse,
     OKHGenerateJobRef,
     OKHGenerateJobsResponse,
+    OKHGenerateJobEvents,
     OKHGenerateJobStatus,
     OKHGenerateResponse,
     OKHHarvestResponse,
@@ -1383,6 +1384,35 @@ async def get_generate_from_url_job(
             detail="Async generation jobs are not enabled on this node.",
         )
     return OKHGenerateJobStatus(**generation_jobs.get_job_status(job_id))
+
+
+@router.get(
+    "/generate-from-url/jobs/{job_id}/events",
+    response_model=OKHGenerateJobEvents,
+    summary="Read a generate-from-url job's stage events",
+)
+async def get_generate_from_url_job_events(
+    job_id: str = Path(..., description="Celery task id"),
+    since: int = Query(
+        0,
+        ge=0,
+        description="Return events after this offset; pass back next_cursor.",
+    ),
+) -> OKHGenerateJobEvents:
+    """Return the run's stage events in order, from ``since`` onward.
+
+    Job status reports the *current* stage, which a poll can only sample: a
+    stage shorter than the poll interval is never seen. This returns the log
+    instead, so a client at any interval receives every stage that ran.
+    """
+    from src.core.jobs import generation_jobs
+
+    if not generation_jobs.jobs_available():
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Async generation jobs are not enabled on this node.",
+        )
+    return OKHGenerateJobEvents(**generation_jobs.get_job_events(job_id, since=since))
 
 
 @router.post(

--- a/src/core/jobs/generation_jobs.py
+++ b/src/core/jobs/generation_jobs.py
@@ -122,6 +122,45 @@ def get_job_status(job_id: str) -> Dict[str, Any]:
     return payload
 
 
+def get_job_events(job_id: str, since: int = 0) -> Dict[str, Any]:
+    """Return the run's stage events after ``since``, in order.
+
+    The log is cumulative in the task's own state (see ``tasks.py``), so a
+    caller polling at any interval receives every stage — including ones that
+    began and ended between two polls, which a snapshot of "current stage"
+    cannot express.
+
+    ``since`` is an offset, not a timestamp: pass back ``next_cursor`` from the
+    previous call and only new events arrive. ``next_cursor`` is the length of
+    the whole log, not of this page, so a caller that skipped ahead does not
+    re-read what it already has. Asking for more than exists is not an error,
+    it is an empty page.
+
+    The events live in the task meta while the job runs and in its result once
+    it finishes, because Celery replaces one with the other on success. Both are
+    read here so a caller does not have to care which side of completion it is
+    on.
+    """
+    result = AsyncResult(job_id, app=celery_app)
+    state = result.state or "PENDING"
+
+    events: List[Dict[str, Any]] = []
+    meta = result.info if isinstance(result.info, dict) else {}
+    if isinstance(meta.get("events"), list):
+        events = meta["events"]
+    if state == "SUCCESS" and isinstance(result.result, dict):
+        finished = result.result.get("events")
+        if isinstance(finished, list):
+            events = finished
+
+    return {
+        "job_id": job_id,
+        "state": state,
+        "events": events[max(0, since) :],
+        "next_cursor": len(events),
+    }
+
+
 def revoke_job(job_id: str) -> None:
     """Ask Celery to discard/stop a generate-from-url job."""
     celery_app.control.revoke(job_id, terminate=True, signal="SIGTERM")

--- a/src/core/jobs/tasks.py
+++ b/src/core/jobs/tasks.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Dict, Optional
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
 
 from src.core.generation.progress import ProgressCallback
 from src.core.jobs.celery_app import celery_app
@@ -47,7 +48,26 @@ def generate_from_url_task(
 ) -> Dict[str, Any]:
     """Generate an OKH manifest from a repository URL (runs in the worker)."""
 
+    # Republished whole on every update, not appended to remotely.
+    #
+    # `update_state` OVERWRITES meta, so a client polling the latest event
+    # samples the timeline rather than receiving it: a stage shorter than the
+    # poll interval is never observed. Publishing the cumulative list makes a
+    # poll at any interval see everything so far, with no second store to keep,
+    # expire and secure. Nine stages make that cheap; it would not suit a
+    # high-frequency feed.
+    events: List[Dict[str, Any]] = []
+
     def on_progress(stage: str, fraction: float, message: Optional[str] = None) -> None:
+        events.append(
+            {
+                "seq": len(events),
+                "stage": stage,
+                "fraction": fraction,
+                "message": message,
+                "ts": datetime.now(timezone.utc).isoformat(),
+            }
+        )
         self.update_state(
             state="PROGRESS",
             meta={
@@ -55,6 +75,7 @@ def generate_from_url_task(
                 "fraction": fraction,
                 "message": message,
                 "url": url,
+                "events": events,
             },
         )
 
@@ -72,4 +93,8 @@ def generate_from_url_task(
     payload = dict(result)
     payload["url"] = url
     payload["job_id"] = self.request.id
+    # Celery replaces meta with the return value on success, so the log has to
+    # travel in the result or the record dies exactly when the run completes —
+    # which is when it becomes worth reading.
+    payload["events"] = events
     return payload

--- a/tests/api/test_okh_generate_jobs.py
+++ b/tests/api/test_okh_generate_jobs.py
@@ -261,3 +261,65 @@ async def test_revoke_job_returns_revoked_state(monkeypatch):
     assert resp.status_code == 200, resp.text
     assert resp.json()["state"] == "REVOKED"
     revoke.assert_called_once_with("job-111")
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_get_job_events_returns_the_ordered_log(monkeypatch):
+    """The route hands back the run log, not a snapshot of the current stage."""
+    monkeypatch.setenv("JOBS_ENABLED", "true")
+    monkeypatch.setenv("JOB_BROKER_URL", "redis://redis:6379/1")
+
+    with patch(
+        "src.core.jobs.generation_jobs.get_job_events",
+        return_value={
+            "job_id": "job-111",
+            "state": "PROGRESS",
+            "events": [
+                {
+                    "seq": 0,
+                    "stage": "clone",
+                    "fraction": 0.0,
+                    "message": "Cloning",
+                    "ts": "2026-08-29T00:00:00+00:00",
+                },
+                {
+                    "seq": 1,
+                    "stage": "direct",
+                    "fraction": 0.12,
+                    "message": None,
+                    "ts": "2026-08-29T00:00:01+00:00",
+                },
+            ],
+            "next_cursor": 2,
+        },
+    ) as reader:
+        app, _ = _get_app()
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as client:
+            resp = await client.get(
+                "/v1/api/okh/generate-from-url/jobs/job-111/events?since=0"
+            )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert [event["stage"] for event in body["events"]] == ["clone", "direct"]
+    assert body["next_cursor"] == 2
+    reader.assert_called_once_with("job-111", since=0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+async def test_get_job_events_503_when_jobs_are_disabled(monkeypatch):
+    monkeypatch.setenv("JOBS_ENABLED", "false")
+
+    app, _ = _get_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://testserver"
+    ) as client:
+        resp = await client.get("/v1/api/okh/generate-from-url/jobs/job-1/events")
+
+    assert resp.status_code == 503, resp.text

--- a/tests/parity/manifest.py
+++ b/tests/parity/manifest.py
@@ -615,6 +615,16 @@ UNCALLED_ENDPOINTS: tuple[Endpoint, ...] = (
     *_decision(
         "planned",
         "backlog",
+        "The generate-from-url run log. Job status reports the stage a run is "
+        "on, which a poll can only sample — a stage shorter than the poll "
+        "interval is never seen — so this returns the ordered log instead. The "
+        "provenance view (#378/#379) reads it to draw the stage timeline, and "
+        "the commit that wires that call deletes this row.",
+        "/api/okh/generate-from-url/jobs/{job_id}/events",
+    ),
+    *_decision(
+        "planned",
+        "backlog",
         "Calls asset_service.salvage_match and enriches a design's components "
         "with fleet availability, so it belongs to the /assets section rather "
         "than to the design catalogue — the salvage surface is where a reader "

--- a/tests/unit/test_generation_job_events.py
+++ b/tests/unit/test_generation_job_events.py
@@ -1,0 +1,153 @@
+"""The generate-from-url run log: every stage survives, whatever the poll rate.
+
+Job status reports the stage a run is *on*. Celery's ``update_state``
+overwrites its meta, so a client polling that field samples the timeline rather
+than receiving it: a stage shorter than the interval between two polls is never
+observed at all. The early stages carry small weights against ``llm``'s
+dominant one, so on a fast repository several can pass unseen — and a record of
+"what was done" cannot be built from a channel that only ever holds the present
+moment.
+
+The fix is to publish the cumulative log on every update instead of the latest
+event. These tests pin that property from both ends: the worker writes the whole
+log, and the reader pages through it.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+from src.core.jobs import generation_jobs
+from src.core.jobs.tasks import generate_from_url_task
+
+STAGES = [
+    ("clone", 0.0),
+    ("direct", 0.12),
+    ("heuristic", 0.17),
+    ("nlp", 0.25),
+    ("llm", 0.40),
+    ("quality", 0.95),
+]
+
+
+def _run_emitting_stages(published: List[Dict[str, Any]]):
+    """Run the real task against a fake generator, capturing every publish."""
+
+    async def fake_generate(*, progress=None, **_kwargs):
+        for stage, fraction in STAGES:
+            progress(stage, fraction, f"{stage} running")
+        return {"manifest": {"title": "Fixture"}}
+
+    def record(*, state, meta):  # noqa: ARG001 - state is always PROGRESS here
+        # A snapshot of what a client polling at this instant would receive.
+        published.append({"events": list(meta.get("events") or [])})
+
+    with (
+        patch("src.core.jobs.tasks._run_generate_from_url", fake_generate),
+        patch.object(generate_from_url_task, "update_state", record),
+    ):
+        return generate_from_url_task(url="https://github.com/a/one")
+
+
+def test_a_poll_at_any_moment_sees_every_stage_so_far():
+    """The regression: a slow poller must not miss a short stage.
+
+    Reading only the last publish — the worst case for a client that polled
+    once, late — still yields the complete ordered log. Before this, that read
+    returned a single stage and the five before it were unrecoverable.
+    """
+    published: List[Dict[str, Any]] = []
+    _run_emitting_stages(published)
+
+    assert len(published) == len(STAGES)
+    latest = published[-1]["events"]
+    assert [event["stage"] for event in latest] == [stage for stage, _ in STAGES]
+
+    # And a client that happened to poll in the middle sees everything up to
+    # that point, not just the stage in flight.
+    midpoint = published[2]["events"]
+    assert [event["stage"] for event in midpoint] == ["clone", "direct", "heuristic"]
+
+
+def test_the_log_survives_completion():
+    """Celery replaces meta with the return value, so the log rides in both."""
+    published: List[Dict[str, Any]] = []
+    payload = _run_emitting_stages(published)
+
+    assert [event["stage"] for event in payload["events"]] == [
+        stage for stage, _ in STAGES
+    ]
+
+
+def test_events_are_ordered_and_numbered():
+    published: List[Dict[str, Any]] = []
+    payload = _run_emitting_stages(published)
+
+    assert [event["seq"] for event in payload["events"]] == list(range(len(STAGES)))
+    fractions = [event["fraction"] for event in payload["events"]]
+    assert fractions == sorted(fractions), "progress must not go backwards"
+    assert all(event["ts"] for event in payload["events"])
+
+
+class _FakeResult:
+    def __init__(self, state: str, info: Any = None, result: Any = None):
+        self.state = state
+        self.info = info
+        self.result = result
+
+
+def _events(state: str, *, info=None, result=None, since: int = 0):
+    with patch.object(
+        generation_jobs,
+        "AsyncResult",
+        lambda *_a, **_k: _FakeResult(state, info, result),
+    ):
+        return generation_jobs.get_job_events("job-1", since=since)
+
+
+LOG = [
+    {"seq": 0, "stage": "clone", "fraction": 0.0, "message": None, "ts": "t0"},
+    {"seq": 1, "stage": "direct", "fraction": 0.12, "message": None, "ts": "t1"},
+    {"seq": 2, "stage": "nlp", "fraction": 0.25, "message": None, "ts": "t2"},
+]
+
+
+def test_since_returns_only_what_the_caller_has_not_seen():
+    page = _events("PROGRESS", info={"events": LOG}, since=2)
+    assert [event["stage"] for event in page["events"]] == ["nlp"]
+    assert page["next_cursor"] == 3
+
+
+def test_next_cursor_spans_the_whole_log_not_the_page():
+    """Otherwise a caller that skipped ahead would re-read events it has."""
+    first = _events("PROGRESS", info={"events": LOG})
+    assert first["next_cursor"] == 3
+    assert (
+        _events("PROGRESS", info={"events": LOG}, since=first["next_cursor"])["events"]
+        == []
+    )
+
+
+def test_reading_past_the_end_is_an_empty_page_not_an_error():
+    page = _events("PROGRESS", info={"events": LOG}, since=99)
+    assert page["events"] == []
+    assert page["next_cursor"] == 3
+
+
+def test_events_are_read_from_the_result_once_the_job_succeeds():
+    page = _events("SUCCESS", info={}, result={"events": LOG, "manifest": {}})
+    assert [event["stage"] for event in page["events"]] == ["clone", "direct", "nlp"]
+    assert page["state"] == "SUCCESS"
+
+
+def test_a_job_with_no_events_yet_reports_an_empty_log():
+    page = _events("PENDING", info=None)
+    assert page == {
+        "job_id": "job-1",
+        "state": "PENDING",
+        "events": [],
+        "next_cursor": 0,
+    }


### PR DESCRIPTION
Closes #375.

The substrate Track B and Track C both need: a durable, ordered record of what a generation run did.

## The problem

Job status reports the stage a run is *on*. Celery's `update_state` **overwrites** its meta, so a client polling that field *samples* the timeline rather than receiving it — any stage shorter than the interval between two polls is never observed.

That is not a corner case. The early stages carry small weights against `llm`'s dominant one, so on a fast repository several pass between polls unseen. "Progress jumped from 0% to 40%" is this, not a fault. And a record of what a run did cannot be built on a channel that only ever holds the present moment.

## The fix is not a second store

The worker keeps the log and republishes it **whole** on every update. A poll at any interval then sees everything so far, with nothing extra to keep, expire or secure — no Redis list, no TTL to manage, no new failure mode. Nine stages make that cheap; it would not suit a high-frequency feed, and the comment in `tasks.py` says so.

The log also rides in the job **result**, because Celery replaces meta with the return value on success. Without that the record would die exactly when it becomes worth reading.

## Surface

```
GET /api/okh/generate-from-url/jobs/{job_id}/events?since=N
```

```json
{
  "job_id": "…", "state": "PROGRESS", "next_cursor": 4,
  "events": [
    {"seq": 0, "stage": "clone",  "fraction": 0.0,  "message": "…", "ts": "…"},
    {"seq": 1, "stage": "direct", "fraction": 0.12, "message": "…", "ts": "…"}
  ]
}
```

`since` takes the previous response's `next_cursor`, which is the length of the whole log rather than of the page — a caller that skipped ahead does not silently re-read what it has. Reading past the end is an empty page, not an error.

Mirrored as `ohm okh generate-jobs events <job_id> --since N`, and documented in `docs/ops/async-generation.md` next to the symptom it explains.

## Testing

The regression test drives the **real task closure** rather than a reimplementation of it, and fails when the publish is reverted to a snapshot — reading only the final update then yields one stage instead of six. Verified by making that revert.

Eight unit tests cover the write side (cumulative publishing, ordering, monotonic fractions, survival past completion) and the read side (paging, cursor semantics, reading past the end, an empty log). Two API contract tests cover the route and its 503 when jobs are disabled.

## Housekeeping

Recorded in the parity manifest as `planned` / `backlog`. #378/#379 read this endpoint to draw the stage timeline, and per the manifest's own rule that commit **deletes** the row rather than editing it.

`total` was dropped from the payload during review: it was always `len(events)` — the same value `next_cursor` carries — and two fields that can never differ are a false affordance.

## Verification

`make ready`: 14/14, including the response-model gate from #374, which this route satisfies by declaring `OKHGenerateJobEvents`. `frontend-ready`: all stages — 703 unit, 237 e2e (the generated schema changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qew1kZog2JA8AKCgLxzn5X
