### PR TITLE
A dedicated interface for generate-from-url (#393)

### DIFF
--- a/frontend/src/api/ohm/okh.ts
+++ b/frontend/src/api/ohm/okh.ts
@@ -363,6 +363,37 @@ export async function submitGenerateJobs(
   return data;
 }
 
+export type GenerateJobEvents =
+  components["schemas"]["OKHGenerateJobEvents"];
+
+/**
+ * The run's stage log, in order.
+ *
+ * Distinct from job status, which reports the stage a run is *on*: that field
+ * is overwritten on every update, so polling it samples the timeline rather
+ * than receiving it and a stage shorter than the interval is never seen. The
+ * log is cumulative, so a poll at any rate gets everything that ran.
+ *
+ * Fetched whole rather than paged from a cursor. The endpoint takes `since`,
+ * but a run has nine stages — carrying a cursor to save eight rows would be
+ * state to keep correct for no gain.
+ */
+export async function getGenerateJobEvents(
+  jobId: string,
+): Promise<GenerateJobEvents> {
+  const { data, error, response } = await apiClient.GET(
+    "/api/okh/generate-from-url/jobs/{job_id}/events",
+    { params: { path: { job_id: jobId }, query: { since: 0 } } },
+  );
+  if (error || !response.ok) {
+    throw new ApiError(
+      response.status,
+      errorMessage(error, `Could not read the run log (HTTP ${response.status})`),
+    );
+  }
+  return data as GenerateJobEvents;
+}
+
 export async function getGenerateJobStatus(
   jobId: string,
 ): Promise<GenerateJobStatus> {

--- a/frontend/src/features/generate/GenerateView.test.tsx
+++ b/frontend/src/features/generate/GenerateView.test.tsx
@@ -1,6 +1,20 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { ApiError } from "../../api/ohm/client";
-import { generationErrorMessage } from "./GenerateView";
+import { GenerateView, generationErrorMessage } from "./GenerateView";
+
+function renderView() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <GenerateView />
+    </QueryClientProvider>,
+  );
+}
 
 describe("generationErrorMessage", () => {
   it("explains a 404 without blaming the user", () => {
@@ -38,5 +52,31 @@ describe("generationErrorMessage", () => {
 
   it("handles a non-Error throw", () => {
     expect(generationErrorMessage("boom")).toBe("Generation failed.");
+  });
+});
+
+describe("GenerateView — before a run", () => {
+  it("says what will happen, in the stage names a reader can act on", () => {
+    renderView();
+    expect(screen.getByText("What will happen")).toBeInTheDocument();
+    // The user-facing labels, not the pipeline's own stage keys.
+    expect(screen.getByText("Reading repository")).toBeInTheDocument();
+    expect(screen.getByText("Enhancing with AI")).toBeInTheDocument();
+    expect(screen.queryByText("bom_verification")).not.toBeInTheDocument();
+  });
+
+  it("drops the model stage from the plan when the run will skip it", async () => {
+    const user = userEvent.setup();
+    renderView();
+    await user.click(screen.getByLabelText("Skip the language model"));
+    // Promising a stage that will not run is worse than saying nothing.
+    expect(screen.queryByText("Enhancing with AI")).not.toBeInTheDocument();
+    expect(screen.getByText("Reading repository")).toBeInTheDocument();
+  });
+
+  it("offers a way back in for a record already on disk", () => {
+    renderView();
+    expect(screen.getByText("Re-open a past run")).toBeInTheDocument();
+    expect(screen.getByLabelText("Generation record")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/generate/GenerateView.tsx
+++ b/frontend/src/features/generate/GenerateView.tsx
@@ -17,16 +17,20 @@ import { FIELD, FIELD_SM, LABEL } from "../../components/ui/field";
 import {
   PANEL,
   PANEL_ACCENT,
+  PANEL_BODY,
   PANEL_DANGER,
   PANEL_INSET,
   PANEL_WARNING,
 } from "../../components/ui/surface";
+import { BODY_MUTED, CARD_TITLE } from "../../components/ui/typography";
 import { PageHero } from "../../components/layout/PageHero";
-import { useQueries } from "@tanstack/react-query";
+import { useQueries, useQuery } from "@tanstack/react-query";
+import { Check } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { withNavState } from "../../lib/navState";
 import { ApiError } from "../../api/ohm/client";
 import {
+  getGenerateJobEvents,
   getGenerateJobStatus,
   revokeGenerateJob,
   submitGenerateJobs,
@@ -39,10 +43,12 @@ import { downloadManifest } from "./serialize";
 import { missingRequired } from "./manifestTiers";
 import { TieredEditor } from "./TieredEditor";
 import { ProvenanceRecord } from "./ProvenanceRecord";
+import { ReopenRecord } from "./ReopenRecord";
 import {
   readGenerationProvenance,
   type GenerationProvenance,
 } from "./generationProvenance";
+import { plannedStages, stageLabel as labelFor } from "./jobProgress";
 import { parseRepoUrlList } from "./urlValidation";
 import {
   aggregatePercent,
@@ -116,6 +122,29 @@ function ProgressBar({
   );
 }
 
+/**
+ * Time since the run began, ticking.
+ *
+ * Its own component so the second-by-second re-render stays here rather than
+ * driving the whole view — the progress bar and the job list only change when
+ * the server says something new.
+ */
+function Elapsed({ since }: { since: number }) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+  const seconds = Math.max(0, Math.round((now - since) / 1000));
+  return (
+    <p className="text-xs tabular-nums text-muted-foreground">
+      {seconds < 60
+        ? `${seconds}s elapsed`
+        : `${Math.floor(seconds / 60)}m ${seconds % 60}s elapsed`}
+    </p>
+  );
+}
+
 export function GenerateView() {
   const router = useRouter();
   const [url, setUrl] = useState("");
@@ -127,6 +156,8 @@ export function GenerateView() {
   const [provenance, setProvenance] = useState<GenerationProvenance | null>(
     null,
   );
+  const [noLlm, setNoLlm] = useState(false);
+  const [startedAt, setStartedAt] = useState<number | null>(null);
   const [report, setReport] = useState<OkhQualityReport | null>(null);
   const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
 
@@ -141,6 +172,24 @@ export function GenerateView() {
       retry: false,
     })),
   });
+
+  // The run log for a single job, so finished stages stay on screen instead of
+  // being replaced by whatever is running now. Status reports the current stage
+  // only, and it is overwritten on every update — a stage shorter than the poll
+  // never appears there at all (#375).
+  //
+  // One job only: a batch already gets a row each in the list below, and nine
+  // stages times N repositories is a wall, not a status.
+  const soleJob = jobs.length === 1 ? jobs[0] : null;
+  const soleState = statusQueries[0]?.data?.state;
+  const eventsQuery = useQuery({
+    queryKey: ["okh-generate-job-events", soleJob?.job_id] as const,
+    queryFn: () => getGenerateJobEvents(soleJob!.job_id),
+    enabled: Boolean(soleJob),
+    refetchInterval: isTerminalJobState(soleState) ? false : 1000,
+    retry: false,
+  });
+  const ranStages = eventsQuery.data?.events ?? [];
 
   const statuses = useMemo(() => {
     return jobs.map((job, i) => {
@@ -211,7 +260,8 @@ export function GenerateView() {
     setActive(true);
 
     try {
-      const batch = await submitGenerateJobs(parsed.urls);
+      setStartedAt(Date.now());
+      const batch = await submitGenerateJobs(parsed.urls, { noLlm });
       setJobs(batch.jobs);
     } catch (err) {
       setActive(false);
@@ -289,6 +339,25 @@ export function GenerateView() {
         <p id="repo-url-hint" className="mt-1.5 text-xs text-muted-foreground">
           Separate multiple repositories with commas.
         </p>
+
+        {/* min-h-7: the responsive lane measures a checkbox's LABEL, since the
+            row is what a thumb hits. A flex label is block-level and so spans
+            the panel, and at the line-height of its text it sat at 20px —
+            under the 24px WCAG 2.5.8 floor. */}
+        <label className="mt-3 flex min-h-7 items-center gap-2 text-sm text-foreground">
+          <input
+            type="checkbox"
+            checked={noLlm}
+            disabled={active}
+            onChange={(e) => setNoLlm(e.target.checked)}
+            className="h-4 w-4 rounded border-border"
+          />
+          Skip the language model
+        </label>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Faster, and it never invents a field — but it reads less out of prose,
+          so more of the manifest comes back empty.
+        </p>
         {urlError && (
           <p
             id="repo-url-error"
@@ -299,6 +368,33 @@ export function GenerateView() {
           </p>
         )}
       </div>
+
+      {!showProgress && !manifest && !provenance && (
+        <>
+        <div className={cn(PANEL, PANEL_BODY)}>
+          <h2 className={CARD_TITLE}>What will happen</h2>
+          <p className={cn(BODY_MUTED, "mt-1")}>
+            {plannedStages(!noLlm).length} stages, typically under a minute.
+            Each records what it produced, so every field in the result can be
+            traced back to the layer that made it.
+          </p>
+          <ol className="mt-3 flex flex-wrap gap-x-2 gap-y-1.5">
+            {plannedStages(!noLlm).map((stage, i) => (
+              <li
+                key={stage}
+                className={cn(
+                  "text-sm text-muted-foreground",
+                  i > 0 && "border-l border-border pl-2",
+                )}
+              >
+                {labelFor(stage)}
+              </li>
+            ))}
+          </ol>
+        </div>
+        <ReopenRecord onOpen={setProvenance} />
+        </>
+      )}
 
       {showProgress && (
         <div role="status" className={cn(PANEL_ACCENT, "space-y-4")}>
@@ -311,6 +407,42 @@ export function GenerateView() {
             }
             value={aggregate}
           />
+          {startedAt !== null && <Elapsed since={startedAt} />}
+          {ranStages.length > 0 && (
+            <ol className="space-y-1">
+              {ranStages.map((event, i) => {
+                // A stage is emitted when it BEGINS, so the last entry is the
+                // one in flight — ticking it would report work as done while
+                // it is still running.
+                const running =
+                  i === ranStages.length - 1 && !isTerminalJobState(soleState);
+                return (
+                  <li
+                    key={event.seq}
+                    className="flex items-baseline gap-2 text-sm text-muted-foreground"
+                  >
+                    {running ? (
+                      <span
+                        aria-hidden="true"
+                        className="h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-primary motion-reduce:animate-none"
+                      />
+                    ) : (
+                      <Check
+                        aria-hidden="true"
+                        className="h-4 w-4 shrink-0 text-success"
+                      />
+                    )}
+                    <span className="text-foreground">
+                      {labelFor(event.stage)}
+                    </span>
+                    <span className="ml-auto font-mono text-xs tabular-nums">
+                      {Math.round(event.fraction * 100)}%
+                    </span>
+                  </li>
+                );
+              })}
+            </ol>
+          )}
           {statuses.length > 1 && (
             <ul className="space-y-3">
               {statuses.map((s) => (

--- a/frontend/src/features/generate/ReopenRecord.test.tsx
+++ b/frontend/src/features/generate/ReopenRecord.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ReopenRecord } from "./ReopenRecord";
+
+const record = {
+  schema: "ohm-generation-provenance/v1",
+  generated_at: "2026-08-29T12:00:00+00:00",
+  source_url: "https://github.com/org/repo",
+  stages: [{ seq: 0, stage: "clone", fraction: 1, message: null, ts: null }],
+  fields: {
+    title: {
+      layer: "direct",
+      method: "metadata_name",
+      confidence: 0.98,
+      source: "metadata.name",
+    },
+  },
+};
+
+function file(name: string, body: unknown) {
+  return new File([JSON.stringify(body)], name, { type: "application/json" });
+}
+
+describe("ReopenRecord", () => {
+  it("opens a record read from disk, without a server round trip", async () => {
+    const onOpen = vi.fn();
+    const user = userEvent.setup();
+    render(<ReopenRecord onOpen={onOpen} />);
+
+    await user.upload(
+      screen.getByLabelText("Generation record"),
+      file("run.provenance.json", record),
+    );
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onOpen.mock.calls[0][0].source_url).toBe(
+      "https://github.com/org/repo",
+    );
+  });
+
+  it("names the likely mistake when handed the manifest instead", async () => {
+    // The two arrive together from the same download and look alike; "invalid
+    // file" would leave the reader guessing which one was wrong.
+    const onOpen = vi.fn();
+    const user = userEvent.setup();
+    render(<ReopenRecord onOpen={onOpen} />);
+
+    await user.upload(
+      screen.getByLabelText("Generation record"),
+      file("design.okh.json", { title: "A design", version: "1.0.0" }),
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /not a generation record.*\.provenance\.json/i,
+    );
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("says so when a .json file does not parse", async () => {
+    const onOpen = vi.fn();
+    const user = userEvent.setup();
+    render(<ReopenRecord onOpen={onOpen} />);
+
+    await user.upload(
+      screen.getByLabelText("Generation record"),
+      // A .json name, because the input's accept filter is what stops a .txt
+      // ever reaching the handler through the picker.
+      new File(["{ truncated"], "run.provenance.json", {
+        type: "application/json",
+      }),
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/not valid JSON/i);
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/generate/ReopenRecord.tsx
+++ b/frontend/src/features/generate/ReopenRecord.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+import { PANEL, PANEL_BODY } from "@/components/ui/surface";
+import { BODY_MUTED, CARD_TITLE } from "@/components/ui/typography";
+import { LABEL } from "@/components/ui/field";
+import { cn } from "@/lib/utils";
+import {
+  readGenerationProvenance,
+  type GenerationProvenance,
+} from "./generationProvenance";
+
+/**
+ * Bring a downloaded generation record back to read it again.
+ *
+ * Generated designs are not kept on the server — without accounts there is no
+ * owner to attach a run to — so the file a user downloaded IS the copy. That
+ * makes arriving here holding one an ordinary way to use this page, not an
+ * edge case, which is why it sits beside the URL field rather than somewhere
+ * further in.
+ *
+ * Read in the browser: nothing is uploaded, and there is no round trip to
+ * lose the file to.
+ */
+export function ReopenRecord({
+  onOpen,
+}: {
+  onOpen: (record: GenerationProvenance) => void;
+}) {
+  const [error, setError] = useState<string | null>(null);
+  const [dragging, setDragging] = useState(false);
+
+  async function read(file: File) {
+    setError(null);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await file.text());
+    } catch {
+      setError(`${file.name} is not valid JSON.`);
+      return;
+    }
+    const record = readGenerationProvenance(parsed);
+    if (!record) {
+      // Named specifically: the likeliest mistake is handing this the manifest
+      // rather than the record, and the two arrive as similar-looking files
+      // from the same download.
+      setError(
+        `${file.name} is not a generation record. It should be the .provenance.json file, not the manifest.`,
+      );
+      return;
+    }
+    onOpen(record);
+  }
+
+  return (
+    <div
+      onDragOver={(e) => {
+        e.preventDefault();
+        setDragging(true);
+      }}
+      onDragLeave={() => setDragging(false)}
+      onDrop={(e) => {
+        e.preventDefault();
+        setDragging(false);
+        const file = e.dataTransfer.files?.[0];
+        if (file) void read(file);
+      }}
+      className={cn(PANEL, PANEL_BODY, dragging && "border-primary")}
+    >
+      <h2 className={CARD_TITLE}>Re-open a past run</h2>
+      <p className={cn(BODY_MUTED, "mt-1")}>
+        Generated designs are not kept on the server, so the record you
+        downloaded is the copy. Drop it here, or choose it below.
+      </p>
+
+      <div className="mt-3">
+        {/* The input is the control; the drop target is an enhancement over
+            it. A drop zone alone cannot be reached from a keyboard. */}
+        <label className={LABEL} htmlFor="reopen-provenance">
+          Generation record
+        </label>
+        <input
+          id="reopen-provenance"
+          type="file"
+          accept=".json,application/json"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) void read(file);
+          }}
+          className="mt-1 block w-full text-sm text-foreground file:mr-3 file:min-h-9 file:rounded-md file:border file:border-border file:bg-muted file:px-3 file:text-sm file:font-medium hover:file:bg-accent"
+        />
+      </div>
+
+      {error ? (
+        <p role="alert" className="mt-2 text-sm text-destructive-ink">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/features/generate/jobProgress.test.ts
+++ b/frontend/src/features/generate/jobProgress.test.ts
@@ -4,6 +4,9 @@ import {
   isTerminalJobState,
   progressPercent,
   stageLabel,
+  PLANNED_STAGES,
+  plannedStages,
+  STAGE_LABELS,
 } from "./jobProgress";
 
 describe("jobProgress", () => {
@@ -26,5 +29,28 @@ describe("jobProgress", () => {
         { state: "PROGRESS", fraction: 0.5 },
       ]),
     ).toBe(75);
+  });
+});
+
+describe("the planned stage list", () => {
+  it("names every stage it plans", () => {
+    // The panel shown before a run reads these labels. A stage without one
+    // would render its raw pipeline name at a user.
+    for (const stage of PLANNED_STAGES) {
+      expect(stageLabel(stage)).not.toBe(stage);
+    }
+  });
+
+  it("has a label for nothing it does not plan", () => {
+    // The other direction: a label left behind after a stage is removed is a
+    // promise the pipeline no longer keeps.
+    const labelled = Object.keys(STAGE_LABELS);
+    expect([...labelled].sort()).toEqual([...PLANNED_STAGES].sort());
+  });
+
+  it("drops the model stage when a run is told to skip it", () => {
+    expect(plannedStages(true)).toContain("llm");
+    expect(plannedStages(false)).not.toContain("llm");
+    expect(plannedStages(false)).toHaveLength(PLANNED_STAGES.length - 1);
   });
 });

--- a/frontend/src/features/generate/jobProgress.ts
+++ b/frontend/src/features/generate/jobProgress.ts
@@ -6,7 +6,33 @@ export function isTerminalJobState(state: string | undefined | null): boolean {
   return Boolean(state && TERMINAL_JOB_STATES.has(state));
 }
 
-const STAGE_LABELS: Record<string, string> = {
+/**
+ * The stages a run reports, in pipeline order.
+ *
+ * Mirrors `planned_stages()` on the server, which is what makes it possible to
+ * say what will happen *before* a run starts rather than only narrating it
+ * afterwards. `llm` is conditional there and here: a run told to skip the model
+ * never emits it, and promising a stage that will not run is worse than saying
+ * nothing.
+ */
+export const PLANNED_STAGES = [
+  "clone",
+  "direct",
+  "heuristic",
+  "nlp",
+  "llm",
+  "bom_verification",
+  "bom_normalization",
+  "quality",
+  "materials_routing",
+] as const;
+
+export function plannedStages(useLlm: boolean): string[] {
+  return PLANNED_STAGES.filter((stage) => useLlm || stage !== "llm");
+}
+
+/** Exported for the drift check in the tests: labels and planned stages must agree. */
+export const STAGE_LABELS: Record<string, string> = {
   clone: "Reading repository",
   direct: "Mapping fields",
   heuristic: "Analysing structure",

--- a/frontend/src/test/fixtures/index.ts
+++ b/frontend/src/test/fixtures/index.ts
@@ -1285,6 +1285,39 @@ export const solutionHierarchyFixture = {
   },
 };
 
+export const generateJobEventsFixture = {
+  status: "success",
+  message: "Events retrieved",
+  data: {
+    job_id: "job-1",
+    state: "PROGRESS",
+    next_cursor: 3,
+    events: [
+      {
+        seq: 0,
+        stage: "clone",
+        fraction: 0.12,
+        message: "Reading repository",
+        ts: "2026-08-29T12:00:00+00:00",
+      },
+      {
+        seq: 1,
+        stage: "direct",
+        fraction: 0.17,
+        message: null,
+        ts: "2026-08-29T12:00:04+00:00",
+      },
+      {
+        seq: 2,
+        stage: "nlp",
+        fraction: 0.4,
+        message: null,
+        ts: "2026-08-29T12:00:04.200+00:00",
+      },
+    ],
+  },
+};
+
 export const remotePackagesFixture = {
   status: "success",
   message: "Remote packages listed",
@@ -1327,6 +1360,7 @@ export const matchDomainsFixture = {
 
 export const fixturesByPath: Record<string, unknown> = {
   "/v1/api/match/domains": matchDomainsFixture,
+  "/v1/api/okh/generate-from-url/jobs/job-1/events": generateJobEventsFixture,
   "/v1/api/package/remote": remotePackagesFixture,
   "/v1/api/package/demo/widget/1.0.0/verify-signature": packageSignatureFixture,
   "/v1/api/supply-tree/solution/sol-1/staleness": solutionStalenessFixture,

--- a/frontend/src/test/msw/handlers.ts
+++ b/frontend/src/test/msw/handlers.ts
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from "msw";
 import {
   domainsFixture,
+  generateJobEventsFixture,
   healthFixture,
   metricsFixture,
   matchResponseFixture,
@@ -89,6 +90,9 @@ export const handlers = [
     HttpResponse.json(fileTypesValidationFixture),
   ),
   http.get("*/v1/api/file-types", () => HttpResponse.json(fileTypesFixture)),
+  http.get("*/v1/api/okh/generate-from-url/jobs/:id/events", () =>
+    HttpResponse.json(generateJobEventsFixture),
+  ),
   http.get("*/v1/api/match/domains", () =>
     HttpResponse.json(matchDomainsFixture),
   ),

--- a/tests/parity/manifest.py
+++ b/tests/parity/manifest.py
@@ -615,16 +615,6 @@ UNCALLED_ENDPOINTS: tuple[Endpoint, ...] = (
     *_decision(
         "planned",
         "backlog",
-        "The generate-from-url run log. Job status reports the stage a run is "
-        "on, which a poll can only sample — a stage shorter than the poll "
-        "interval is never seen — so this returns the ordered log instead. The "
-        "provenance view (#378/#379) reads it to draw the stage timeline, and "
-        "the commit that wires that call deletes this row.",
-        "/api/okh/generate-from-url/jobs/{job_id}/events",
-    ),
-    *_decision(
-        "planned",
-        "backlog",
         "Calls asset_service.salvage_match and enriches a design's components "
         "with fleet availability, so it belongs to the /assets section rather "
         "than to the design catalogue — the salvage surface is where a reader "


### PR DESCRIPTION
Closes #393.

Generation had a page, but it explained nothing before you committed a minute to it, showed only the stage it was on while it ran, and offered no way back to a record you had already downloaded.

## Before a run: what will happen

Using the stage labels `jobProgress.ts` **already had** and nothing had ever shown — "Reading repository", "Enhancing with AI" — surfaced through `plannedStages()`, which mirrors the server's own function.

The list honours the checkbox: skip the model and "Enhancing with AI" leaves the plan, because promising a stage that will not run is worse than saying nothing. A **drift test guards both directions**: every planned stage has a label, and no label outlives the stage it named.

## The no-LLM option is now offered at all

It existed in the API client and no UI ever passed it — the backend could do it and nobody could ask.

## While it runs: finished stages stay on screen

Fed by the run log from #375. Status reports only the current stage and overwrites it, so a stage shorter than the poll never appeared anywhere.

The stage in flight is marked as **running, not ticked**: stages are emitted when they *begin*, and a tick would report work as done while it is still happening. Scoped to a single job — nine stages times N repositories is a wall, not a status.

## Re-opening a record

Beside the URL field rather than further in: with nothing kept on the server the file **is** the copy, so arriving holding one is ordinary use, not an edge case. Read in the browser; nothing is uploaded. Handed the manifest instead of the record, it says so specifically — the two arrive together from the same download and look alike.

The file input is the control and the drop target is an enhancement over it, because a drop zone alone cannot be reached from a keyboard.

## Parity

The row recording this endpoint as uncalled is **deleted, not edited**, per the manifest's own rule. #375's commit predicted this; this is the commit that wires the call.

## Two things the gates caught that I had wrong

**The responsive lane measures a checkbox's LABEL**, not the input — "the row is what a thumb hits". A `flex` label is block-level, so it spanned the panel at 302×20, under the 24px floor. Now `min-h-7` → 302×28.

**I first blamed the file input** and added a `min-h-9` that did nothing: `file:min-h-9` already sizes it through the button pseudo-element. That class and the comment claiming it fixed something are both gone. Both diagnoses were settled by measuring against a dev server I started myself, after two detours through evidence that did not apply — a production CSS bundle when the lane runs `next dev`, and an artifact I had not yet proven was current.

**The `✓` and `·` I used are dingbats**, which `uniformity` forbids in UI source and the design guidance rules out. Now a lucide `Check`, a pulsing dot that respects `motion-reduce`, and a border for the separator.

## Verification

`make ready`: 14/14. `frontend-ready`: all stages — 735 unit, 237 e2e, a11y and the responsive lane included.

Design: the **/generate** artboard on the canvas linked from #378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qew1kZog2JA8AKCgLxzn5X
