### PR TITLE
The generation record fills in while the run happens (#379)

### DIFF
--- a/frontend/src/features/generate/GenerateView.tsx
+++ b/frontend/src/features/generate/GenerateView.tsx
@@ -25,7 +25,6 @@ import {
 import { BODY_MUTED, CARD_TITLE } from "../../components/ui/typography";
 import { PageHero } from "../../components/layout/PageHero";
 import { useQueries, useQuery } from "@tanstack/react-query";
-import { Check } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { withNavState } from "../../lib/navState";
 import { ApiError } from "../../api/ohm/client";
@@ -45,6 +44,7 @@ import { TieredEditor } from "./TieredEditor";
 import { ProvenanceRecord } from "./ProvenanceRecord";
 import { ReopenRecord } from "./ReopenRecord";
 import {
+  liveRecordFrom,
   readGenerationProvenance,
   type GenerationProvenance,
 } from "./generationProvenance";
@@ -190,6 +190,11 @@ export function GenerateView() {
     retry: false,
   });
   const ranStages = eventsQuery.data?.events ?? [];
+
+  const liveRecord =
+    ranStages.length > 0
+      ? liveRecordFrom(ranStages, soleJob?.url ?? null)
+      : null;
 
   const statuses = useMemo(() => {
     return jobs.map((job, i) => {
@@ -408,41 +413,6 @@ export function GenerateView() {
             value={aggregate}
           />
           {startedAt !== null && <Elapsed since={startedAt} />}
-          {ranStages.length > 0 && (
-            <ol className="space-y-1">
-              {ranStages.map((event, i) => {
-                // A stage is emitted when it BEGINS, so the last entry is the
-                // one in flight — ticking it would report work as done while
-                // it is still running.
-                const running =
-                  i === ranStages.length - 1 && !isTerminalJobState(soleState);
-                return (
-                  <li
-                    key={event.seq}
-                    className="flex items-baseline gap-2 text-sm text-muted-foreground"
-                  >
-                    {running ? (
-                      <span
-                        aria-hidden="true"
-                        className="h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-primary motion-reduce:animate-none"
-                      />
-                    ) : (
-                      <Check
-                        aria-hidden="true"
-                        className="h-4 w-4 shrink-0 text-success"
-                      />
-                    )}
-                    <span className="text-foreground">
-                      {labelFor(event.stage)}
-                    </span>
-                    <span className="ml-auto font-mono text-xs tabular-nums">
-                      {Math.round(event.fraction * 100)}%
-                    </span>
-                  </li>
-                );
-              })}
-            </ol>
-          )}
           {statuses.length > 1 && (
             <ul className="space-y-3">
               {statuses.map((s) => (
@@ -469,6 +439,14 @@ export function GenerateView() {
             </button>
           )}
         </div>
+      )}
+
+      {/* Not gated on showProgress: that goes false the moment the batch is
+          terminal, and a failed run's stages are the only account of how far
+          it got. `live` drops with it, so the heading stops claiming the run
+          is still going. */}
+      {!provenance && liveRecord && (
+        <ProvenanceRecord record={liveRecord} live={!allTerminal} />
       )}
 
       {error && (

--- a/frontend/src/features/generate/ProvenanceRecord.test.tsx
+++ b/frontend/src/features/generate/ProvenanceRecord.test.tsx
@@ -101,3 +101,50 @@ describe("ProvenanceRecord — a run that recorded little", () => {
     expect(screen.getByRole("heading", { name: /What ran/ })).toBeInTheDocument();
   });
 });
+
+describe("ProvenanceRecord — watching a run", () => {
+  const live = {
+    ...record,
+    generated_at: null,
+    fields: {},
+  };
+
+  it("opens on the stages, because that is the view with anything in it", () => {
+    // Review would greet a watching reader with "no fields": they arrive only
+    // when the run finishes.
+    render(<ProvenanceRecord record={live} live />);
+    expect(screen.getByRole("heading", { name: /What ran/ })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Stages" })).toBeChecked();
+  });
+
+  it("says the run is still going", () => {
+    render(<ProvenanceRecord record={live} live />);
+    expect(
+      // Regex: SectionHeading appends an sr-only "— link to this section"
+      // to every heading's accessible name.
+      screen.getByRole("heading", { name: /How this design is being generated/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("marks the last stage as running, not finished", () => {
+    // Stages are emitted when they BEGIN, so the newest row is in flight.
+    render(<ProvenanceRecord record={live} live />);
+    expect(screen.getByText("running")).toBeInTheDocument();
+  });
+
+  it("claims nothing is running once the run is over", () => {
+    render(<ProvenanceRecord record={record} />);
+    expect(screen.queryByText("running")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /How this design was generated/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the stages a failed run got through", () => {
+    // The failure case: not live any more, but the log is the only account of
+    // how far it got.
+    render(<ProvenanceRecord record={live} />);
+    expect(screen.getByRole("radio", { name: "Review" })).toBeChecked();
+    expect(screen.getByText("This run recorded no fields.")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/generate/ProvenanceRecord.tsx
+++ b/frontend/src/features/generate/ProvenanceRecord.tsx
@@ -156,7 +156,13 @@ function FieldsList({ record }: { record: GenerationProvenance }) {
   );
 }
 
-function StageList({ record }: { record: GenerationProvenance }) {
+function StageList({
+  record,
+  live,
+}: {
+  record: GenerationProvenance;
+  live: boolean;
+}) {
   const stages = stageDurations(record.stages);
   if (stages.length === 0) return <NothingRecorded what="stages" />;
   return (
@@ -165,7 +171,7 @@ function StageList({ record }: { record: GenerationProvenance }) {
         What ran — {stages.length} {stages.length === 1 ? "stage" : "stages"}
       </SectionHeading>
       <ol className="mt-1 divide-y divide-border">
-        {stages.map((stage) => (
+        {stages.map((stage, i) => (
           <li
             key={stage.seq}
             className="flex flex-wrap items-baseline gap-x-3 gap-y-1 px-4 py-2.5"
@@ -173,6 +179,11 @@ function StageList({ record }: { record: GenerationProvenance }) {
             <span className="font-mono text-small text-foreground">
               {stage.stage}
             </span>
+            {/* A stage is emitted when it BEGINS, so while a run is going the
+                last row is the one in flight rather than one that finished. */}
+            {live && i === stages.length - 1 ? (
+              <span className={CAPTION}>running</span>
+            ) : null}
             {stage.message ? (
               <span className={CAPTION}>{stage.message}</span>
             ) : null}
@@ -197,15 +208,31 @@ function StageList({ record }: { record: GenerationProvenance }) {
   );
 }
 
-export function ProvenanceRecord({ record }: { record: GenerationProvenance }) {
-  const [view, setView] = useState<View>("review");
+export function ProvenanceRecord({
+  record,
+  live = false,
+}: {
+  record: GenerationProvenance;
+  /**
+   * The run is still going: the record grows under the reader.
+   *
+   * Opens on Stages, because that is the view with anything in it — fields
+   * arrive only when the run finishes, so Review would greet a watching reader
+   * with "no fields". The chosen view is then theirs: this seeds the initial
+   * state and never yanks them elsewhere when the run ends.
+   */
+  live?: boolean;
+}) {
+  const [view, setView] = useState<View>(live ? "stages" : "review");
   const groups = groupForReview(record);
 
   return (
     <section aria-labelledby="provenance-record" className="space-y-3">
       <div className="flex flex-wrap items-baseline justify-between gap-2">
         <SectionHeading id="provenance-record" role="title">
-          How this design was generated
+          {live
+            ? "How this design is being generated"
+            : "How this design was generated"}
         </SectionHeading>
         {record.source_url ? (
           <span className={cn(CAPTION, "font-mono")}>{record.source_url}</span>
@@ -221,7 +248,7 @@ export function ProvenanceRecord({ record }: { record: GenerationProvenance }) {
 
       {view === "review" ? <ReviewList groups={groups} /> : null}
       {view === "fields" ? <FieldsList record={record} /> : null}
-      {view === "stages" ? <StageList record={record} /> : null}
+      {view === "stages" ? <StageList record={record} live={live} /> : null}
     </section>
   );
 }

--- a/frontend/src/features/generate/generationProvenance.test.ts
+++ b/frontend/src/features/generate/generationProvenance.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  liveRecordFrom,
   groupForReview,
   readGenerationProvenance,
   stageDurations,
@@ -110,5 +111,28 @@ describe("stageDurations", () => {
       { seq: 0, stage: "clone", fraction: 0.1, message: null, ts: null },
     ]);
     expect(only.seconds).toBeNull();
+  });
+});
+
+describe("liveRecordFrom", () => {
+  it("carries the stages that have run, and no fields yet", () => {
+    const live = liveRecordFrom(record.stages, "https://github.com/org/repo");
+    expect(live.stages).toEqual(record.stages);
+    // Fields are only known once the manifest exists; claiming any mid-run
+    // would be inventing them.
+    expect(live.fields).toEqual({});
+    expect(live.source_url).toBe("https://github.com/org/repo");
+  });
+
+  it("is the same structure the finished record has", () => {
+    // The live view and the downloaded sidecar must be one page, not two that
+    // happen to look alike — so the partial one has to parse as a record.
+    const live = liveRecordFrom(record.stages, null);
+    expect(readGenerationProvenance(live)).not.toBeNull();
+    expect(readGenerationProvenance(live)?.stages).toEqual(record.stages);
+  });
+
+  it("groups to nothing while no fields exist, rather than inventing a group", () => {
+    expect(groupForReview(liveRecordFrom(record.stages, null))).toEqual([]);
   });
 });

--- a/frontend/src/features/generate/generationProvenance.ts
+++ b/frontend/src/features/generate/generationProvenance.ts
@@ -139,6 +139,28 @@ export function groupForReview(record: GenerationProvenance): ReviewGroup[] {
   ].filter((group) => group.fields.length > 0);
 }
 
+/**
+ * The run so far, in the shape a finished record has.
+ *
+ * Fields stay empty until the run ends — they are only known once the manifest
+ * exists — so this is honestly partial rather than a different kind of thing.
+ * Building it here means the live view and the downloaded record are the same
+ * structure rendered by the same component, which is the whole reason the
+ * record was designed before the live view.
+ */
+export function liveRecordFrom(
+  stages: ProvenanceStage[],
+  sourceUrl: string | null,
+): GenerationProvenance {
+  return {
+    schema: "ohm-generation-provenance/v1",
+    generated_at: null,
+    source_url: sourceUrl,
+    stages,
+    fields: {},
+  };
+}
+
 /** Seconds each stage ran, from the gap to the next one. The last has no successor. */
 export function stageDurations(
   stages: ProvenanceStage[],


### PR DESCRIPTION
Closes #379.

**Mostly deletion, which is the point.** The record was designed first precisely so the live view would not need a second surface.

`liveRecordFrom` builds the run so far in the shape a finished run produces — the stages that have run, no fields yet — and `ProvenanceRecord` renders it. A test asserts the partial record still **parses as a record**, so the two cannot drift into looking alike while being different things.

## Watching a run

It opens on **Stages**: fields arrive only when the run ends, so Review would greet a watching reader with "no fields". That seeds the initial view and never yanks them elsewhere when the run finishes — they stay where they were looking.

The heading says the run is still going, and the newest stage is marked **running** rather than finished, because stages are emitted when they *begin*.

## One thing removed

The stage list added to the progress panel in #393 is gone. It would have been the same information twice on one screen. The panel keeps the bar, the elapsed time and cancel; the record owns the stages.

## Two defects found while working through the criteria

**Removing that list, I cut the multi-job progress list with it** — the batch view would have lost its per-URL bars. An unused import gave it away; restored, and verified by diffing the removals against main.

**"A failed run shows the stages that completed before the failure" was broken by construction.** `showProgress` goes false the moment the batch is terminal, so a failed run's stages vanished with it. The record now renders whenever stages exist and no final record has arrived, with `live` dropping so the heading stops claiming the run is ongoing. The log is the only account of how far a failed run got.

## Resuming

Needs no client state: the log is cumulative server-side (#375) and every poll asks from the start, so a fresh mount receives everything that has run. That property was built in #375 and is what makes this criterion free here.

## Verification

`make ready`: 14/14. `frontend-ready`: all stages — 743 unit, 237 e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qew1kZog2JA8AKCgLxzn5X
