### PR TITLE
Response models for the taxonomy routes, and a reload count that was always zero (#373, 1 of N)

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 648
+Total Python files: 650
 
 ├── deploy/
 │   ├── __init__.py
@@ -781,6 +781,15 @@ Total Python files: 648
 │       │   │   │           class HierarchySummary
 │       │   │   │           class SolutionHierarchyData
 │       │   │   │           class SolutionHierarchyResponse
+│       │   │   ├── taxonomy/
+│       │   │   │   └── response.py
+│       │   │   │           class ProcessDefinition
+│       │   │   │           class TaxonomyIndexData
+│       │   │   │           class TaxonomyIndexResponse
+│       │   │   │           class TaxonomyReloadData
+│       │   │   │           class TaxonomyReloadResponse
+│       │   │   │           class TaxonomyValidationData
+│       │   │   │           class TaxonomyValidationResponse
 │       │   │   ├── utility/
 │       │   │   │   ├── request.py
 │       │   │   │   │       class DomainFilterRequest
@@ -2041,6 +2050,9 @@ Total Python files: 648
     │   │       def _solution()
     │   │       def _app()
     │   │       def _stub_timestamps()
+    │   │       def _normalise()
+    │   ├── test_taxonomy_contract.py
+    │   │       def _app()
     │   │       def _normalise()
     │   ├── test_utility_default_domain.py
     │   │       def _get_app()
@@ -3430,7 +3442,7 @@ Total Python files: 648
 
 ## Overview
 
-Total files analyzed: 648
+Total files analyzed: 650
 
 ## Entry Points
 
@@ -4597,6 +4609,24 @@ Named explicitly because the fron...
   - Envelope for the component-hierarchy route.
 
 Declaring this is what makes ``open...
+
+### `src/core/api/models/taxonomy/response.py`
+> Response models for the taxonomy routes.
+
+Derived from the payloads the routes already returned, cap...
+
+**Exports:** ProcessDefinition, TaxonomyIndexData, TaxonomyIndexResponse, TaxonomyReloadData, TaxonomyReloadResponse
+
+**Classes:**
+- `ProcessDefinition` (inherits: BaseModel)
+  - One canonical process, with its aliases and place in the tree....
+- `TaxonomyIndexData` (inherits: BaseModel)
+- `TaxonomyIndexResponse` (inherits: SuccessResponse)
+- `TaxonomyReloadData` (inherits: BaseModel)
+  - What the reload changed. Atomic: on failure the route raises instead....
+- `TaxonomyReloadResponse` (inherits: SuccessResponse)
+- `TaxonomyValidationData` (inherits: BaseModel)
+- `TaxonomyValidationResponse` (inherits: SuccessResponse)
 
 ### `src/core/api/models/utility/request.py`
 
@@ -10175,6 +10205,13 @@ The Solutions browse was ...
 This route returned a ba...
 
 **Internal Dependencies:** 6 imports
+
+### `tests/api/test_taxonomy_contract.py`
+> Contract: the taxonomy routes are shape-frozen before they gain response models.
+
+Each of these retu...
+
+**Internal Dependencies:** 1 imports
 
 ### `tests/api/test_visibility_routes.py`
 > Contract tests for GET/PUT /api/{okh,okw}/{id}/visibility....

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -7917,6 +7917,26 @@ export interface components {
             records_synced: number;
         };
         /**
+         * ProcessDefinition
+         * @description One canonical process, with its aliases and place in the tree.
+         */
+        ProcessDefinition: {
+            /** Canonical Id */
+            canonical_id: string;
+            /** Display Name */
+            display_name: string;
+            /** Tsdc Code */
+            tsdc_code?: string | null;
+            /** Parent */
+            parent?: string | null;
+            /** Aliases */
+            aliases: string[];
+            /** Children */
+            children: string[];
+            /** Wikidata Iri */
+            wikidata_iri?: string | null;
+        };
+        /**
          * ProcessRequirement
          * @description Model for extracted process requirements
          */
@@ -9521,6 +9541,168 @@ export interface components {
              * @default 0
              */
             total_pulled: number;
+        };
+        /** TaxonomyIndexData */
+        TaxonomyIndexData: {
+            /** Total */
+            total: number;
+            /** Source */
+            source: string;
+            /** Processes */
+            processes: components["schemas"]["ProcessDefinition"][];
+        };
+        /**
+         * TaxonomyIndexResponse
+         * @example {
+         *       "data": {},
+         *       "message": "Operation completed successfully",
+         *       "metadata": {},
+         *       "request_id": "req_123456789",
+         *       "status": "success",
+         *       "timestamp": "2024-01-01T12:00:00Z"
+         *     }
+         */
+        TaxonomyIndexResponse: {
+            /**
+             * @description Success status
+             * @default success
+             */
+            status: components["schemas"]["APIStatus"];
+            /**
+             * Message
+             * @description Human-readable response message
+             */
+            message: string;
+            /**
+             * Timestamp
+             * Format: date-time
+             * @description Response timestamp
+             */
+            timestamp?: string;
+            /**
+             * Request Id
+             * @description Request identifier if provided
+             */
+            request_id?: string | null;
+            data: components["schemas"]["TaxonomyIndexData"];
+            /**
+             * Metadata
+             * @description Additional response metadata
+             */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+        };
+        /**
+         * TaxonomyReloadData
+         * @description What the reload changed. Atomic: on failure the route raises instead.
+         */
+        TaxonomyReloadData: {
+            /** Added */
+            added: string[];
+            /** Removed */
+            removed: string[];
+            /** Total */
+            total: number;
+            /** Source */
+            source: string;
+            /** Version */
+            version?: string | null;
+        };
+        /**
+         * TaxonomyReloadResponse
+         * @example {
+         *       "data": {},
+         *       "message": "Operation completed successfully",
+         *       "metadata": {},
+         *       "request_id": "req_123456789",
+         *       "status": "success",
+         *       "timestamp": "2024-01-01T12:00:00Z"
+         *     }
+         */
+        TaxonomyReloadResponse: {
+            /**
+             * @description Success status
+             * @default success
+             */
+            status: components["schemas"]["APIStatus"];
+            /**
+             * Message
+             * @description Human-readable response message
+             */
+            message: string;
+            /**
+             * Timestamp
+             * Format: date-time
+             * @description Response timestamp
+             */
+            timestamp?: string;
+            /**
+             * Request Id
+             * @description Request identifier if provided
+             */
+            request_id?: string | null;
+            data: components["schemas"]["TaxonomyReloadData"];
+            /**
+             * Metadata
+             * @description Additional response metadata
+             */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+        };
+        /** TaxonomyValidationData */
+        TaxonomyValidationData: {
+            /** Valid */
+            valid: boolean;
+            /** Total Processes */
+            total_processes: number;
+            /** Errors */
+            errors: string[];
+            /** Source */
+            source: string;
+        };
+        /**
+         * TaxonomyValidationResponse
+         * @example {
+         *       "data": {},
+         *       "message": "Operation completed successfully",
+         *       "metadata": {},
+         *       "request_id": "req_123456789",
+         *       "status": "success",
+         *       "timestamp": "2024-01-01T12:00:00Z"
+         *     }
+         */
+        TaxonomyValidationResponse: {
+            /**
+             * @description Success status
+             * @default success
+             */
+            status: components["schemas"]["APIStatus"];
+            /**
+             * Message
+             * @description Human-readable response message
+             */
+            message: string;
+            /**
+             * Timestamp
+             * Format: date-time
+             * @description Response timestamp
+             */
+            timestamp?: string;
+            /**
+             * Request Id
+             * @description Request identifier if provided
+             */
+            request_id?: string | null;
+            data: components["schemas"]["TaxonomyValidationData"];
+            /**
+             * Metadata
+             * @description Additional response metadata
+             */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
         };
         /** TriageItemResponse */
         TriageItemResponse: {
@@ -16713,7 +16895,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["TaxonomyIndexResponse"];
                 };
             };
             /** @description Bad Request */
