### PR TITLE
The generation record, as three readings of one run (#378)

### DIFF
--- a/frontend/src/features/generate/GenerateView.tsx
+++ b/frontend/src/features/generate/GenerateView.tsx
@@ -38,6 +38,11 @@ import { toQualityBanner } from "./qualityBanner";
 import { downloadManifest } from "./serialize";
 import { missingRequired } from "./manifestTiers";
 import { TieredEditor } from "./TieredEditor";
+import { ProvenanceRecord } from "./ProvenanceRecord";
+import {
+  readGenerationProvenance,
+  type GenerationProvenance,
+} from "./generationProvenance";
 import { parseRepoUrlList } from "./urlValidation";
 import {
   aggregatePercent,
@@ -119,6 +124,9 @@ export function GenerateView() {
   const [jobs, setJobs] = useState<GenerateJobRef[]>([]);
   const [active, setActive] = useState(false);
   const [manifest, setManifest] = useState<Manifest | null>(null);
+  const [provenance, setProvenance] = useState<GenerationProvenance | null>(
+    null,
+  );
   const [report, setReport] = useState<OkhQualityReport | null>(null);
   const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
 
@@ -145,6 +153,7 @@ export function GenerateView() {
         message: data?.message,
         error: data?.error,
         manifest: data?.manifest,
+        provenance: data?.provenance,
         quality_report: data?.quality_report,
       };
     });
@@ -175,6 +184,9 @@ export function GenerateView() {
     const pick = successes[0];
     setSelectedJobId(pick.job_id);
     setManifest(pick.manifest as Manifest);
+    // Parsed rather than cast: the server types this Dict[str, Any], so codegen
+    // vouches for nothing. A malformed record costs this panel, not the run.
+    setProvenance(readGenerationProvenance(pick.provenance));
     setReport((pick.quality_report as OkhQualityReport | null) ?? null);
     if (failures.length > 0) {
       setError(
@@ -352,6 +364,9 @@ export function GenerateView() {
                   onClick={() => {
                     setSelectedJobId(s.job_id);
                     setManifest(s.manifest as Manifest);
+                    // Also swapped, or the record would describe the run the
+                    // reader just navigated away from.
+                    setProvenance(readGenerationProvenance(s.provenance));
                     setReport(
                       (s.quality_report as OkhQualityReport | null) ?? null,
                     );
@@ -386,6 +401,8 @@ export function GenerateView() {
           <div className={PANEL}>
             <TieredEditor manifest={manifest} onChange={setManifest} />
           </div>
+
+          {provenance && <ProvenanceRecord record={provenance} />}
 
           <div className="flex flex-wrap items-center gap-3">
             <button

--- a/frontend/src/features/generate/ProvenanceRecord.test.tsx
+++ b/frontend/src/features/generate/ProvenanceRecord.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { ProvenanceRecord } from "./ProvenanceRecord";
+import type { GenerationProvenance } from "./generationProvenance";
+
+const record: GenerationProvenance = {
+  schema: "ohm-generation-provenance/v1",
+  generated_at: "2026-08-29T12:00:00+00:00",
+  source_url: "https://github.com/org/repo",
+  stages: [
+    { seq: 0, stage: "clone", fraction: 0.12, message: "Cloning", ts: "2026-08-29T12:00:00Z" },
+    { seq: 1, stage: "direct", fraction: 0.17, message: null, ts: "2026-08-29T12:00:04Z" },
+    { seq: 2, stage: "nlp", fraction: 0.4, message: null, ts: "2026-08-29T12:00:04.200Z" },
+  ],
+  fields: {
+    title: { layer: "direct", method: "metadata_name", confidence: 0.98, source: "metadata.name" },
+    description: { layer: "nlp", method: "readme_summary", confidence: 0.62, source: "README.md" },
+    version: { layer: "direct", method: "none", confidence: 0, source: "no_version_found" },
+  },
+};
+
+describe("ProvenanceRecord", () => {
+  it("opens on Review, with what needs checking first", () => {
+    render(<ProvenanceRecord record={record} />);
+    const headings = screen
+      .getAllByRole("heading", { level: 2 })
+      .map((h) => h.textContent ?? "");
+    const notFound = headings.findIndex((t) => t.includes("Nothing was found"));
+    const settled = headings.findIndex((t) =>
+      t.includes("Read straight from the repository"),
+    );
+    expect(notFound).toBeGreaterThanOrEqual(0);
+    expect(notFound).toBeLessThan(settled);
+  });
+
+  it("says a field was not found instead of showing it as zero", () => {
+    // "0.00" reads as a measurement; the generator did not measure low
+    // confidence here, it found nothing.
+    render(<ProvenanceRecord record={record} />);
+    expect(screen.getByText("not found")).toBeInTheDocument();
+    expect(screen.queryByText("0.00")).not.toBeInTheDocument();
+  });
+
+  it("switches to every field, with method and source", async () => {
+    const user = userEvent.setup();
+    render(<ProvenanceRecord record={record} />);
+    await user.click(screen.getByRole("radio", { name: "Fields" }));
+
+    expect(screen.getByText("Every field — 3")).toBeInTheDocument();
+    expect(screen.getByText("readme_summary")).toBeInTheDocument();
+    expect(screen.getAllByText("method")).toHaveLength(3);
+  });
+
+  it("switches to the stages, including one shorter than a poll", async () => {
+    // direct ran for 0.2s. A progress bar sampling once a second never shows
+    // it; the log is the only place it exists.
+    const user = userEvent.setup();
+    render(<ProvenanceRecord record={record} />);
+    await user.click(screen.getByRole("radio", { name: "Stages" }));
+
+    const stages = screen.getByRole("heading", { name: /What ran/ })
+      .parentElement as HTMLElement;
+    expect(within(stages).getByText("direct")).toBeInTheDocument();
+    expect(within(stages).getByText("0.2s")).toBeInTheDocument();
+  });
+
+  it("is one keyboard stop, arrow keys moving between readings", async () => {
+    // SegmentedControl's contract; asserted here because the tabs are useless
+    // to a keyboard user if this regresses.
+    const user = userEvent.setup();
+    render(<ProvenanceRecord record={record} />);
+    await user.tab();
+    await user.tab();
+    expect(screen.getByRole("radio", { name: "Review" })).toHaveFocus();
+    await user.keyboard("{ArrowRight}");
+    expect(screen.getByRole("radio", { name: "Fields" })).toHaveFocus();
+  });
+
+  it("names the repository the record came from", () => {
+    render(<ProvenanceRecord record={record} />);
+    expect(screen.getByText("https://github.com/org/repo")).toBeInTheDocument();
+  });
+});
+
+describe("ProvenanceRecord — a run that recorded little", () => {
+  const bare: GenerationProvenance = {
+    schema: "ohm-generation-provenance/v1",
+    generated_at: null,
+    source_url: null,
+    stages: [{ seq: 0, stage: "clone", fraction: 1, message: null, ts: null }],
+    fields: {},
+  };
+
+  it("says so on the view that is empty, rather than showing a blank tab", async () => {
+    const user = userEvent.setup();
+    render(<ProvenanceRecord record={bare} />);
+    expect(screen.getByText("This run recorded no fields.")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("radio", { name: "Stages" }));
+    expect(screen.getByRole("heading", { name: /What ran/ })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/generate/ProvenanceRecord.tsx
+++ b/frontend/src/features/generate/ProvenanceRecord.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useState } from "react";
+import { Badge } from "@/components/ui/Badge";
+import { SectionHeading } from "@/components/ui/SectionHeading";
+import { SegmentedControl } from "@/components/ui/SegmentedControl";
+import { PANEL, PANEL_MUTED } from "@/components/ui/surface";
+import { BODY_MUTED, CAPTION } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+import {
+  groupForReview,
+  stageDurations,
+  type GenerationProvenance,
+  type NamedField,
+  type ReviewGroup,
+} from "./generationProvenance";
+
+/**
+ * How a generated manifest was produced.
+ *
+ * Three readings of one record, because a reviewer arrives with one of three
+ * questions and no single ordering answers all of them:
+ *
+ *   Review — what needs checking?
+ *   Fields — is this particular value right?
+ *   Stages — what did the run do?
+ *
+ * Nothing is duplicated between them; they differ in what they put first.
+ *
+ * Rendered from a record handed in, never fetched here: generation is not
+ * persisted server-side, so the same view serves a run that just finished and
+ * a sidecar someone kept on disk (#393 supplies the second).
+ */
+type View = "review" | "fields" | "stages";
+
+const VIEWS = [
+  { value: "review" as const, label: "Review" },
+  { value: "fields" as const, label: "Fields" },
+  { value: "stages" as const, label: "Stages" },
+];
+
+/** Layer names are the API's own; a badge tints the ones that inferred. */
+function LayerBadge({ layer }: { layer: string }) {
+  const variant =
+    layer === "llm" || layer === "nlp" || layer === "heuristic"
+      ? "yellow"
+      : "default";
+  return (
+    <Badge variant={variant}>
+      <span className="font-mono">{layer}</span>
+    </Badge>
+  );
+}
+
+function Confidence({ value }: { value: number }) {
+  if (value <= 0) {
+    return (
+      <span className="font-mono text-caption text-destructive-ink">
+        not found
+      </span>
+    );
+  }
+  return (
+    <span className="font-mono text-caption tabular-nums">
+      {value.toFixed(2)}
+    </span>
+  );
+}
+
+/** One field as a row: what it is, where it came from, how sure the run was. */
+function FieldRow({ field }: { field: NamedField }) {
+  return (
+    <li className="flex flex-wrap items-baseline gap-x-3 gap-y-1 px-4 py-2.5">
+      <span className="text-small text-foreground">{field.name}</span>
+      <span className={cn(CAPTION, "font-mono")}>{field.source}</span>
+      <span className="ml-auto flex items-baseline gap-3">
+        <LayerBadge layer={field.layer} />
+        <Confidence value={field.confidence} />
+      </span>
+    </li>
+  );
+}
+
+/** Said by whichever view has nothing, rather than leaving a blank tab. */
+function NothingRecorded({ what }: { what: string }) {
+  return <p className={cn(PANEL_MUTED, BODY_MUTED)}>This run recorded no {what}.</p>;
+}
+
+function ReviewList({ groups }: { groups: ReviewGroup[] }) {
+  if (groups.length === 0) return <NothingRecorded what="fields" />;
+  return (
+    <div className="space-y-4">
+      {groups.map((group) => (
+        <section
+          key={group.id}
+          aria-labelledby={`provenance-${group.id}`}
+          className={PANEL}
+        >
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+            <SectionHeading id={`provenance-${group.id}`} role="card">
+              {group.title} — {group.fields.length}{" "}
+              {group.fields.length === 1 ? "field" : "fields"}
+            </SectionHeading>
+            <p className={CAPTION}>{group.note}</p>
+          </div>
+          <ul className="mt-1 divide-y divide-border">
+            {group.fields.map((field) => (
+              <FieldRow key={field.name} field={field} />
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function FieldsList({ record }: { record: GenerationProvenance }) {
+  const fields = Object.entries(record.fields)
+    .map(([name, field]) => ({ name, ...field }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  if (fields.length === 0) return <NothingRecorded what="fields" />;
+  return (
+    <section aria-labelledby="provenance-fields" className={PANEL}>
+      <SectionHeading id="provenance-fields" role="card">
+        Every field — {fields.length}
+      </SectionHeading>
+      <ul className="mt-1 divide-y divide-border">
+        {fields.map((field) => (
+          <li key={field.name} className="px-4 py-2.5">
+            <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+              <span className="text-small text-foreground">{field.name}</span>
+              <span className="ml-auto flex items-baseline gap-3">
+                <LayerBadge layer={field.layer} />
+                <Confidence value={field.confidence} />
+              </span>
+            </div>
+            <dl className="mt-1 flex flex-wrap gap-x-6 gap-y-0.5">
+              <div className="flex items-baseline gap-1.5">
+                <dt className={CAPTION}>method</dt>
+                <dd className={cn(CAPTION, "font-mono text-foreground")}>
+                  {field.method}
+                </dd>
+              </div>
+              <div className="flex items-baseline gap-1.5">
+                <dt className={CAPTION}>read from</dt>
+                <dd className={cn(CAPTION, "font-mono text-foreground")}>
+                  {field.source}
+                </dd>
+              </div>
+            </dl>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function StageList({ record }: { record: GenerationProvenance }) {
+  const stages = stageDurations(record.stages);
+  if (stages.length === 0) return <NothingRecorded what="stages" />;
+  return (
+    <section aria-labelledby="provenance-stages" className={PANEL}>
+      <SectionHeading id="provenance-stages" role="card">
+        What ran — {stages.length} {stages.length === 1 ? "stage" : "stages"}
+      </SectionHeading>
+      <ol className="mt-1 divide-y divide-border">
+        {stages.map((stage) => (
+          <li
+            key={stage.seq}
+            className="flex flex-wrap items-baseline gap-x-3 gap-y-1 px-4 py-2.5"
+          >
+            <span className="font-mono text-small text-foreground">
+              {stage.stage}
+            </span>
+            {stage.message ? (
+              <span className={CAPTION}>{stage.message}</span>
+            ) : null}
+            <span className="ml-auto flex items-baseline gap-3">
+              {stage.seconds === null ? null : (
+                <span className={cn(CAPTION, "font-mono tabular-nums")}>
+                  {stage.seconds.toFixed(1)}s
+                </span>
+              )}
+              <span className={cn(CAPTION, "font-mono tabular-nums")}>
+                {Math.round(stage.fraction * 100)}%
+              </span>
+            </span>
+          </li>
+        ))}
+      </ol>
+      <p className={cn(CAPTION, "mt-2 px-4")}>
+        Every stage the run reported, in order — including ones that finished
+        faster than a poll, which the progress bar alone cannot show.
+      </p>
+    </section>
+  );
+}
+
+export function ProvenanceRecord({ record }: { record: GenerationProvenance }) {
+  const [view, setView] = useState<View>("review");
+  const groups = groupForReview(record);
+
+  return (
+    <section aria-labelledby="provenance-record" className="space-y-3">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <SectionHeading id="provenance-record" role="title">
+          How this design was generated
+        </SectionHeading>
+        {record.source_url ? (
+          <span className={cn(CAPTION, "font-mono")}>{record.source_url}</span>
+        ) : null}
+      </div>
+
+      <SegmentedControl
+        label="How to read the generation record"
+        value={view}
+        options={VIEWS}
+        onChange={setView}
+      />
+
+      {view === "review" ? <ReviewList groups={groups} /> : null}
+      {view === "fields" ? <FieldsList record={record} /> : null}
+      {view === "stages" ? <StageList record={record} /> : null}
+    </section>
+  );
+}

--- a/frontend/src/features/generate/generationProvenance.test.ts
+++ b/frontend/src/features/generate/generationProvenance.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  groupForReview,
+  readGenerationProvenance,
+  stageDurations,
+  type GenerationProvenance,
+} from "./generationProvenance";
+
+const record: GenerationProvenance = {
+  schema: "ohm-generation-provenance/v1",
+  generated_at: "2026-08-29T12:00:00+00:00",
+  source_url: "https://github.com/org/repo",
+  stages: [
+    { seq: 0, stage: "clone", fraction: 0.12, message: "Cloning", ts: "2026-08-29T12:00:00Z" },
+    { seq: 1, stage: "nlp", fraction: 0.4, message: null, ts: "2026-08-29T12:00:04Z" },
+    { seq: 2, stage: "quality", fraction: 1, message: null, ts: "2026-08-29T12:00:06Z" },
+  ],
+  fields: {
+    title: { layer: "direct", method: "metadata_name", confidence: 0.98, source: "metadata.name" },
+    description: { layer: "nlp", method: "readme_summary", confidence: 0.62, source: "README.md" },
+    version: { layer: "direct", method: "none", confidence: 0, source: "no_version_found" },
+    notes: { layer: "user_edit", method: "review", confidence: 1, source: "user_input" },
+  },
+};
+
+describe("readGenerationProvenance", () => {
+  it("accepts a well-formed record", () => {
+    expect(readGenerationProvenance(record)?.schema).toBe(
+      "ohm-generation-provenance/v1",
+    );
+  });
+
+  it("keeps fields the schema does not describe", () => {
+    // A stripping parse would silently lose server data — the same hazard that
+    // makes response_model dangerous to hand-write, rebuilt at the client.
+    const withExtra = { ...record, future_key: "kept" };
+    expect(readGenerationProvenance(withExtra)).toMatchObject({
+      future_key: "kept",
+    });
+  });
+
+  it("returns null for a malformed record rather than throwing", () => {
+    // The record is supporting detail: a bad one costs the panel, not the page.
+    expect(readGenerationProvenance({ schema: "x" })).toBeNull();
+    expect(readGenerationProvenance(null)).toBeNull();
+    expect(readGenerationProvenance({ ...record, fields: "nope" })).toBeNull();
+  });
+});
+
+describe("groupForReview", () => {
+  it("puts what needs checking before what does not", () => {
+    const ids = groupForReview(record).map((g) => g.id);
+    expect(ids.indexOf("not-found")).toBeLessThan(ids.indexOf("inferred"));
+    expect(ids.indexOf("inferred")).toBeLessThan(ids.indexOf("taken"));
+  });
+
+  it("treats a zero-confidence field as not found, whatever its layer", () => {
+    const notFound = groupForReview(record).find((g) => g.id === "not-found");
+    expect(notFound?.fields.map((f) => f.name)).toEqual(["version"]);
+  });
+
+  it("separates a hand edit from a metadata read", () => {
+    const groups = Object.fromEntries(
+      groupForReview(record).map((g) => [g.id, g.fields.map((f) => f.name)]),
+    );
+    expect(groups.edited).toEqual(["notes"]);
+    expect(groups.taken).toEqual(["title"]);
+  });
+
+  it("shows a field from an unknown layer rather than dropping it", () => {
+    const withUnknown: GenerationProvenance = {
+      ...record,
+      fields: {
+        ...record.fields,
+        mystery: { layer: "quantum", method: "?", confidence: 0.5, source: "?" },
+      },
+    };
+    const unrecognised = groupForReview(withUnknown).find(
+      (g) => g.id === "unrecognised",
+    );
+    expect(unrecognised?.fields.map((f) => f.name)).toEqual(["mystery"]);
+  });
+
+  it("accounts for every field exactly once", () => {
+    // The invariant that matters: this view must not be able to lose a field.
+    const seen = groupForReview(record).flatMap((g) => g.fields.map((f) => f.name));
+    expect(seen.sort()).toEqual(Object.keys(record.fields).sort());
+  });
+
+  it("drops empty groups so a clean run shows no empty headings", () => {
+    const clean: GenerationProvenance = {
+      ...record,
+      fields: { title: record.fields.title },
+    };
+    expect(groupForReview(clean).map((g) => g.id)).toEqual(["taken"]);
+  });
+});
+
+describe("stageDurations", () => {
+  it("measures each stage by the gap to the next", () => {
+    const [clone, nlp, quality] = stageDurations(record.stages);
+    expect(clone.seconds).toBe(4);
+    expect(nlp.seconds).toBe(2);
+    // Nothing follows the last stage, so its length is unknowable from the log.
+    expect(quality.seconds).toBeNull();
+  });
+
+  it("reports null rather than guessing when a timestamp is missing", () => {
+    const [only] = stageDurations([
+      { seq: 0, stage: "clone", fraction: 0.1, message: null, ts: null },
+    ]);
+    expect(only.seconds).toBeNull();
+  });
+});

--- a/frontend/src/features/generate/generationProvenance.ts
+++ b/frontend/src/features/generate/generationProvenance.ts
@@ -1,0 +1,154 @@
+import { z } from "zod";
+
+/**
+ * The record of how a generated manifest was produced.
+ *
+ * Distinct from `/api/okh/{id}/provenance`, which is *record* provenance —
+ * who published a manifest and when. This is generation provenance: which
+ * layer produced each field, by what method, and from where.
+ *
+ * It arrives as `Dict[str, Any]` server-side, so codegen types it
+ * `Record<string, unknown>` and the compiler can vouch for nothing. Parsed at
+ * the boundary for the reason in docs/architecture/api-response-contracts.md:
+ * a drift then names the field instead of throwing somewhere inside a render.
+ */
+
+/** `looseObject` throughout: a parse that strips server fields is a parse that loses data. */
+const stageSchema = z.looseObject({
+  seq: z.number(),
+  stage: z.string(),
+  fraction: z.number(),
+  message: z.string().nullish(),
+  ts: z.string().nullish(),
+});
+
+const fieldSchema = z.looseObject({
+  layer: z.string(),
+  method: z.string(),
+  confidence: z.number(),
+  source: z.string(),
+});
+
+export const generationProvenanceSchema = z.looseObject({
+  schema: z.string(),
+  generated_at: z.string().nullish(),
+  source_url: z.string().nullish(),
+  stages: z.array(stageSchema),
+  fields: z.record(z.string(), fieldSchema),
+});
+
+export type ProvenanceStage = z.infer<typeof stageSchema>;
+export type ProvenanceField = z.infer<typeof fieldSchema>;
+export type GenerationProvenance = z.infer<typeof generationProvenanceSchema>;
+
+/** One field, with its name, for rendering as a row. */
+export interface NamedField extends ProvenanceField {
+  name: string;
+}
+
+/**
+ * Parse a record from a run or a file.
+ *
+ * Returns `null` rather than throwing: a record is supporting detail, and a
+ * malformed one should cost the panel, not the page that ran the generation.
+ */
+export function readGenerationProvenance(
+  value: unknown,
+): GenerationProvenance | null {
+  const parsed = generationProvenanceSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+export interface ReviewGroup {
+  id: string;
+  /** What the reader is being told about this set. */
+  title: string;
+  /** Why it is grouped this way, in the reader's terms. */
+  note: string;
+  /** How much scrutiny this group asks for. */
+  weight: "none" | "check" | "settled";
+  fields: NamedField[];
+}
+
+/** Layers where a model or a rule decided, rather than copied. */
+const INFERRED = new Set(["heuristic", "nlp", "llm"]);
+/** Layers that read or restructured what was already there. */
+const TAKEN = new Set(["direct", "bom_normalization"]);
+
+/**
+ * Group the fields by how much checking each deserves.
+ *
+ * The ordering is the point: a reviewer's time goes to what a model guessed,
+ * not to a title copied out of repository metadata. Empty groups are dropped,
+ * so a clean run does not render three headings over nothing.
+ *
+ * Every field lands in exactly one group, including one whose layer this does
+ * not recognise — an unknown layer is a reason to show a field prominently,
+ * never a reason to drop it from the page.
+ */
+export function groupForReview(record: GenerationProvenance): ReviewGroup[] {
+  const named: NamedField[] = Object.entries(record.fields)
+    .map(([name, field]) => ({ name, ...field }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const notFound = named.filter((f) => f.confidence <= 0);
+  const rest = named.filter((f) => f.confidence > 0);
+  const inferred = rest.filter((f) => INFERRED.has(f.layer));
+  const taken = rest.filter((f) => TAKEN.has(f.layer));
+  const edited = rest.filter((f) => f.layer === "user_edit");
+  const unrecognised = rest.filter(
+    (f) => !INFERRED.has(f.layer) && !TAKEN.has(f.layer) && f.layer !== "user_edit",
+  );
+
+  return [
+    {
+      id: "not-found",
+      title: "Nothing was found",
+      note: "the generator looked and came back empty",
+      weight: "none" as const,
+      fields: notFound,
+    },
+    {
+      id: "inferred",
+      title: "Inferred from prose",
+      note: "a model or a heuristic read text and decided; worth confirming",
+      weight: "check" as const,
+      fields: inferred,
+    },
+    {
+      id: "unrecognised",
+      title: "Produced by an unfamiliar layer",
+      note: "this view does not know this layer; treat it as unchecked",
+      weight: "check" as const,
+      fields: unrecognised,
+    },
+    {
+      id: "edited",
+      title: "Edited by hand",
+      note: "a person set this during review",
+      weight: "settled" as const,
+      fields: edited,
+    },
+    {
+      id: "taken",
+      title: "Read straight from the repository",
+      note: "copied from metadata or a file; little to check",
+      weight: "settled" as const,
+      fields: taken,
+    },
+  ].filter((group) => group.fields.length > 0);
+}
+
+/** Seconds each stage ran, from the gap to the next one. The last has no successor. */
+export function stageDurations(
+  stages: ProvenanceStage[],
+): Array<ProvenanceStage & { seconds: number | null }> {
+  return stages.map((stage, i) => {
+    const next = stages[i + 1];
+    const from = stage.ts ? Date.parse(stage.ts) : NaN;
+    const to = next?.ts ? Date.parse(next.ts) : NaN;
+    const seconds =
+      Number.isFinite(from) && Number.isFinite(to) ? (to - from) / 1000 : null;
+    return { ...stage, seconds };
+  });
+}


### PR DESCRIPTION
Closes #378.

#376 made the pipeline record how it produced every field. Nothing rendered it. This does.

## Three readings, not three designs

A reviewer arrives with one of three questions, and no single ordering answers all of them:

| View | Question |
|---|---|
| **Review** (default) | what needs checking? |
| **Fields** | is this particular value right? |
| **Stages** | what did the run do? |

Nothing is duplicated between them — they differ in what they put first, and Review opens because triage is the common case.

**Review groups by scrutiny, not by pipeline order:** nothing-found first, then what a model or heuristic inferred, then what was read straight from the repository. A reviewer's attention belongs on a description the LLM wrote, not on a title copied out of metadata.

## Nothing can silently vanish

Fields whose layer this view does not recognise land in their own group, labelled as unchecked, and **a test asserts every field appears in exactly one group**. If the backend adds a seventh `GenerationLayer`, the field shows up flagged rather than disappearing — the failure that would be hardest to notice.

A zero confidence reads **"not found"**, not `0.00`. The generator did not measure low confidence there; it looked and found nothing, and a number invites the wrong reading. There is a test asserting `0.00` never appears.

## A deviation from the wireframe, deliberately

The canvas drew underline tabs. This uses **`SegmentedControl`** instead.

That component exists because three hand-rolled switchers had inconsistent ARIA and no keyboard support — including, by its own docstring, "the create page's guided/JSON tabs". Hand-rolling a fourth to match my own sketch would have repeated exactly what it was written to end. So the three readings are one tab stop with arrow-key movement, and a test pins that.

## Parsed, not cast

The record is parsed with zod at the boundary, per `docs/architecture/api-response-contracts.md`: the server types it `Dict[str, Any]`, so codegen vouches for nothing. A malformed record returns `null` and costs this panel, not the run that produced it.

Switching between jobs in a batch swaps the record too — otherwise it would describe the run the reader just navigated away from.

## Smaller things

Each view states its own emptiness; a run with stages but no fields left the Review tab blank in the first pass. Stage durations come from the gap to the next event, and the last stage reports none rather than guessing.

The view **renders a record handed to it and never fetches** — generation is not persisted server-side, so the same component serves a finished run and a sidecar someone kept on disk. #393 supplies the second.

## Verification

`make ready`: 14/14. `frontend-ready`: all stages — 721 unit, 237 e2e, a11y included. 18 new tests (11 model, 7 view).

Design: the Record artboards on the canvas linked from #378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qew1kZog2JA8AKCgLxzn5X
