### PR TITLE
Generation provenance sidecar, produced beside every manifest (#376)

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 646
+Total Python files: 648
 
 ├── deploy/
 │   ├── __init__.py
@@ -1228,6 +1228,9 @@ Total Python files: 646
 │       │   ├── progress.py
 │       │   │       class ProgressEmitter (__init__, fraction_for, emit)
 │       │   │       def planned_stages()
+│       │   ├── provenance.py
+│       │   │       def _field_record()
+│       │   │       def build_provenance()
 │       │   ├── quality.py
 │       │   │       class ValidationResult (__post_init__)
 │       │   │       class QualityAssessor (__init__, assess_field_confidence, validate_required_fields...)
@@ -2778,6 +2781,17 @@ Total Python files: 646
         │       def test_celery_task_forwards_progress_via_update_state()
         │       def test_get_job_status_surfaces_progress_meta()
         │       def test_revoke_job_calls_celery_control()
+        ├── test_generation_provenance.py
+        │       def _result()
+        │       def _stable()
+        │       def test_building_the_record_leaves_the_manifest_content_hash_unchanged()
+        │       def test_the_manifest_carries_no_provenance()
+        │       def test_every_generated_field_reports_layer_method_confidence_and_source()
+        │       def test_the_timeline_comes_through()
+        │       def test_the_manifest_id_is_stable_across_serialisations()
+        │       def test_an_async_run_can_supply_its_own_timeline()
+        │       def test_the_record_is_self_describing()
+        │       def test_a_run_with_no_fields_still_produces_a_record()
         ├── test_geographic_facility_filtering.py
         │       def _make_facility()
         │       def matches_filters()
@@ -3416,7 +3430,7 @@ Total Python files: 646
 
 ## Overview
 
-Total files analyzed: 646
+Total files analyzed: 648
 
 ## Entry Points
 
@@ -7379,7 +7393,7 @@ Generates a complete, empty OKH manifest ...
 
 Prompts for required fields, then optiona...
 
-**Internal Dependencies:** 3 imports
+**Internal Dependencies:** 4 imports
 
 ### `src/cli/okw.py`
 > OKW (OpenKnowWhere) commands for OHM CLI
@@ -8733,6 +8747,19 @@ Fractions are start-of-stage cumulatives so ...
   - Return the ordered public stages for a generate-from-url run....
 
 **Internal Dependencies:** 1 imports
+
+### `src/core/generation/provenance.py`
+> The record of how a generated manifest was produced.
+
+A *sidecar*, never part of the manifest. ``man...
+
+**Exports:** build_provenance
+
+**Functions:**
+- `build_provenance(result)`
+  - Build the sidecar for a completed generation.
+
+Always produced, never behind a f...
 
 ### `src/core/generation/quality.py`
 > Quality assessment for OKH manifest generation.
@@ -11573,6 +11600,24 @@ Reading only the las...
 - `test_get_job_status_surfaces_progress_meta()`
 
 **Internal Dependencies:** 11 imports
+
+### `tests/unit/test_generation_provenance.py`
+> The generation record travels beside the manifest, never inside it.
+
+``manifest_content_hash`` is ta...
+
+**Exports:** test_building_the_record_leaves_the_manifest_content_hash_unchanged, test_the_manifest_carries_no_provenance, test_every_generated_field_reports_layer_method_confidence_and_source, test_the_timeline_comes_through, test_the_manifest_id_is_stable_across_serialisations
+
+**Functions:**
+- `test_building_the_record_leaves_the_manifest_content_hash_unchanged()`
+- `test_the_manifest_carries_no_provenance()`
+  - Not even under another name: the hash covers every key....
+- `test_every_generated_field_reports_layer_method_confidence_and_source()`
+- `test_the_timeline_comes_through()`
+- `test_the_manifest_id_is_stable_across_serialisations()`
+  - Guards the premise of the hash test above, not the sidecar itself....
+
+**Internal Dependencies:** 9 imports
 
 ### `tests/unit/test_geographic_facility_filtering.py`
 > Unit tests for geographic facility filtering (issue #172)....

--- a/docs-site/docs/guides/import-from-a-url.md
+++ b/docs-site/docs/guides/import-from-a-url.md
@@ -103,6 +103,49 @@ is the better choice if software is going to consume it directly.
     records to a shared catalogue would degrade it for everyone. Saving arrives
     with accounts.
 
+## What the generator did, and why
+
+Every run also produces a **provenance record** — a second file beside the
+manifest, not part of it:
+
+```
+manifest.okh.json          the design
+manifest.provenance.json   how it was produced
+```
+
+It carries the stage timeline and, for each field, which layer produced it, by
+what method, at what confidence, and from where:
+
+```json
+{
+  "fields": {
+    "title":       {"layer": "direct", "method": "metadata_name",
+                    "confidence": 0.91, "source": "metadata.name"},
+    "description": {"layer": "nlp", "method": "readme_summary",
+                    "confidence": 0.62, "source": "README.md"}
+  }
+}
+```
+
+That is what makes review possible rather than guesswork. A field read straight
+from repository metadata and a field inferred from prose are not equally
+trustworthy, and the record tells you which you are looking at.
+
+`source` is a short label — `metadata.name`, `README.md`, `no_version_found` —
+naming where the extractor looked. It is not an excerpt, and does not point at
+a line.
+
+!!! note "Why it is a separate file"
+
+    A manifest's content hash is taken over the whole file, and that hash is
+    what pins a package and dedups the federation catalogue. Recording *how* a
+    design was made inside the design itself would give the same design two
+    different addresses. So the manifest stays exactly what it would have been,
+    and the record travels beside it.
+
+It is always produced — there is no flag to remember, because the run worth
+explaining is invariably the one you did not think to ask about.
+
 ## When it doesn't work
 
 **"That repository couldn't be read."** Private, misspelled, or moved. Only

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -6371,6 +6371,10 @@ export interface components {
             manifest?: {
                 [key: string]: unknown;
             } | null;
+            /** Provenance */
+            provenance?: {
+                [key: string]: unknown;
+            } | null;
             /** Quality Report */
             quality_report?: {
                 [key: string]: unknown;
@@ -6479,6 +6483,10 @@ export interface components {
             manifest: {
                 [key: string]: unknown;
             };
+            /** Provenance */
+            provenance?: {
+                [key: string]: unknown;
+            } | null;
             /** Quality Report */
             quality_report?: {
                 [key: string]: unknown;

--- a/src/cli/okh.py
+++ b/src/cli/okh.py
@@ -1582,6 +1582,23 @@ async def generate_from_url(
                 with open(manifest_path, "w") as f:
                     json.dump(result, f, indent=2)
 
+            # The generation record, written beside the manifest and never
+            # inside it: the manifest's content hash is what pins a package and
+            # dedups the federation catalogue, so embedding how it was made
+            # would give the same design two addresses. See
+            # src/core/generation/provenance.py.
+            if raw_result is not None and hasattr(raw_result, "generated_fields"):
+                from src.core.generation.provenance import build_provenance
+
+                provenance_path = output_path / "manifest.provenance.json"
+                with open(provenance_path, "w") as f:
+                    json.dump(
+                        build_provenance(raw_result, source_url=url),
+                        f,
+                        indent=2,
+                        default=str,
+                    )
+
             # Export BOM if available, formats specified, and NOT in unified mode
             if (
                 bom_formats

--- a/src/core/api/models/okh/response.py
+++ b/src/core/api/models/okh/response.py
@@ -181,6 +181,10 @@ class OKHGenerateResponse(BaseModel):
     success: bool
     message: str
     manifest: Dict[str, Any]
+    # The sidecar: how this manifest was produced. Deliberately alongside the
+    # manifest rather than inside it — embedding it would change the design's
+    # content address and break pins, collection dedup and federation dedup.
+    provenance: Optional[Dict[str, Any]] = None
 
     quality_report: Optional[Dict[str, Any]] = None
 
@@ -210,6 +214,7 @@ class OKHGenerateJobStatus(BaseModel):
     url: Optional[str] = None
     error: Optional[str] = None
     manifest: Optional[Dict[str, Any]] = None
+    provenance: Optional[Dict[str, Any]] = None
     quality_report: Optional[Dict[str, Any]] = None
 
 

--- a/src/core/generation/engine.py
+++ b/src/core/generation/engine.py
@@ -677,9 +677,11 @@ class GenerationEngine:
             emitter.emit("materials_routing", "Routing materials confidence")
             await self._apply_materials_confidence_routing(result)
 
-            project_data.metadata["_generation_processing_logs"] = list(
-                gen_meta.processing_logs
-            )
+            # Was `project_data.metadata["_generation_processing_logs"]`, a list
+            # of formatted strings no production code read. The same record now
+            # reaches the provenance sidecar structured, so it can be rendered
+            # and sorted rather than only logged.
+            result.stage_events = list(emitter.events)
 
             # Update metrics
             processing_time = time.time() - start_time

--- a/src/core/generation/models.py
+++ b/src/core/generation/models.py
@@ -388,6 +388,10 @@ class ManifestGeneration:
     review_items: Dict[str, List[Any]] = field(default_factory=dict)
     # Keys rejected by LLM/human triage; suppress re-harvest on re-normalize
     materials_rejected_keys: set = field(default_factory=set)
+    # What ran, in order, from ProgressEmitter. Read by the provenance sidecar;
+    # never by to_okh_manifest — the manifest must not change because we
+    # recorded how it was made.
+    stage_events: List[Dict[str, Any]] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary format"""

--- a/src/core/generation/progress.py
+++ b/src/core/generation/progress.py
@@ -9,7 +9,8 @@ large-repo runs; renormalize after dropping inactive stages (e.g. ``no_llm``).
 
 from __future__ import annotations
 
-from typing import Callable, Dict, List, Optional, Sequence
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional, Sequence
 
 from src.core.generation.models import GenerationMetadata
 
@@ -64,6 +65,10 @@ class ProgressEmitter:
         self._callback = callback
         self._metadata = metadata
         self._last = 0.0
+        # The structured record of what ran. `processing_logs` holds the same
+        # information as prose, which reads well in a log and cannot be
+        # rendered, sorted or diffed.
+        self.events: List[Dict[str, Any]] = []
         total = sum(_STAGE_WEIGHTS.get(s, 1.0) for s in self._stages)
         running = 0.0
         self._cum: Dict[str, float] = {}
@@ -79,6 +84,15 @@ class ProgressEmitter:
     def emit(self, stage: str, message: Optional[str] = None) -> None:
         fraction = max(self._last, self.fraction_for(stage))
         self._last = fraction
+        self.events.append(
+            {
+                "seq": len(self.events),
+                "stage": stage,
+                "fraction": round(fraction, 4),
+                "message": message,
+                "ts": datetime.now(timezone.utc).isoformat(),
+            }
+        )
         if self._metadata is not None:
             label = message or stage
             self._metadata.add_processing_log(f"{stage}: {label} ({fraction:.2f})")

--- a/src/core/generation/provenance.py
+++ b/src/core/generation/provenance.py
@@ -1,0 +1,79 @@
+"""The record of how a generated manifest was produced.
+
+A *sidecar*, never part of the manifest. ``manifest_content_hash`` is taken over
+the whole manifest dict with no field exclusions, so provenance embedded in it
+would change the design's content address — the value that pins a package, dedups
+a collection, and dedups the federation catalogue. The same design generated
+twice would become two different designs.
+
+Namespacing the keys and excluding them from the hash is not an escape either:
+an ``ohm_``-prefixed key is already inside the hash today, so changing the hash
+function would retroactively invalidate every existing pin and catalogue entry.
+
+This mirrors a call already made for record provenance, which lives in its own
+store for the same reason (``models/provenance.py``, per
+``notes/federated-identity-adr.md`` §4.3).
+
+The pipeline already computes all of this and used to discard it: ``FieldGeneration``
+carries the layer, method and source of every field, and ``to_okh_manifest``
+exported only a bare confidence float. Nothing here is new instrumentation.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from .models import FieldGeneration, ManifestGeneration
+
+SCHEMA = "ohm-generation-provenance/v1"
+
+
+def _field_record(field_gen: FieldGeneration) -> Dict[str, Any]:
+    """Layer, method, confidence and source for one generated field.
+
+    ``raw_source`` is a short label — ``"metadata.name"``, ``"README.md"``,
+    ``"no_version_found"`` — not an excerpt of source text. It ships whole
+    because it is already small. File and line spans would mean threading
+    offsets through every extractor in all four layers, which is a project of
+    its own rather than a field (deferred; see #370's follow-up).
+    """
+    return {
+        "layer": field_gen.source_layer.value,
+        "method": field_gen.generation_method,
+        "confidence": round(float(field_gen.confidence), 3),
+        "source": field_gen.raw_source,
+    }
+
+
+def build_provenance(
+    result: ManifestGeneration,
+    *,
+    source_url: Optional[str] = None,
+    stages: Optional[List[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    """Build the sidecar for a completed generation.
+
+    Always produced, never behind a flag: the one run worth explaining is
+    otherwise the run that recorded nothing. It costs a dict comprehension over
+    fields the pipeline already computed.
+
+    ``stages`` defaults to the timeline the engine collected. An async run can
+    pass the job event log instead, which carries the same shape.
+    """
+    fields = {
+        name: _field_record(field_gen)
+        for name, field_gen in sorted(result.generated_fields.items())
+    }
+    timeline = (
+        stages
+        if stages is not None
+        else list(getattr(result, "stage_events", []) or [])
+    )
+    return {
+        "schema": SCHEMA,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "source_url": source_url,
+        "stages": timeline,
+        "fields": fields,
+    }

--- a/src/core/jobs/generation_jobs.py
+++ b/src/core/jobs/generation_jobs.py
@@ -109,12 +109,14 @@ def get_job_status(job_id: str) -> Dict[str, Any]:
         "url": meta.get("url"),
         "error": None,
         "manifest": None,
+        "provenance": None,
         "quality_report": None,
     }
     if state == "SUCCESS" and isinstance(result.result, dict):
         payload["url"] = result.result.get("url") or payload["url"]
         payload["message"] = result.result.get("message") or payload["message"]
         payload["manifest"] = result.result.get("manifest")
+        payload["provenance"] = result.result.get("provenance")
         payload["quality_report"] = result.result.get("quality_report")
         payload["fraction"] = 1.0
     elif state == "FAILURE":

--- a/src/core/services/okh_service.py
+++ b/src/core/services/okh_service.py
@@ -1099,10 +1099,19 @@ class OKHService(BaseService["OKHService"]):
                 # Prepended: it explains the gaps the other recommendations list.
                 recommendations.insert(0, note)
 
+            # Always produced, never behind a flag: the one run worth explaining
+            # is otherwise the run that recorded nothing. A sidecar, not part of
+            # the manifest — see generation/provenance.py for why that matters
+            # to the content hash.
+            from ..generation.provenance import build_provenance
+
+            provenance = build_provenance(result, source_url=url)
+
             return {
                 "success": True,
                 "message": "Manifest generated successfully",
                 "manifest": manifest_dict,
+                "provenance": provenance,
                 "quality_report": {
                     "overall_quality": result.quality_report.overall_quality,
                     "required_fields_complete": result.quality_report.required_fields_complete,

--- a/tests/unit/test_generation_progress.py
+++ b/tests/unit/test_generation_progress.py
@@ -95,8 +95,13 @@ async def test_generate_manifest_async_reports_monotonic_progress():
     assert "heuristic" in stage_names
     assert "quality" in stage_names
     assert "llm" not in stage_names
-    logs = project.metadata.get("_generation_processing_logs")
-    assert logs and any("direct" in line for line in logs)
+    # The run's own record of what it did. This used to be a list of formatted
+    # strings on project.metadata that nothing but this assertion read; it is
+    # now the structured timeline the provenance sidecar renders.
+    assert result.stage_events, "expected the run to record its stages"
+    assert any(event["stage"] == "direct" for event in result.stage_events)
+    recorded = [event["fraction"] for event in result.stage_events]
+    assert recorded == sorted(recorded)
 
 
 def test_celery_task_forwards_progress_via_update_state(monkeypatch):

--- a/tests/unit/test_generation_provenance.py
+++ b/tests/unit/test_generation_provenance.py
@@ -1,0 +1,164 @@
+"""The generation record travels beside the manifest, never inside it.
+
+``manifest_content_hash`` is taken over the whole manifest dict with no field
+exclusions, so provenance embedded in ``metadata`` would change the design's
+content address — the value that pins a package, dedups a collection and dedups
+the federation catalogue. The same design generated twice would then be two
+different designs, and "clean" versus "with provenance" two more.
+
+The first test is the one that matters: producing the record must leave the
+manifest byte-identical.
+"""
+
+from __future__ import annotations
+
+import copy
+
+from src.core.federation.catalog import manifest_content_hash
+from src.core.generation.models import (
+    FieldGeneration,
+    GenerationLayer,
+    ManifestGeneration,
+    PlatformType,
+    ProjectData,
+    QualityReport,
+)
+from src.core.generation.provenance import SCHEMA, build_provenance
+
+STAGES = [
+    {"seq": 0, "stage": "clone", "fraction": 0.12, "message": "Cloning", "ts": "t0"},
+    {"seq": 1, "stage": "nlp", "fraction": 0.40, "message": None, "ts": "t1"},
+]
+
+
+def _result() -> ManifestGeneration:
+    return ManifestGeneration(
+        project_data=ProjectData(
+            platform=PlatformType.GITHUB,
+            url="https://example.com/org/repo",
+            metadata={},
+            files=[],
+            documentation=[],
+            raw_content={},
+        ),
+        generated_fields={
+            # Present so the manifest id is derived (uuid5 over the repo URL)
+            # rather than random: without a repo, to_okh_manifest falls back to
+            # uuid4 and is non-deterministic call to call, which would make the
+            # hash comparison below meaningless rather than strict.
+            "repo": FieldGeneration(
+                value="https://example.com/org/repo",
+                confidence=1.0,
+                source_layer=GenerationLayer.DIRECT,
+                generation_method="metadata_html_url",
+                raw_source="metadata.html_url",
+            ),
+            "title": FieldGeneration(
+                value="Open Ventilator",
+                confidence=0.91,
+                source_layer=GenerationLayer.DIRECT,
+                generation_method="metadata_name",
+                raw_source="metadata.name",
+            ),
+            "description": FieldGeneration(
+                value="A 3D-printable valve",
+                confidence=0.62,
+                source_layer=GenerationLayer.NLP,
+                generation_method="readme_summary",
+                raw_source="README.md",
+            ),
+        },
+        confidence_scores={"title": 0.91, "description": 0.62},
+        quality_report=QualityReport(
+            overall_quality=0.8,
+            required_fields_complete=True,
+            missing_required_fields=[],
+            low_confidence_fields=["description"],
+            recommendations=[],
+        ),
+        missing_fields=[],
+        stage_events=list(STAGES),
+    )
+
+
+def _stable(manifest: dict) -> dict:
+    """The manifest minus the one field that is a clock reading.
+
+    ``metadata.generated_at`` is stamped per call, so two serialisations of the
+    same result differ there and nowhere else. Freezing it isolates the question
+    this test asks — does building the record change the manifest — from the
+    passage of time.
+    """
+    out = copy.deepcopy(manifest)
+    if isinstance(out.get("metadata"), dict):
+        out["metadata"]["generated_at"] = "<frozen>"
+    return out
+
+
+def test_building_the_record_leaves_the_manifest_content_hash_unchanged():
+    result = _result()
+    before = manifest_content_hash(_stable(result.to_okh_manifest()))
+
+    build_provenance(result, source_url="https://example.com/org/repo")
+
+    after = manifest_content_hash(_stable(result.to_okh_manifest()))
+    assert before == after, (
+        "Producing provenance changed the manifest's content address. Pins, "
+        "collection dedup and federation dedup all key off this hash."
+    )
+
+
+def test_the_manifest_carries_no_provenance():
+    """Not even under another name: the hash covers every key."""
+    manifest = _result().to_okh_manifest()
+    serialised = str(manifest)
+    assert "provenance" not in serialised
+    assert "stage_events" not in serialised
+    assert SCHEMA not in serialised
+
+
+def test_every_generated_field_reports_layer_method_confidence_and_source():
+    record = build_provenance(_result())
+
+    assert record["fields"]["title"] == {
+        "layer": GenerationLayer.DIRECT.value,
+        "method": "metadata_name",
+        "confidence": 0.91,
+        "source": "metadata.name",
+    }
+    # The accuracy-checking case: which layer produced this, and from where.
+    assert record["fields"]["description"]["layer"] == GenerationLayer.NLP.value
+    assert record["fields"]["description"]["source"] == "README.md"
+
+
+def test_the_timeline_comes_through():
+    record = build_provenance(_result())
+    assert [event["stage"] for event in record["stages"]] == ["clone", "nlp"]
+
+
+def test_the_manifest_id_is_stable_across_serialisations():
+    """Guards the premise of the hash test above, not the sidecar itself."""
+    result = _result()
+    assert result.to_okh_manifest()["id"] == result.to_okh_manifest()["id"]
+
+
+def test_an_async_run_can_supply_its_own_timeline():
+    """The job event log has the same shape, so it substitutes directly."""
+    from_job = [{"seq": 0, "stage": "llm", "fraction": 0.4, "message": None, "ts": "t"}]
+    record = build_provenance(_result(), stages=from_job)
+    assert [event["stage"] for event in record["stages"]] == ["llm"]
+
+
+def test_the_record_is_self_describing():
+    record = build_provenance(_result(), source_url="https://example.com/org/repo")
+    assert record["schema"] == SCHEMA
+    assert record["source_url"] == "https://example.com/org/repo"
+    assert record["generated_at"]
+
+
+def test_a_run_with_no_fields_still_produces_a_record():
+    result = _result()
+    result.generated_fields = {}
+    record = build_provenance(result)
+    assert record["fields"] == {}
+    assert record["schema"] == SCHEMA


### PR DESCRIPTION
Closes #376.

## The reframe

The pipeline was not under-instrumented, it was **under-serialized**. Every `FieldGeneration` already carried the layer that produced it, the method, the confidence and a source label — and `to_okh_manifest` exported a bare confidence float and discarded the rest. The stage timeline was likewise written to `processing_logs` as prose nothing rendered.

Almost everything this issue asks to surface was already being computed and thrown away, so **this adds no new instrumentation**.

## A sidecar, never part of the manifest

`manifest_content_hash` is taken over the whole dict with no field exclusions, and that hash pins a package, dedups a collection, and dedups the federation catalogue. Provenance inside the manifest would give the same design two addresses — and "clean" versus "with provenance" two more.

Namespacing under `ohm_` and excluding it from the hash is not an escape either: `ohm_created_by` is already inside the hash, so changing the hash function would retroactively invalidate every existing pin. This mirrors the call already made for record provenance, which lives in its own store for the same reason.

## Two tests, guarding different things

This is worth reading carefully, because the issue asked for one test and one is not enough:

- **the content-hash test** catches mutation *while building* the record;
- it does **not** catch embedding — deterministic embedding moves both hashes equally and passes — so **a second test** asserts the manifest carries no provenance under any name.

Verified by writing provenance into `manifest_metadata` and watching only the second fail.

### An unrelated non-determinism found on the way

The hash test failed on its first run, and not because of the sidecar: `to_okh_manifest` is non-deterministic **by itself** when a manifest has no `repo` field, because the id falls back to `uuid.uuid4()`. The fixture now carries a repo so the `uuid5` path is exercised and the assertion stays strict. The fallback is pre-existing and untouched here — a repo-less design gets a new id on every generation, which may deserve its own issue.

## What the record contains

```json
{
  "schema": "ohm-generation-provenance/v1",
  "source_url": "…",
  "stages": [{"seq": 0, "stage": "clone", "fraction": 0.12, "ts": "…"}],
  "fields": {
    "title": {"layer": "direct", "method": "metadata_name",
              "confidence": 0.91, "source": "metadata.name"}
  }
}
```

`source` ships as-is: a short label (`metadata.name`, `README.md`, `no_version_found`), not an excerpt. File/line spans would mean threading offsets through every extractor in all four layers — deferred deliberately.

Always produced, no flag: the run worth explaining is invariably the one nobody thought to ask about, and it costs a comprehension over fields already in hand.

## Surface

Returned on the generate response and on async job status, written as `manifest.provenance.json` beside the manifest by the CLI, documented in the import guide.

## The orphaned key is gone

`project_data.metadata["_generation_processing_logs"]` is removed. No production code read it — but **one test did**, which slightly overstated my "read by nothing" claim in the issue. That assertion now checks the structured timeline instead, including monotonic fractions, which the string form could not express.

## Verification

`make ready`: 14/14. `frontend-ready`: all stages — 703 unit, 237 e2e.

Next in the chain: #378 draws this record (HITL — needs a design review), then #379 makes the same page fill in live from the #375 event log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qew1kZog2JA8AKCgLxzn5X