@@ -16747,7 +16929,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["TaxonomyReloadResponse"];
                 };
             };
             /** @description Bad Request */
@@ -16781,7 +16963,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["TaxonomyValidationResponse"];
                 };
             };
             /** @description Bad Request */

--- a/frontend/src/api/ohm/taxonomy.test.ts
+++ b/frontend/src/api/ohm/taxonomy.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { fetchProcessTaxonomy } from "./taxonomy";
+import { http, HttpResponse } from "msw";
+import { server } from "../../test/msw/server";
+import {
+  fetchProcessTaxonomy,
+  reloadProcessTaxonomy,
+  validateProcessTaxonomy,
+} from "./taxonomy";
 
 describe("fetchProcessTaxonomy", () => {
   it("unwraps SuccessResponse data.processes", async () => {
@@ -11,5 +17,38 @@ describe("fetchProcessTaxonomy", () => {
       children: expect.any(Array),
     });
     expect(processes.some((p) => p.canonical_id === "3d_printing")).toBe(true);
+  });
+
+  it("names the endpoint and field when the shape drifts", async () => {
+    // The process list feeds a form's options, so a drift degrades to a form
+    // with nothing to choose. The parse turns that into a stated failure.
+    server.use(
+      http.get("*/v1/api/taxonomy", () =>
+        HttpResponse.json({ data: { processes: [{ canonical_id: 1 }] } }),
+      ),
+    );
+    await expect(fetchProcessTaxonomy()).rejects.toThrow(
+      /\/api\/taxonomy.*processes\.0/,
+    );
+  });
+});
+
+describe("reloadProcessTaxonomy", () => {
+  it("reports the process count the route actually returns", async () => {
+    // Regression: this read `total_processes`, which reload has never sent —
+    // the field is `total`, and `total_processes` belongs to validate. The
+    // settings panel therefore said "Reloaded 0 process(es)" every time, and
+    // the fixture encoded the same wrong name so the suite agreed.
+    expect(await reloadProcessTaxonomy()).toBe(51);
+  });
+});
+
+describe("validateProcessTaxonomy", () => {
+  it("returns the validation payload, which does carry total_processes", async () => {
+    // The near-identical naming across the two routes is how the reload bug
+    // survived; pinning both keeps them told apart.
+    const result = await validateProcessTaxonomy();
+    expect(result.valid).toBe(true);
+    expect(result.total_processes).toBe(51);
   });
 });

