### PR TITLE
Promote Generate to a top-level header action (#392)

### DIFF
--- a/frontend/src/components/layout/SiteHeader.test.tsx
+++ b/frontend/src/components/layout/SiteHeader.test.tsx
@@ -1,0 +1,79 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SiteHeader } from "./SiteHeader";
+import { AuthProvider } from "../../context/AuthContext";
+import { DomainContext } from "../../context/DomainContext";
+import { setMockNavigation } from "../../test/nextNavigation";
+import type { OhmDomain } from "../../features/settings/domainPreference";
+
+/**
+ * Generate is promoted out of the sitemap into the header.
+ *
+ * It is the longest-running and most distinctive operation in the product and
+ * sat two clicks away behind an icon with no word on it. These tests pin the
+ * three things that make the promotion correct rather than merely present.
+ */
+function renderHeader(domain: OhmDomain = "manufacturing") {
+  // The header mounts the demo-data badge, which reads auth and the query
+  // cache; the subject here is the Generate action, so those are supplied
+  // rather than stubbed out.
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <AuthProvider>
+        <DomainContext.Provider value={{ domain, setDomain: () => {} }}>
+          <SiteHeader />
+        </DomainContext.Provider>
+      </AuthProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("SiteHeader — the Generate action", () => {
+  it("is reachable by name, at every width", () => {
+    // One text node, sr-only below `sm`, so the accessible name does not
+    // depend on the viewport — the icon alone would leave the phone header
+    // with an unnamed control.
+    renderHeader();
+    const action = screen.getByRole("link", { name: "Generate" });
+    expect(action).toHaveAttribute("href", "/okh/generate");
+  });
+
+  it("does not claim the current page when you are elsewhere", () => {
+    setMockNavigation({ pathname: "/okh" });
+    renderHeader();
+    expect(
+      screen.getByRole("link", { name: "Generate" }),
+    ).not.toHaveAttribute("aria-current");
+  });
+
+  it("claims the current page inside the generator", () => {
+    setMockNavigation({ pathname: "/okh/generate" });
+    renderHeader();
+    expect(screen.getByRole("link", { name: "Generate" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+
+  it("is absent in the cooking domain, which has no generator", () => {
+    // navGroupsForDomain drops Generate for cooking. Promoting it anyway would
+    // advertise in the chrome a route that domain deliberately removes.
+    renderHeader("cooking");
+    expect(
+      screen.queryByRole("link", { name: "Generate" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("leaves the existing header controls alone", () => {
+    renderHeader();
+    expect(screen.getByRole("button", { name: /Switch to/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Site menu" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Open Hardware Manager/ }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/layout/SiteHeader.tsx
+++ b/frontend/src/components/layout/SiteHeader.tsx
@@ -2,21 +2,41 @@
 
 import { useCallback, useState } from "react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { Menu, Moon, Sun } from "lucide-react";
 import { useTheme } from "../../context/ThemeContext";
+import { useDomain } from "../../context/DomainContext";
 import { NavDrawer } from "./NavDrawer";
+import { GENERATE_ENTRY, isActivePath, navGroupsForDomain } from "./nav";
 import { useKeyboardShortcuts } from "../../hooks/useKeyboardShortcuts";
 import { DemoDataBadge } from "../../features/dashboard/DemoDataBadge";
 import { Logo } from "./Logo";
 
 /**
  * The universal header, in the TTM chrome idiom: a slim bar that carries the
- * wordmark and the tools cluster, and nothing else. Every page's own h1 is
- * its identity; all navigation is consolidated in the hamburger sitemap.
+ * wordmark and the tools cluster. Every page's own h1 is its identity, and the
+ * sitemap stays consolidated in the hamburger.
+ *
+ * One exception, and it is deliberate: Generate. It is the longest-running and
+ * most distinctive operation in the product, and it sat two clicks away behind
+ * an icon with no word on it — present in the sitemap under Create, invisible
+ * in the chrome. Promoting it puts the only word in the bar on the thing most
+ * worth finding. It is an action rather than a section, which is why it reads
+ * as a button and not as the first of a row of nav links.
  */
 export function SiteHeader() {
   const [menuOpen, setMenuOpen] = useState(false);
   const { isDark, toggle } = useTheme();
+  const { domain } = useDomain();
+  const pathname = usePathname() ?? "";
+
+  // Asked of the domain-filtered sitemap rather than of GENERATE_ENTRY, because
+  // cooking drops generation altogether: promoting a row that domain removes
+  // would advertise a route it deliberately hides.
+  const generatePromoted = navGroupsForDomain(domain).some((group) =>
+    group.entries.includes(GENERATE_ENTRY),
+  );
+  const GenerateIcon = GENERATE_ENTRY.icon;
 
   // Stable, because the drawer's focus trap keys its effect on this callback:
   // an inline arrow made every header render a teardown and rebuild of the
@@ -51,6 +71,25 @@ export function SiteHeader() {
           <span className="mr-2 empty:mr-0">
             <DemoDataBadge />
           </span>
+
+          {/* Square below `sm`, labelled from `sm` up. One text node either
+              way — `sr-only`, not a second hidden copy — so the accessible
+              name is the same string at every width, and being out of flow it
+              opens no gap beside the icon on a phone. */}
+          {generatePromoted && (
+            <Link
+              href={GENERATE_ENTRY.href}
+              aria-current={
+                isActivePath(pathname, GENERATE_ENTRY.href) ? "page" : undefined
+              }
+              className="mr-1 flex h-11 w-11 items-center justify-center gap-2 rounded-md bg-primary text-primary-foreground no-underline transition-colors hover:bg-primary/80 sm:w-auto sm:px-3"
+            >
+              <GenerateIcon aria-hidden="true" className="h-5 w-5" />
+              <span className="text-sm font-medium sr-only sm:not-sr-only">
+                Generate
+              </span>
+            </Link>
+          )}
 
           <button
             type="button"

--- a/frontend/src/components/layout/nav.ts
+++ b/frontend/src/components/layout/nav.ts
@@ -90,6 +90,22 @@ export interface NavGroup {
   accent: string;
 }
 
+/**
+ * Generate, which the header promotes to a labelled action.
+ *
+ * Declared once and referenced into Create below rather than spelled twice, so
+ * the header and the sitemap cannot disagree about the route, name or icon.
+ * Promotion adds a second way in; the row stays. It is still dropped for
+ * cooking by `navGroupsForDomain`, which is why the header asks that function
+ * rather than reaching for this constant.
+ */
+export const GENERATE_ENTRY: NavEntry = {
+  href: "/okh/generate",
+  name: "Generate",
+  desc: "draft a design manifest from a URL",
+  icon: RobotIcon,
+};
+
 export const NAV_GROUPS: NavGroup[] = [
   {
     label: "Explore",
@@ -151,12 +167,7 @@ export const NAV_GROUPS: NavGroup[] = [
         desc: "pair a design with facilities that can build it",
         icon: IntegrationIcon,
       },
-      {
-        href: "/okh/generate",
-        name: "Generate",
-        desc: "draft a design manifest from a URL",
-        icon: RobotIcon,
-      },
+      GENERATE_ENTRY,
       {
         href: "/okh/new",
         name: "New design",


### PR DESCRIPTION
Closes #392.

Generation is the longest-running and most distinctive operation in the product, and it took two clicks to reach behind an icon carrying no word.

**It was not missing from navigation.** `nav.ts` has listed Generate under **Create** all along, with an icon and the description "draft a design manifest from a URL". The problem is that the whole sitemap lives behind the hamburger, and `SiteHeader` renders only the mark and two icon buttons — so nothing in the chrome suggested the generator existed.

This adds a second way in. The sitemap row stays exactly where it was, and the entry is now **declared once** and referenced into Create, so the header and the sitemap cannot drift apart on route, name or icon.

## The domain gate — not in the issue

`navGroupsForDomain` **drops Generate for cooking**, along with Match, Packages, New design and RFQ; there is an existing test asserting that. Promoting it unconditionally would have advertised in the chrome a route that domain deliberately hides.

So the header asks the *domain-filtered* sitemap whether the row is present, rather than reaching for the constant directly. There is a test for it, and I confirmed it fails when the gate is removed.

## Responsive, and what the tests can and cannot prove

Square below `sm`, labelled above. **One text node either way** — `sr-only sm:not-sr-only`, not a second hidden copy — so the accessible name is the same string at every width. Two copies, or an icon alone, would leave the phone header with an unnamed control.

Being honest about coverage: **jsdom evaluates no CSS**, so the unit tests cannot distinguish `sr-only` from `hidden` and do not prove the responsive half. That is the existing responsive lane's job — it runs every route at 360px and 768px asserting nothing overflows horizontally and no control is undersized, and the header is on every page, so this is covered without touching the frozen baseline.

## Why a button, not a nav row

The header is 56px with a 44px target on each side; a row of links underneath would double the chrome on every page to surface one destination. Generate is an *action* that starts a long-running job, not a section you browse — a button says that, a nav link does not.

## Docstring

`SiteHeader`'s own docstring claimed the bar carries "nothing else" and that "all navigation is consolidated in the hamburger sitemap". This change makes both false, so it now records the exception and the reason for it.

## Tests

Five, covering: reachable by name with the right href; no `aria-current` elsewhere; `aria-current="page"` inside the generator; absent for cooking; and the existing header controls untouched.

## Verification

`make ready`: 14/14. `frontend-ready`: all stages — 708 unit, 237 e2e, a11y included.

Design: the **Header · top-level Generate** artboard on the canvas linked from #378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qew1kZog2JA8AKCgLxzn5X