--- a/frontend/src/api/ohm/taxonomy.ts
+++ b/frontend/src/api/ohm/taxonomy.ts
@@ -1,42 +1,53 @@
+import { z } from "zod";
 import { apiClient, ApiError, errorMessage } from "./client";
+import { parsePayload } from "./parse";
+import type { components } from "../generated/schema";
 import type { TaxonomyProcess } from "../../features/okw/facilityFormModel";
 
-type RawProcess = {
-  canonical_id?: string;
-  display_name?: string;
-  parent?: string | null;
-  children?: string[];
-};
+/**
+ * Generated from the route's response model — no longer hand-written here.
+ *
+ * Kept exported because it is this function's return type; the process shape
+ * is reachable from the generated module if a caller ever needs it.
+ */
+export type TaxonomyValidation =
+  components["schemas"]["TaxonomyValidationData"];
+
+const TAXONOMY_PATH = "/api/taxonomy";
+
+/**
+ * The process list drives the facility form's options, so a drift here degrades
+ * to a form with nothing to choose rather than to a visible error. That is the
+ * case the runtime parse is for; validate and reload below are operator
+ * actions whose results are read on screen, where a wrong shape shows itself.
+ */
+const taxonomySchema = z.looseObject({
+  processes: z.array(
+    z.looseObject({
+      canonical_id: z.string(),
+      display_name: z.string(),
+      parent: z.string().nullish(),
+      children: z.array(z.string()),
+    }),
+  ),
+});
 
 /** Load process taxonomy (processes.yaml via GET /api/taxonomy). */
 export async function fetchProcessTaxonomy(): Promise<TaxonomyProcess[]> {
-  const { data, error, response } = await apiClient.GET("/api/taxonomy");
+  const { data, error, response } = await apiClient.GET(TAXONOMY_PATH);
   if (error || !response.ok) {
     throw new ApiError(
       response.status,
       errorMessage(error, `Failed to load taxonomy (HTTP ${response.status})`),
     );
   }
-  const raw =
-    (data as { data?: { processes?: RawProcess[] } } | null)?.data?.processes ??
-    [];
-  return raw
-    .filter((p): p is RawProcess & { canonical_id: string } =>
-      Boolean(p.canonical_id),
-    )
-    .map((p) => ({
-      canonical_id: p.canonical_id,
-      display_name: p.display_name || p.canonical_id,
-      parent: p.parent ?? null,
-      children: Array.isArray(p.children) ? p.children : [],
-    }));
-}
-
-export interface TaxonomyValidation {
-  valid: boolean;
-  total_processes: number;
-  errors: string[];
-  source: string;
+  const payload = parsePayload(TAXONOMY_PATH, taxonomySchema, data?.data);
+  return payload.processes.map((p) => ({
+    canonical_id: p.canonical_id,
+    display_name: p.display_name || p.canonical_id,
+    parent: p.parent ?? null,
+    children: p.children,
+  }));
 }
 
 /** Check processes.yaml on the server's disk, without applying it. */
@@ -44,20 +55,13 @@ export async function validateProcessTaxonomy(): Promise<TaxonomyValidation> {
   const { data, error, response } = await apiClient.GET(
     "/api/taxonomy/validate",
   );
-  if (error || !response.ok) {
+  if (error || !response.ok || !data) {
     throw new ApiError(
       response.status,
       errorMessage(error, `Validation failed (HTTP ${response.status})`),
     );
   }
-  const body =
-    (data as { data?: Partial<TaxonomyValidation> } | null)?.data ?? {};
-  return {
-    valid: body.valid ?? false,
-    total_processes: body.total_processes ?? 0,
-    errors: body.errors ?? [],
-    source: body.source ?? "",
-  };
+  return data.data;
 }
 
 /**
@@ -67,18 +71,21 @@ export async function validateProcessTaxonomy(): Promise<TaxonomyValidation> {
  * the server validates first and keeps the current taxonomy if the new file
  * does not parse, so a bad edit degrades to "nothing changed" rather than to a
  * node that can no longer match.
+ *
+ * Returns the process count. This read `total_processes`, which the route has
+ * never returned — the field is `total` — so the settings panel reported
+ * "Reloaded 0 process(es)" on every successful reload. The hand-written cast
+ * is what let a name that matched nothing compile.
  */
 export async function reloadProcessTaxonomy(): Promise<number> {
   const { data, error, response } = await apiClient.POST(
     "/api/taxonomy/reload",
   );
-  if (error || !response.ok) {
+  if (error || !response.ok || !data) {
     throw new ApiError(
       response.status,
       errorMessage(error, `Reload failed (HTTP ${response.status})`),
     );
   }
-  const body =
-    (data as { data?: { total_processes?: number } } | null)?.data ?? {};
-  return body.total_processes ?? 0;
+  return data.data.total;
 }

--- a/frontend/src/test/fixtures/index.ts
+++ b/frontend/src/test/fixtures/index.ts
@@ -1386,7 +1386,13 @@ export const fixturesByPath: Record<string, unknown> = {
   "/v1/api/taxonomy/reload": {
     status: "success",
     message: "Taxonomy reloaded",
-    data: { total_processes: 51 },
+    data: {
+      added: [],
+      removed: [],
+      total: 51,
+      source: "config/processes.yaml",
+      version: "1.0.0",
+    },
   },
   "/v1/api/file-types/validate": fileTypesValidationFixture,
   "/v1/api/file-types": fileTypesFixture,

--- a/frontend/src/test/msw/handlers.ts
+++ b/frontend/src/test/msw/handlers.ts
@@ -119,7 +119,18 @@ export const handlers = [
     HttpResponse.json({
       status: "success",
       message: "Taxonomy reloaded",
-      data: { total_processes: 51 },
+      data: {
+        // The shape the route actually returns — the golden in
+        // tests/api/golden/taxonomy_reload.json is the source of truth. This
+        // said `total_processes`, matching a field the client read and the API
+        // has never sent, so the suite was green against a payload that does
+        // not exist.
+        added: [],
+        removed: [],
+        total: 51,
+        source: "config/processes.yaml",
+        version: "1.0.0",
+      },
     }),
   ),
   http.get("*/v1/api/llm/health", () => HttpResponse.json(llmHealthFixture)),

--- a/src/core/api/models/taxonomy/response.py
+++ b/src/core/api/models/taxonomy/response.py
@@ -1,0 +1,64 @@
+"""Response models for the taxonomy routes.
+
+Derived from the payloads the routes already returned, captured in
+``tests/api/golden/`` before these models existed — not from reading the route
+bodies. ``response_model`` filters undeclared fields, so a model written from
+the code rather than from the wire can silently delete something a client
+reads. See ``docs/architecture/api-response-contracts.md``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+from ..base import SuccessResponse
+
+
+class ProcessDefinition(BaseModel):
+    """One canonical process, with its aliases and place in the tree."""
+
+    canonical_id: str
+    display_name: str
+    tsdc_code: Optional[str] = None
+    parent: Optional[str] = None
+    aliases: List[str]
+    children: List[str]
+    wikidata_iri: Optional[str] = None
+
+
+class TaxonomyIndexData(BaseModel):
+    total: int
+    #: Absolute path to the YAML the taxonomy was loaded from, or "built-in".
+    source: str
+    processes: List[ProcessDefinition]
+
+
+class TaxonomyIndexResponse(SuccessResponse):
+    data: TaxonomyIndexData
+
+
+class TaxonomyReloadData(BaseModel):
+    """What the reload changed. Atomic: on failure the route raises instead."""
+
+    added: List[str]
+    removed: List[str]
+    total: int
+    source: str
+    version: Optional[str] = None
+
+
+class TaxonomyReloadResponse(SuccessResponse):
+    data: TaxonomyReloadData
+
+
+class TaxonomyValidationData(BaseModel):
+    valid: bool
+    total_processes: int
+    errors: List[str]
+    source: str
+
+
+class TaxonomyValidationResponse(SuccessResponse):
+    data: TaxonomyValidationData

--- a/src/core/api/routes/taxonomy.py
+++ b/src/core/api/routes/taxonomy.py
@@ -17,6 +17,11 @@ from ....core.taxonomy import (
 )
 from ..constants.openapi import RESPONSES_400_500
 from ..error_handlers import create_success_response
+from ..models.taxonomy.response import (
+    TaxonomyIndexResponse,
+    TaxonomyReloadResponse,
+    TaxonomyValidationResponse,
+)
 from ...utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -30,6 +35,7 @@ router = APIRouter(
 
 @router.get(
     "",
+    response_model=TaxonomyIndexResponse,
     summary="Get current taxonomy",
     description="Returns all processes in the current taxonomy with their definitions.",
 )
@@ -69,6 +75,7 @@ async def get_taxonomy(http_request: Request = None) -> Any:
 
 @router.post(
     "/reload",
+    response_model=TaxonomyReloadResponse,
     summary="Reload taxonomy from YAML",
     description=(
         "Reload the process taxonomy from the YAML configuration file. "
@@ -108,6 +115,7 @@ async def reload_taxonomy(http_request: Request = None) -> Any:
 
 @router.get(
     "/validate",
+    response_model=TaxonomyValidationResponse,
     summary="Validate taxonomy YAML",
     description="Validate the current taxonomy YAML file without applying changes.",
 )

--- a/tests/api/golden/taxonomy_index.json
+++ b/tests/api/golden/taxonomy_index.json
@@ -1,0 +1,738 @@
+{
+  "data": {
+    "processes": [
+      {
+        "aliases": [
+          "3d print",
+          "3d printing",
+          "3d_printing",
+          "3dp",
+          "additive manufacturing",
+          "am",
+          "print",
+          "printing"
+        ],
+        "canonical_id": "3d_printing",
+        "children": [
+          "3d_printing_dlp",
+          "3d_printing_fdm",
+          "3d_printing_sla",
+          "3d_printing_sls"
+        ],
+        "display_name": "3D Printing",
+        "parent": null,
+        "tsdc_code": "3DP",
+        "wikidata_iri": "https://www.wikidata.org/entity/Q229367"
+      },
+      {
+        "aliases": [
+          "digital light processing",
+          "dlp",
+          "dlp printing"
+        ],
+        "canonical_id": "3d_printing_dlp",
+        "children": [],
+        "display_name": "DLP 3D Printing",
+        "parent": "3d_printing",
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "fdm",
+          "fdm printing",
+          "fff",
+          "fused deposition modeling",
+          "fused deposition modelling",
+          "fused filament fabrication",
+          "fused_filament_fabrication"
+        ],
+        "canonical_id": "3d_printing_fdm",
+        "children": [],
+        "display_name": "FDM 3D Printing",
+        "parent": "3d_printing",
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "sla",
+          "sla printer",
+          "sla printing",
+          "stereolithography"
+        ],
+        "canonical_id": "3d_printing_sla",
+        "children": [],
+        "display_name": "SLA 3D Printing",
+        "parent": "3d_printing",
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "selective laser sintering",
+          "sls",
+          "sls printing"
+        ],
+        "canonical_id": "3d_printing_sls",
+        "children": [],
+        "display_name": "SLS 3D Printing",
+        "parent": "3d_printing",
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "anneal",
+          "annealing"
+        ],
+        "canonical_id": "annealing",
+        "children": [],
+        "display_name": "Annealing",
+        "parent": "heat_treatment",
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "anodising",
+          "anodize",
+          "anodizing"
+        ],
+        "canonical_id": "anodizing",
+        "children": [],
+        "display_name": "Anodizing",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "arc welding",
+          "arc_welding"
+        ],
+        "canonical_id": "arc_welding",
+        "children": [],
+        "display_name": "Arc Welding",
+        "parent": "welding",
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "asm",
+          "assemble",
+          "assembling",
+          "assembly",
+          "assembly line",
+          "assembly_line",
+          "attach",
+          "attaching",
+          "component assembly",
+          "install",
+          "installing",
+          "mount",
+          "mounting"
+        ],
+        "canonical_id": "assembly",
+        "children": [
+          "electronics_assembly",
+          "mechanical_assembly",
+          "pcb_assembly"
+        ],
+        "display_name": "Assembly",
+        "parent": null,
+        "tsdc_code": "ASM",
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "bend",
+          "bending"
+        ],
+        "canonical_id": "bending",
+        "children": [],
+        "display_name": "Bending",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "braze",
+          "brazing",
+          "silver brazing",
+          "torch brazing"
+        ],
+        "canonical_id": "brazing",
+        "children": [],
+        "display_name": "Brazing",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "cast",
+          "casting"
+        ],
+        "canonical_id": "casting",
+        "children": [],
+        "display_name": "Casting",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "cnc",
+          "cnc machining",
+          "cnc_machining",
+          "computer numerical control",
+          "machining",
+          "subtractive manufacturing"
+        ],
+        "canonical_id": "cnc_machining",
+        "children": [
+          "cnc_milling",
+          "cnc_turning",
+          "precision_machining"
+        ],
+        "display_name": "CNC Machining",
+        "parent": null,
+        "tsdc_code": "CNC",
+        "wikidata_iri": "https://www.wikidata.org/entity/Q3689317"
+      },
+      {
+        "aliases": [
+          "cnc mill",
+          "cnc milling",
+          "cnc_mill",
+          "cnc_milling",
+          "milling"
+        ],
+        "canonical_id": "cnc_milling",
+        "children": [],
+        "display_name": "CNC Milling",
+        "parent": "cnc_machining",
+        "tsdc_code": null,
+        "wikidata_iri": "https://www.wikidata.org/entity/Q656950"
+      },
+      {
+        "aliases": [
+          "cnc lathe",
+          "cnc turning",
+          "cnc_lathe",
+          "cnc_turning",
+          "turning"
+        ],
+        "canonical_id": "cnc_turning",
+        "children": [],
+        "display_name": "CNC Turning",
+        "parent": "cnc_machining",
+        "tsdc_code": null,
+        "wikidata_iri": "https://www.wikidata.org/entity/Q258127"
+      },
+      {
+        "aliases": [
+          "coat",
+          "coating"
+        ],
+        "canonical_id": "coating",
+        "children": [],
+        "display_name": "Coating",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "cut",
+          "cutting"
+        ],
+        "canonical_id": "cutting",
+        "children": [
+          "sawing",
+          "shearing"
+        ],
+        "display_name": "Cutting",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "deburr",
+          "deburring"
+        ],
+        "canonical_id": "deburring",
+        "children": [],
+        "display_name": "Deburring",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "drill",
+          "drilling"
+        ],
+        "canonical_id": "drilling",
+        "children": [],
+        "display_name": "Drilling",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "cir",
+          "circuitry",
+          "electronic circuitry"
+        ],
+        "canonical_id": "electronic_circuitry",
+        "children": [],
+        "display_name": "Electronic Circuitry",
+        "parent": null,
+        "tsdc_code": "CIR",
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "electronics assembly",
+          "electronics manufacturing",
+          "electronics_assembly",
+          "electronics_manufacturing"
+        ],
+        "canonical_id": "electronics_assembly",
+        "children": [],
+        "display_name": "Electronics Assembly",
+        "parent": "assembly",
+        "tsdc_code": null,
+        "wikidata_iri": "https://www.wikidata.org/entity/Q11650"
+      },
+      {
+        "aliases": [
+          "chrome plating",
+          "electroplate",
+          "electroplating",
+          "nickel plating",
+          "plating",
+          "zinc plating"
+        ],
+        "canonical_id": "electroplating",
+        "children": [],
+        "display_name": "Electroplating",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "forge",
+          "forging"
+        ],
+        "canonical_id": "forging",
+        "children": [],
+        "display_name": "Forging",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "grind",
+          "grinding"
+        ],
+        "canonical_id": "grinding",
+        "children": [],
+        "display_name": "Grinding",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "heat treat",
+          "heat treatment",
+          "heat_treatment"
+        ],
+        "canonical_id": "heat_treatment",
+        "children": [
+          "annealing",
+          "quenching",
+          "tempering"
+        ],
+        "display_name": "Heat Treatment",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "injection molding",
+          "injection moulding",
+          "injection_molding"
+        ],
+        "canonical_id": "injection_molding",
+        "children": [],
+        "display_name": "Injection Molding",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "las",
+          "laser",
+          "laser cut",
+          "laser cutting",
+          "laser_cutting"
+        ],
+        "canonical_id": "laser_cutting",
+        "children": [],
+        "display_name": "Laser Cutting",
+        "parent": null,
+        "tsdc_code": "LAS",
+        "wikidata_iri": "https://www.wikidata.org/entity/Q593053"
+      },
+      {
+        "aliases": [
+          "mec",
+          "mechanical assembly",
+          "mechanical_assembly"
+        ],
+        "canonical_id": "mechanical_assembly",
+        "children": [],
+        "display_name": "Mechanical Assembly",
+        "parent": "assembly",
+        "tsdc_code": "MEC",
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "mig",
+          "mig welding",
+          "mig_welding"
+        ],
+        "canonical_id": "mig_welding",
+        "children": [],
+        "display_name": "MIG Welding",
+        "parent": "welding",
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "packaging",
+          "packaging and labeling",
+          "packaging_and_labeling"
+        ],
+        "canonical_id": "packaging",
+        "children": [],
+        "display_name": "Packaging",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "paint",
+          "painting"
+        ],
+        "canonical_id": "painting",
+        "children": [],
+        "display_name": "Painting",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": "https://www.wikidata.org/entity/Q11629"
+      },
+      {
+        "aliases": [
+          "clean room assembly",
+          "clean_room_assembly",
+          "pcb assembly",
+          "pcb_assembly"
+        ],
+        "canonical_id": "pcb_assembly",
+        "children": [],
+        "display_name": "PCB Assembly",
+        "parent": "assembly",
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "circuit board",
+          "pcb",
+          "pcb fabrication",
+          "pcb_fabrication",
+          "printed circuit board",
+          "printed_circuit_board"
+        ],
+        "canonical_id": "pcb_fabrication",
+        "children": [],
+        "display_name": "PCB Fabrication",
+        "parent": null,
+        "tsdc_code": "PCB",
+        "wikidata_iri": "https://www.wikidata.org/entity/Q173350"
+      },
+      {
+        "aliases": [
+          "cnc plasma",
+          "cnc plasma cutting",
+          "plasma cut",
+          "plasma cutting",
+          "plasma_cutting"
+        ],
+        "canonical_id": "plasma_cutting",
+        "children": [],
+        "display_name": "Plasma Cutting",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "polish",
+          "polishing"
+        ],
+        "canonical_id": "polishing",
+        "children": [],
+        "display_name": "Polishing",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "post",
+          "post processing",
+          "post-processing",
+          "post_processing",
+          "postprocessing"
+        ],
+        "canonical_id": "post_processing",
+        "children": [],
+        "display_name": "Post-Processing",
+        "parent": null,
+        "tsdc_code": "POST",
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "precision machining",
+          "precision_machining"
+        ],
+        "canonical_id": "precision_machining",
+        "children": [],
+        "display_name": "Precision Machining",
+        "parent": "cnc_machining",
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "quench",
+          "quenching"
+        ],
+        "canonical_id": "quenching",
+        "children": [],
+        "display_name": "Quenching",
+        "parent": "heat_treatment",
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "sand",
+          "sanding"
+        ],
+        "canonical_id": "sanding",
+        "children": [],
+        "display_name": "Sanding",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "saw",
+          "sawing"
+        ],
+        "canonical_id": "sawing",
+        "children": [],
+        "display_name": "Sawing",
+        "parent": "cutting",
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "cut and sew",
+          "garment construction",
+          "sew",
+          "sewing",
+          "sewn",
+          "stitch",
+          "stitching",
+          "textile"
+        ],
+        "canonical_id": "sewing",
+        "children": [],
+        "display_name": "Sewing",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": "https://www.wikidata.org/entity/Q652122"
+      },
+      {
+        "aliases": [
+          "shear",
+          "shearing"
+        ],
+        "canonical_id": "shearing",
+        "children": [],
+        "display_name": "Shearing",
+        "parent": "cutting",
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "sheet",
+          "sheet metal",
+          "sheet metal forming",
+          "sheet_metal",
+          "sheet_metal_forming"
+        ],
+        "canonical_id": "sheet_metal_forming",
+        "children": [],
+        "display_name": "Sheet Metal Forming",
+        "parent": null,
+        "tsdc_code": "SHEET",
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "solder",
+          "soldering"
+        ],
+        "canonical_id": "soldering",
+        "children": [],
+        "display_name": "Soldering",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "surface finish",
+          "surface finishing",
+          "surface treatment",
+          "surface_finish",
+          "surface_finishing",
+          "surface_treatment"
+        ],
+        "canonical_id": "surface_finishing",
+        "children": [],
+        "display_name": "Surface Finishing",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "temper",
+          "tempering"
+        ],
+        "canonical_id": "tempering",
+        "children": [],
+        "display_name": "Tempering",
+        "parent": "heat_treatment",
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "quality control",
+          "quality_control",
+          "test equipment",
+          "test_equipment",
+          "testing"
+        ],
+        "canonical_id": "testing",
+        "children": [],
+        "display_name": "Testing",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "tig",
+          "tig welding",
+          "tig_welding"
+        ],
+        "canonical_id": "tig_welding",
+        "children": [],
+        "display_name": "TIG Welding",
+        "parent": "welding",
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "d\u00e9coupe vinyle",
+          "plotter",
+          "sticker cutting",
+          "vinyl cutter",
+          "vinyl cutting",
+          "vinyl_cutting"
+        ],
+        "canonical_id": "vinyl_cutting",
+        "children": [],
+        "display_name": "Vinyl Cutting",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": "https://www.wikidata.org/entity/Q12860083"
+      },
+      {
+        "aliases": [
+          "water jet",
+          "water jet cutting",
+          "water_jet_cutting",
+          "waterjet"
+        ],
+        "canonical_id": "water_jet_cutting",
+        "children": [],
+        "display_name": "Water Jet Cutting",
+        "parent": null,
+        "tsdc_code": null,
+        "wikidata_iri": null
+      },
+      {
+        "aliases": [
+          "wel",
+          "weld",
+          "welder",
+          "welding"
+        ],
+        "canonical_id": "welding",
+        "children": [
+          "arc_welding",
+          "mig_welding",
+          "tig_welding"
+        ],
+        "display_name": "Welding",
+        "parent": null,
+        "tsdc_code": "WEL",
+        "wikidata_iri": "https://www.wikidata.org/entity/Q131172"
+      }
+    ],
+    "source": "<repo>/src/config/taxonomy/processes.yaml",
+    "total": 51
+  },
+  "message": "Taxonomy retrieved successfully",
+  "metadata": {},
+  "status": "success"
+}

--- a/tests/api/golden/taxonomy_reload.json
+++ b/tests/api/golden/taxonomy_reload.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "added": [],
+    "removed": [],
+    "source": "<repo>/src/config/taxonomy/processes.yaml",
+    "total": 51,
+    "version": "1.0.0"
+  },
+  "message": "Taxonomy reloaded successfully",
+  "metadata": {},
+  "status": "success"
+}

--- a/tests/api/golden/taxonomy_validate.json
+++ b/tests/api/golden/taxonomy_validate.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "errors": [],
+    "source": "<repo>/src/config/taxonomy/processes.yaml",
+    "total_processes": 51,
+    "valid": true
+  },
+  "message": "Taxonomy validation completed",
+  "metadata": {},
+  "status": "success"
+}

--- a/tests/api/test_taxonomy_contract.py
+++ b/tests/api/test_taxonomy_contract.py
@@ -1,0 +1,91 @@
+"""Contract: the taxonomy routes are shape-frozen before they gain response models.
+
+Each of these returned a bare ``SuccessResponse`` annotated ``-> Any``, so
+FastAPI inferred no schema, ``openapi-typescript`` emitted no type, and the
+frontend had nothing to check a hand-written one against (#369, #373).
+
+Adding ``response_model`` is what fixes that, and it is also what makes this
+test necessary: ``response_model`` FILTERS. Any field the model does not
+declare is silently dropped from the JSON, so a model written by reading the
+route can delete a field a client reads — the same class of bug, introduced by
+its own fix.
+
+So the payloads are frozen against goldens captured from the routes BEFORE the
+models existed. The models are correct exactly when this test still passes.
+
+To change a contract deliberately:
+    BLESS_TAXONOMY_CONTRACT=1 .venv/bin/python -m pytest \
+        tests/api/test_taxonomy_contract.py
+and commit the regenerated golden with the reason in the message.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+GOLDEN_DIR = Path(__file__).parent / "golden"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+ROUTES = [
+    ("get", "/v1/api/taxonomy", "taxonomy_index"),
+    ("post", "/v1/api/taxonomy/reload", "taxonomy_reload"),
+    ("get", "/v1/api/taxonomy/validate", "taxonomy_validate"),
+]
+
+
+def _app() -> FastAPI:
+    from src.core.main import api_v1
+
+    app = FastAPI()
+    app.mount("/v1", api_v1)
+    return app
+
+
+def _normalise(payload: dict) -> dict:
+    """Drop what legitimately differs between runs and between machines.
+
+    ``timestamp`` and ``request_id`` are per-request. ``source`` is an absolute
+    path to the YAML on this checkout, so freezing it would pin the golden to
+    one developer's directory layout.
+    """
+    text = json.dumps(payload)
+    text = re.sub(re.escape(str(REPO_ROOT)), "<repo>", text)
+    body = json.loads(text)
+    body.pop("timestamp", None)
+    body.pop("request_id", None)
+    return body
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+@pytest.mark.parametrize("method,path,name", ROUTES)
+async def test_payload_is_field_identical_to_the_golden(method, path, name):
+    app = _app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.request(method, path)
+
+    assert response.status_code == 200, response.text
+    body = _normalise(response.json())
+
+    golden = GOLDEN_DIR / f"{name}.json"
+    if os.getenv("BLESS_TAXONOMY_CONTRACT"):
+        GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
+        golden.write_text(json.dumps(body, indent=2, sort_keys=True) + "\n")
+        pytest.skip(f"golden re-blessed: {golden.name}")
+
+    assert golden.exists(), (
+        f"No golden at {golden}. Capture one with BLESS_TAXONOMY_CONTRACT=1 "
+        "BEFORE adding a response_model."
+    )
+    assert body == json.loads(golden.read_text()), (
+        f"{method.upper()} {path} changed shape. If a response_model was just "
+        "added, it is filtering a field the route used to return."
+    )

--- a/tests/parity/test_response_models.py
+++ b/tests/parity/test_response_models.py
@@ -66,9 +66,6 @@ ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
         ("GET", "/api/supply-tree/solution/{solution_id}/staleness"),
         ("GET", "/api/supply-tree/solution/{solution_id}/visualization"),
         ("GET", "/api/supply-tree/solutions"),
-        ("GET", "/api/taxonomy"),
-        ("POST", "/api/taxonomy/reload"),
-        ("GET", "/api/taxonomy/validate"),
         ("GET", "/api/utility/domains"),
         ("GET", "/api/utility/metrics"),
     }


### PR DESCRIPTION
First router of #373, split by router as agreed. **Three operations off the debt list: 34 → 31.**

Each route returned a `SuccessResponse` annotated `-> Any`, so FastAPI inferred no schema, codegen emitted no type, and the frontend hand-wrote one the compiler could not check against anything.

## Test first, in the order the procedure requires

The goldens in `tests/api/golden/taxonomy_*.json` were captured from the routes **before** the models existed, and pass against them unmodelled. The models then had to leave the payloads byte-identical — which they do.

Verified the lock has teeth by deleting `aliases` from a model and watching the golden fail with the message a future author needs:

```
GET /v1/api/taxonomy changed shape. If a response_model was just added,
it is filtering a field the route used to return.
```

## The typing found a live bug

`reloadProcessTaxonomy` read `total_processes`. **`/reload` has never returned that field** — it returns `total`. `total_processes` belongs to `/validate`, whose payload is otherwise similar enough that the two were easy to confuse.

The settings panel has therefore been reporting **"Reloaded 0 process(es)"** after every successful reload.

## And the fixture agreed with the bug

The MSW reload handler returned `{total_processes: 51}` — the client's assumption rather than the API's payload — so the suite was green against a response that has never existed.

**This is the #369 failure again, one router over**: a hand-written cast, and a fixture encoding the same wrong guess, agreeing with each other. Corrected against the golden, which the comment now names as the source of truth, and both routes are pinned in tests so the near-identical field names stay told apart.

## Where the runtime parse goes

The process list is parsed at the client boundary because it feeds the facility form's options, where a drift degrades to a form with nothing to choose rather than to a visible error.

Validate and reload are operator actions whose results are read on screen, so a wrong shape shows itself; they rely on the generated types alone. That is the "reserved for where it earns its place" line from `parse.ts`, applied.

## Verification

`make ready`: 14/14. `frontend-ready`: all stages — 738 unit, 237 e2e.

The loop is now proven and mechanical for the remaining routers: capture goldens → add models → confirm unchanged → verify the lock bites → regenerate → delete casts → correct any fixture that agreed with one → shrink the allowlist → backpass.

Refs #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qew1kZog2JA8AKCgLxzn5X
