### PR TITLE
Response models for file-types and utility/domains (#373, 2 of N)

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 650
+Total Python files: 652
 
 ├── deploy/
 │   ├── __init__.py
@@ -654,6 +654,13 @@ Total Python files: 650
 │       │   │   │           class PackageFetchRequest
 │       │   │   │           class PackageFetchResponse
 │       │   │   │           class SignedManifestRecordResponse (from_signed)
+│       │   │   ├── file_types/
+│       │   │   │   └── response.py
+│       │   │   │           class FileTypeDefinition
+│       │   │   │           class FileTypeIndexData
+│       │   │   │           class FileTypeIndexResponse
+│       │   │   │           class FileTypeValidationData
+│       │   │   │           class FileTypeValidationResponse
 │       │   │   ├── llm/
 │       │   │   │   ├── request.py
 │       │   │   │   │       class LLMCredentialUpsert
@@ -800,6 +807,8 @@ Total Python files: 650
 │       │   │   │           class Context
 │       │   │   │           class ContextsResponse
 │       │   │   │           class ErrorResponse
+│       │   │   │           class DomainListData
+│       │   │   │           class DomainListResponse
 │       │   │   ├── validation/
 │       │   │   │   ├── __init__.py
 │       │   │   │   ├── context.py
@@ -1988,6 +1997,9 @@ Total Python files: 650
     │   │       def _get_app()
     │   ├── test_disclosure_routes.py
     │   │       def _get_app()
+    │   ├── test_filetypes_utility_contract.py
+    │   │       def _freeze()
+    │   │       def _normalise()
     │   ├── test_identity_routes.py
     │   │       def _get_app()
     │   ├── test_llm_credential_routes.py
@@ -3442,7 +3454,7 @@ Total Python files: 650
 
 ## Overview
 
-Total files analyzed: 650
+Total files analyzed: 652
 
 ## Entry Points
 
@@ -4281,6 +4293,21 @@ Returns the full OKH ma...
 
 **Internal Dependencies:** 3 imports
 
+### `src/core/api/models/file_types/response.py`
+> Response models for the file-type taxonomy routes.
+
+Derived from payloads captured in ``tests/api/go...
+
+**Exports:** FileTypeDefinition, FileTypeIndexData, FileTypeIndexResponse, FileTypeValidationData, FileTypeValidationResponse
+
+**Classes:**
+- `FileTypeDefinition` (inherits: BaseModel)
+  - One canonical file type and how it is recognised....
+- `FileTypeIndexData` (inherits: BaseModel)
+- `FileTypeIndexResponse` (inherits: SuccessResponse)
+- `FileTypeValidationData` (inherits: BaseModel)
+- `FileTypeValidationResponse` (inherits: SuccessResponse)
+
 ### `src/core/api/models/llm/request.py`
 > Request models for LLM credential management....
 
@@ -4653,6 +4680,11 @@ Derived from the payloads the routes already returned, cap...
   - Response model for validation contexts with standardized fields and LLM informat...
 - `ErrorResponse` (inherits: BaseModel)
   - Response model for API errors...
+- `DomainListData` (inherits: BaseModel)
+  - The ``data`` payload of GET /api/utility/domains.
+
+Derived from the payload capt...
+- `DomainListResponse` (inherits: SuccessResponse)
 
 ### `src/core/api/models/validation/__init__.py`
 > API models for validation operations.
@@ -5934,6 +5966,13 @@ safe to...
   - Return a blank OKH manifest template dict....
 - `okw_blank_template()`
   - Return a blank OKW facility template dict....
+
+### `tests/api/test_filetypes_utility_contract.py`
+> Contract: file-type and utility payloads are frozen before they gain models.
+
+Same reasoning as the ...
+
+**Internal Dependencies:** 2 imports
 
 ## Configuration
 
@@ -7713,7 +7752,7 @@ Provides endpoints for bi-directional conversion ...
 ### `src/core/api/routes/file_types.py`
 > API routes for file type taxonomy....
 
-**Internal Dependencies:** 6 imports
+**Internal Dependencies:** 8 imports
 
 ### `src/core/api/routes/identity.py`
 > Identity API — the unified surface for API keys and accounts.

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -5143,6 +5143,18 @@ export interface components {
             disclosure: components["schemas"]["DisclosureProfile"];
         };
         /**
+         * Domain
+         * @description Model for domain information
+         */
+        Domain: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description: string;
+        };
+        /**
          * DomainBindRequest
          * @description Start a domain (``.well-known``) binding for a DID.
          */
@@ -5164,6 +5176,69 @@ export interface components {
             well_known_document: {
                 [key: string]: unknown;
             };
+        };
+        /**
+         * DomainListData
+         * @description The ``data`` payload of GET /api/utility/domains.
+         *
+         *     Derived from the payload captured in ``tests/api/golden/utility_domains.json``
+         *     before this model existed. Note the nesting: the route puts these under
+         *     ``data``, which is why ``DomainsResponse`` above — which declares them at
+         *     the top level — does not describe this route and is not used by it.
+         */
+        DomainListData: {
+            /** Default Domain */
+            default_domain: string;
+            /** Domains */
+            domains: components["schemas"]["Domain"][];
+            /** Validation Results */
+            validation_results: {
+                [key: string]: unknown;
+            }[];
+            /** Processing Time */
+            processing_time: number;
+        };
+        /**
+         * DomainListResponse
+         * @example {
+         *       "data": {},
+         *       "message": "Operation completed successfully",
+         *       "metadata": {},
+         *       "request_id": "req_123456789",
+         *       "status": "success",
+         *       "timestamp": "2024-01-01T12:00:00Z"
+         *     }
+         */
+        DomainListResponse: {
+            /**
+             * @description Success status
+             * @default success
+             */
+            status: components["schemas"]["APIStatus"];
+            /**
+             * Message
+             * @description Human-readable response message
+             */
+            message: string;
+            /**
+             * Timestamp
+             * Format: date-time
+             * @description Response timestamp
+             */
+            timestamp?: string;
+            /**
+             * Request Id
+             * @description Request identifier if provided
+             */
+            request_id?: string | null;
+            data: components["schemas"]["DomainListData"];
+            /**
+             * Metadata
+             * @description Additional response metadata
+             */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * DomainVerifyRequest
@@ -5407,6 +5482,130 @@ export interface components {
             per_peer_pulled?: {
                 [key: string]: number;
             };
+        };
+        /**
+         * FileTypeDefinition
+         * @description One canonical file type and how it is recognised.
+         */
+        FileTypeDefinition: {
+            /** Canonical Id */
+            canonical_id: string;
+            /** Display Name */
+            display_name: string;
+            /** Extensions */
+            extensions: string[];
+            /** Mime Types */
+            mime_types: string[];
+            /** Okh Role */
+            okh_role: string | null;
+            /** Parent */
+            parent: string | null;
+            /** Render Tier */
+            render_tier: string | null;
+        };
+        /** FileTypeIndexData */
+        FileTypeIndexData: {
+            /** Total */
+            total: number;
+            /** Source */
+            source: string;
+            /** File Types */
+            file_types: components["schemas"]["FileTypeDefinition"][];
+        };
+        /**
+         * FileTypeIndexResponse
+         * @example {
+         *       "data": {},
+         *       "message": "Operation completed successfully",
+         *       "metadata": {},
+         *       "request_id": "req_123456789",
+         *       "status": "success",
+         *       "timestamp": "2024-01-01T12:00:00Z"
+         *     }
+         */
+        FileTypeIndexResponse: {
+            /**
+             * @description Success status
+             * @default success
+             */
+            status: components["schemas"]["APIStatus"];
+            /**
+             * Message
+             * @description Human-readable response message
+             */
+            message: string;
+            /**
+             * Timestamp
+             * Format: date-time
+             * @description Response timestamp
+             */
+            timestamp?: string;
+            /**
+             * Request Id
+             * @description Request identifier if provided
+             */
+            request_id?: string | null;
+            data: components["schemas"]["FileTypeIndexData"];
+            /**
+             * Metadata
+             * @description Additional response metadata
+             */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+        };
+        /** FileTypeValidationData */
+        FileTypeValidationData: {
+            /** Valid */
+            valid: boolean;
+            /** Total File Types */
+            total_file_types: number;
+            /** Errors */
+            errors: string[];
+            /** Source */
+            source: string;
+        };
+        /**
+         * FileTypeValidationResponse
+         * @example {
+         *       "data": {},
+         *       "message": "Operation completed successfully",
+         *       "metadata": {},
+         *       "request_id": "req_123456789",
+         *       "status": "success",
+         *       "timestamp": "2024-01-01T12:00:00Z"
+         *     }
+         */
+        FileTypeValidationResponse: {
+            /**
+             * @description Success status
+             * @default success
+             */
+            status: components["schemas"]["APIStatus"];
+            /**
+             * Message
+             * @description Human-readable response message
+             */
+            message: string;
+            /**
+             * Timestamp
+             * Format: date-time
+             * @description Response timestamp
+             */
+            timestamp?: string;
+            /**
+             * Request Id
+             * @description Request identifier if provided
+             */
+            request_id?: string | null;
+            data: components["schemas"]["FileTypeValidationData"];
+            /**
+             * Metadata
+             * @description Additional response metadata
+             */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
         };
         /** FollowResponse */
         FollowResponse: {
@@ -14937,9 +15136,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["DomainListResponse"];
                 };
             };
             /** @description Bad Request */
@@ -16997,7 +17194,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["FileTypeIndexResponse"];
                 };
             };
             /** @description Bad Request */
@@ -17031,7 +17228,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["FileTypeValidationResponse"];
                 };
             };
             /** @description Bad Request */

--- a/frontend/src/api/ohm/file-types.ts
+++ b/frontend/src/api/ohm/file-types.ts
@@ -6,10 +6,10 @@
  * of falls to `download_only` even when the server knows how to render it. This
  * is the authority; the regex stays as the offline fallback.
  *
- * The endpoints answer with `create_success_response`, whose `data` payload the
- * generated schema types as an open record — so the shapes below are declared
- * here rather than imported, and this module is the one place that narrows
- * them.
+ * The endpoints used to answer with an untyped `data` payload, so these shapes
+ * were declared here and narrowed by hand. Both routes now carry response
+ * models (#373), so the types come from codegen and this module no longer
+ * guesses — it maps.
  */
 import {
   apiClient,
@@ -17,23 +17,10 @@ import {
   errorMessage,
   requestIdFromError,
 } from "./client";
+import type { components } from "../generated/schema";
 
-export interface FileTypeDefinition {
-  canonical_id: string;
-  display_name: string;
-  parent: string | null;
-  extensions: string[];
-  mime_types: string[];
-  okh_role: string | null;
-  render_tier: string | null;
-}
-
-export interface FileTypeTaxonomy {
-  total: number;
-  /** Where the server loaded it from — a YAML path, or "built-in". */
-  source: string;
-  file_types: FileTypeDefinition[];
-}
+export type FileTypeDefinition = components["schemas"]["FileTypeDefinition"];
+export type FileTypeTaxonomy = components["schemas"]["FileTypeIndexData"];
 
 function fail(error: unknown, response: Response, fallback: string): never {
   throw new ApiError(
@@ -43,20 +30,11 @@ function fail(error: unknown, response: Response, fallback: string): never {
   );
 }
 
-/** Narrow the success envelope's open `data` record. */
-function payload<T>(data: unknown): T {
-  return ((data as { data?: unknown } | undefined)?.data ?? {}) as T;
-}
-
 export async function fetchFileTypes(): Promise<FileTypeTaxonomy> {
   const { data, error, response } = await apiClient.GET("/api/file-types");
-  if (error || !response.ok) fail(error, response, "Failed to load file types");
-  const body = payload<Partial<FileTypeTaxonomy>>(data);
-  return {
-    total: body.total ?? 0,
-    source: body.source ?? "built-in",
-    file_types: body.file_types ?? [],
-  };
+  if (error || !response.ok || !data)
+    fail(error, response, "Failed to load file types");
+  return data.data;
 }
 
 /** extension (no dot, lowercased) -> definition. */
@@ -72,25 +50,15 @@ export function fileTypesByExtension(
   return index;
 }
 
-export interface FileTypeValidation {
-  valid: boolean;
-  total_file_types: number;
-  errors: string[];
-  source: string;
-}
+export type FileTypeValidation =
+  components["schemas"]["FileTypeValidationData"];
 
 /** Check the file-types YAML on the server's disk. */
 export async function validateFileTypes(): Promise<FileTypeValidation> {
   const { data, error, response } = await apiClient.GET(
     "/api/file-types/validate",
   );
-  if (error || !response.ok)
+  if (error || !response.ok || !data)
     fail(error, response, "Failed to validate file types");
-  const body = payload<Partial<FileTypeValidation>>(data);
-  return {
-    valid: body.valid ?? false,
-    total_file_types: body.total_file_types ?? 0,
-    errors: body.errors ?? [],
-    source: body.source ?? "",
-  };
+  return data.data;
 }

--- a/frontend/src/api/ohm/utility.ts
+++ b/frontend/src/api/ohm/utility.ts
@@ -1,10 +1,14 @@
 import { apiClient, ApiError, errorMessage } from "./client";
+import type { components } from "../generated/schema";
 
-export interface Domain {
-  id: string;
-  name: string;
-  description?: string | null;
-}
+/**
+ * Generated from the route's response model (#373).
+ *
+ * `id` is the key the API matches on; `name` is for reading. Nothing declared
+ * that before, which is how the match view came to send the second where the
+ * first was required (#369).
+ */
+export type Domain = components["schemas"]["Domain"];
 
 /** Available matching domains (manufacturing, cooking, …). */
 export async function fetchDomains(): Promise<Domain[]> {
@@ -15,24 +19,21 @@ export async function fetchDomains(): Promise<Domain[]> {
       errorMessage(error, `Failed to load domains (HTTP ${response.status})`),
     );
   }
-  return ((data as { data?: { domains?: Domain[] } })?.data?.domains ??
-    []) as Domain[];
+  return data?.data.domains ?? [];
 }
 
 /**
  * Server-configured default domain (`OHM_DEFAULT_DOMAIN`) for first-time
  * visitors — e.g. a cooking-domain instance can default new browsers to
- * "cooking" instead of the hardcoded "manufacturing" fallback. Not yet in the
- * generated schema (the endpoint returns a plain dict), so read defensively;
- * returns null on any failure rather than throwing, since callers treat this
- * as a nice-to-have seed, not a hard requirement.
+ * "cooking" instead of the hardcoded "manufacturing" fallback. Returns null on
+ * any failure rather than throwing, since callers treat this as a
+ * nice-to-have seed, not a hard requirement.
  */
 export async function fetchDefaultDomain(): Promise<string | null> {
   try {
     const { data, error, response } = await apiClient.GET("/api/utility/domains");
     if (error || !response.ok) return null;
-    const value = (data as { data?: { default_domain?: unknown } })?.data?.default_domain;
-    return typeof value === "string" ? value : null;
+    return data?.data.default_domain ?? null;
   } catch {
     return null;
   }

--- a/src/core/api/models/file_types/response.py
+++ b/src/core/api/models/file_types/response.py
@@ -1,0 +1,53 @@
+"""Response models for the file-type taxonomy routes.
+
+Derived from payloads captured in ``tests/api/golden/`` before these models
+existed, not from reading the route bodies: ``response_model`` filters, so a
+model written from the code can silently drop a field a client reads. See
+``docs/architecture/api-response-contracts.md``.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+from ..base import SuccessResponse
+
+
+class FileTypeDefinition(BaseModel):
+    """One canonical file type and how it is recognised."""
+
+    canonical_id: str
+    display_name: str
+    extensions: List[str]
+    mime_types: List[str]
+    # Required but nullable, not optional: every item in the payload carries
+    # all three keys (verified across all 32 in the golden). A default would
+    # make them optional in the schema, and the client would then have to
+    # handle an `undefined` the route never sends.
+    okh_role: Optional[str]
+    parent: Optional[str]
+    render_tier: Optional[str]
+
+
+class FileTypeIndexData(BaseModel):
+    total: int
+    #: Path to the YAML the taxonomy came from, or "built-in".
+    source: str
+    file_types: List[FileTypeDefinition]
+
+
+class FileTypeIndexResponse(SuccessResponse):
+    data: FileTypeIndexData
+
+
+class FileTypeValidationData(BaseModel):
+    valid: bool
+    total_file_types: int
+    errors: List[str]
+    source: str
+
+
+class FileTypeValidationResponse(SuccessResponse):
+    data: FileTypeValidationData

--- a/src/core/api/models/utility/response.py
+++ b/src/core/api/models/utility/response.py
@@ -15,7 +15,15 @@ class Domain(BaseModel):
 
 
 class DomainsResponse(SuccessResponse, LLMResponseMixin):
-    """Response model for available domains with standardized fields and LLM information"""
+    """Response model for available domains with standardized fields and LLM information
+
+    .. warning::
+       Not what GET /api/utility/domains returns, and not used by it. This
+       declares ``domains``/``default_domain`` at the TOP level; the route
+       nests them under ``data``. Attaching this as a ``response_model`` would
+       filter the real payload away. ``DomainListResponse`` below is the one
+       that matches the route.
+    """
 
     domains: List[Domain]
     # Which domain a fresh browser session should open in on this instance
@@ -97,3 +105,24 @@ class ErrorResponse(BaseModel):
     """Response model for API errors"""
 
     error: Dict[str, Any]  # Contains code, message, details
+
+
+class DomainListData(BaseModel):
+    """The ``data`` payload of GET /api/utility/domains.
+
+    Derived from the payload captured in ``tests/api/golden/utility_domains.json``
+    before this model existed. Note the nesting: the route puts these under
+    ``data``, which is why ``DomainsResponse`` above — which declares them at
+    the top level — does not describe this route and is not used by it.
+    """
+
+    default_domain: str
+    domains: List[Domain]
+    #: Per-domain validation reports. Left free-form: they come from the domain
+    #: validators, and a strict model would filter whatever those grow next.
+    validation_results: List[Dict[str, Any]]
+    processing_time: float
+
+
+class DomainListResponse(SuccessResponse):
+    data: DomainListData

--- a/src/core/api/routes/file_types.py
+++ b/src/core/api/routes/file_types.py
@@ -6,6 +6,10 @@ from fastapi import APIRouter, HTTPException, Request, status
 
 from src.core.api.constants.openapi import RESPONSES_400_500
 from src.core.api.error_handlers import create_success_response
+from src.core.api.models.file_types.response import (
+    FileTypeIndexResponse,
+    FileTypeValidationResponse,
+)
 from src.core.taxonomy.file_type_taxonomy import (
     DEFAULT_FILE_TYPES_PATH,
     file_type_taxonomy,
@@ -22,6 +26,7 @@ router = APIRouter(
 
 @router.get(
     "",
+    response_model=FileTypeIndexResponse,
     summary="Get file type taxonomy",
     description="Returns all file types in the current taxonomy.",
 )
@@ -59,6 +64,7 @@ async def get_file_types(http_request: Request = None) -> Any:
 
 @router.get(
     "/validate",
+    response_model=FileTypeValidationResponse,
     summary="Validate file type taxonomy YAML",
 )
 async def validate_file_types(http_request: Request = None) -> Any:

--- a/src/core/api/routes/utility.py
+++ b/src/core/api/routes/utility.py
@@ -32,7 +32,7 @@ from ..models.base import ErrorCode, ErrorDetail, ValidationResult
 
 # Import consolidated utility models
 from ..models.utility.request import ContextFilterRequest, DomainFilterRequest
-from ..models.utility.response import Context, Domain
+from ..models.utility.response import Context, Domain, DomainListResponse
 
 # Set up logging
 logger = get_logger(__name__)
@@ -47,6 +47,7 @@ router = APIRouter(
 
 @router.get(
     "/domains",
+    response_model=DomainListResponse,
     summary="List Available Domains",
     description="""
     Get a list of available domains with enhanced capabilities.

--- a/tests/api/golden/file_types_index.json
+++ b/tests/api/golden/file_types_index.json
@@ -1,0 +1,426 @@
+{
+  "data": {
+    "file_types": [
+      {
+        "canonical_id": "archive",
+        "display_name": "Archive",
+        "extensions": [
+          ".7z",
+          ".gz",
+          ".rar",
+          ".tar",
+          ".tar.gz",
+          ".tgz",
+          ".zip"
+        ],
+        "mime_types": [],
+        "okh_role": "documentation",
+        "parent": null,
+        "render_tier": "download_only"
+      },
+      {
+        "canonical_id": "cad",
+        "display_name": "CAD",
+        "extensions": [],
+        "mime_types": [],
+        "okh_role": "design",
+        "parent": null,
+        "render_tier": "download_only"
+      },
+      {
+        "canonical_id": "cad_dwg",
+        "display_name": "AutoCAD DWG",
+        "extensions": [
+          ".dwg"
+        ],
+        "mime_types": [],
+        "okh_role": "design",
+        "parent": "cad",
+        "render_tier": "download_only"
+      },
+      {
+        "canonical_id": "cad_dxf",
+        "display_name": "DXF",
+        "extensions": [
+          ".dxf"
+        ],
+        "mime_types": [],
+        "okh_role": "grey_zone",
+        "parent": "cad",
+        "render_tier": "download_only"
+      },
+      {
+        "canonical_id": "cad_f3d",
+        "display_name": "Fusion 360",
+        "extensions": [
+          ".f3d"
+        ],
+        "mime_types": [],
+        "okh_role": "design",
+        "parent": "cad",
+        "render_tier": "download_only"
+      },
+      {
+        "canonical_id": "cad_fcstd",
+        "display_name": "FreeCAD",
+        "extensions": [
+          ".fcstd"
+        ],
+        "mime_types": [],
+        "okh_role": "design",
+        "parent": "cad",
+        "render_tier": "download_only"
+      },
+      {
+        "canonical_id": "cad_iges",
+        "display_name": "IGES",
+        "extensions": [
+          ".iges",
+          ".igs"
+        ],
+        "mime_types": [],
+        "okh_role": "design",
+        "parent": "cad",
+        "render_tier": "download_only"
+      },
+      {
+        "canonical_id": "cad_scad",
+        "display_name": "OpenSCAD",
+        "extensions": [
+          ".scad"
+        ],
+        "mime_types": [],
+        "okh_role": "design",
+        "parent": "cad",
+        "render_tier": "text_viewer"
+      },
+      {
+        "canonical_id": "cad_step",
+        "display_name": "STEP",
+        "extensions": [
+          ".step",
+          ".stp"
+        ],
+        "mime_types": [
+          "application/step",
+          "model/step"
+        ],
+        "okh_role": "design",
+        "parent": "cad",
+        "render_tier": "download_only"
+      },
+      {
+        "canonical_id": "code",
+        "display_name": "Source Code",
+        "extensions": [
+          ".c",
+          ".cpp",
+          ".go",
+          ".h",
+          ".java",
+          ".js",
+          ".py",
+          ".rs",
+          ".sh",
+          ".ts"
+        ],
+        "mime_types": [],
+        "okh_role": "software",
+        "parent": null,
+        "render_tier": "text_viewer"
+      },
+      {
+        "canonical_id": "document",
+        "display_name": "Document",
+        "extensions": [],
+        "mime_types": [],
+        "okh_role": "documentation",
+        "parent": null,
+        "render_tier": "download_only"
+      },
+      {
+        "canonical_id": "document_markdown",
+        "display_name": "Markdown",
+        "extensions": [
+          ".markdown",
+          ".md",
+          ".mdown"
+        ],
+        "mime_types": [
+          "text/markdown",
+          "text/x-markdown"
+        ],
+        "okh_role": "documentation",
+        "parent": "document",
+        "render_tier": "text_viewer"
+      },
+      {
+        "canonical_id": "document_office",
+        "display_name": "Office Document",
+        "extensions": [
+          ".doc",
+          ".docx",
+          ".odt",
+          ".rtf"
+        ],
+        "mime_types": [],
+        "okh_role": "documentation",
+        "parent": "document",
+        "render_tier": "download_only"
+      },
+      {
+        "canonical_id": "document_pdf",
+        "display_name": "PDF",
+        "extensions": [
+          ".pdf"
+        ],
+        "mime_types": [
+          "application/pdf"
+        ],
+        "okh_role": "documentation",
+        "parent": "document",
+        "render_tier": "native_inline"
+      },
+      {
+        "canonical_id": "document_plain_text",
+        "display_name": "Plain Text",
+        "extensions": [
+          ".csv",
+          ".log",
+          ".txt"
+        ],
+        "mime_types": [
+          "text/csv",
+          "text/plain"
+        ],
+        "okh_role": "documentation",
+        "parent": "document",
+        "render_tier": "text_viewer"
+      },
+      {
+        "canonical_id": "document_structured",
+        "display_name": "Structured Text",
+        "extensions": [
+          ".json",
+          ".toml",
+          ".xml",
+          ".yaml",
+          ".yml"
+        ],
+        "mime_types": [
+          "application/json",
+          "application/xml",
+          "application/yaml",
+          "text/xml"
+        ],
+        "okh_role": "documentation",
+        "parent": "document",
+        "render_tier": "text_viewer"
+      },
+      {
+        "canonical_id": "drill",
+        "display_name": "Drill File",
+        "extensions": [
+          ".drl",
+          ".xln"
+        ],
+        "mime_types": [],
+        "okh_role": "manufacturing",
+        "parent": "manufacturing",
+        "render_tier": "text_viewer"
+      },
+      {
+        "canonical_id": "eda",
+        "display_name": "EDA",
+        "extensions": [],
+        "mime_types": [],
+        "okh_role": "design",
+        "parent": null,
+        "render_tier": "download_only"
+      },
+      {
+        "canonical_id": "eda_kicad_pcb",
+        "display_name": "KiCad PCB",
+        "extensions": [
+          ".kicad_pcb"
+        ],
+        "mime_types": [],
+        "okh_role": "design",
+        "parent": "eda",
+        "render_tier": "download_only"
+      },
+      {
+        "canonical_id": "eda_schematic",
+        "display_name": "Schematic",
+        "extensions": [
+          ".brd",
+          ".sch"
+        ],
+        "mime_types": [],
+        "okh_role": "design",
+        "parent": "eda",
+        "render_tier": "download_only"
+      },
+      {
+        "canonical_id": "gcode",
+        "display_name": "G-code",
+        "extensions": [
+          ".bgcode",
+          ".cnc",
+          ".gcode",
+          ".nc",
+          ".ngc",
+          ".tap"
+        ],
+        "mime_types": [],
+        "okh_role": "manufacturing",
+        "parent": "manufacturing",
+        "render_tier": "text_viewer"
+      },
+      {
+        "canonical_id": "gerber",
+        "display_name": "Gerber",
+        "extensions": [
+          ".gbr",
+          ".ger"
+        ],
+        "mime_types": [],
+        "okh_role": "manufacturing",
+        "parent": "manufacturing",
+        "render_tier": "text_viewer"
+      },
+      {
+        "canonical_id": "image",
+        "display_name": "Image",
+        "extensions": [],
+        "mime_types": [],
+        "okh_role": "documentation",
+        "parent": null,
+        "render_tier": "native_inline"
+      },
+      {
+        "canonical_id": "image_raster",
+        "display_name": "Raster Image",
+        "extensions": [
+          ".bmp",
+          ".gif",
+          ".jpeg",
+          ".jpg",
+          ".png",
+          ".svg",
+          ".webp"
+        ],
+        "mime_types": [
+          "image/bmp",
+          "image/gif",
+          "image/jpeg",
+          "image/png",
+          "image/svg+xml",
+          "image/webp"
+        ],
+        "okh_role": "documentation",
+        "parent": "image",
+        "render_tier": "native_inline"
+      },
+      {
+        "canonical_id": "manufacturing",
+        "display_name": "Manufacturing",
+        "extensions": [],
+        "mime_types": [],
+        "okh_role": "manufacturing",
+        "parent": null,
+        "render_tier": "download_only"
+      },
+      {
+        "canonical_id": "mesh_3d",
+        "display_name": "3D Mesh",
+        "extensions": [],
+        "mime_types": [],
+        "okh_role": "grey_zone",
+        "parent": null,
+        "render_tier": "wasm_3d"
+      },
+      {
+        "canonical_id": "mesh_3mf",
+        "display_name": "3MF",
+        "extensions": [
+          ".3mf"
+        ],
+        "mime_types": [
+          "application/vnd.ms-package.3dmanufacturing-3dmodel+xml",
+          "model/3mf"
+        ],
+        "okh_role": "manufacturing",
+        "parent": "mesh_3d",
+        "render_tier": "download_only"
+      },
+      {
+        "canonical_id": "mesh_amf",
+        "display_name": "AMF",
+        "extensions": [
+          ".amf"
+        ],
+        "mime_types": [],
+        "okh_role": "manufacturing",
+        "parent": "mesh_3d",
+        "render_tier": "download_only"
+      },
+      {
+        "canonical_id": "mesh_obj",
+        "display_name": "OBJ Mesh",
+        "extensions": [
+          ".obj"
+        ],
+        "mime_types": [
+          "model/obj",
+          "text/plain"
+        ],
+        "okh_role": "grey_zone",
+        "parent": "mesh_3d",
+        "render_tier": "wasm_3d"
+      },
+      {
+        "canonical_id": "mesh_ply",
+        "display_name": "PLY Mesh",
+        "extensions": [
+          ".ply"
+        ],
+        "mime_types": [],
+        "okh_role": "grey_zone",
+        "parent": "mesh_3d",
+        "render_tier": "wasm_3d"
+      },
+      {
+        "canonical_id": "mesh_stl",
+        "display_name": "STL Mesh",
+        "extensions": [
+          ".stl"
+        ],
+        "mime_types": [
+          "application/sla",
+          "application/vnd.ms-pki.stl",
+          "model/stl"
+        ],
+        "okh_role": "grey_zone",
+        "parent": "mesh_3d",
+        "render_tier": "wasm_3d"
+      },
+      {
+        "canonical_id": "unknown",
+        "display_name": "Unknown",
+        "extensions": [],
+        "mime_types": [],
+        "okh_role": "documentation",
+        "parent": null,
+        "render_tier": "download_only"
+      }
+    ],
+    "source": "<repo>/src/config/taxonomy/file_types.yaml",
+    "total": 32
+  },
+  "message": "File type taxonomy retrieved successfully",
+  "metadata": {},
+  "request_id": "<volatile>",
+  "status": "success",
+  "timestamp": "<volatile>"
+}

--- a/tests/api/golden/file_types_validate.json
+++ b/tests/api/golden/file_types_validate.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "errors": [],
+    "source": "<repo>/src/config/taxonomy/file_types.yaml",
+    "total_file_types": 32,
+    "valid": true
+  },
+  "message": "File type taxonomy validation completed",
+  "metadata": {},
+  "request_id": "<volatile>",
+  "status": "success",
+  "timestamp": "<volatile>"
+}

--- a/tests/api/golden/utility_domains.json
+++ b/tests/api/golden/utility_domains.json
@@ -1,0 +1,36 @@
+{
+  "data": {
+    "default_domain": "manufacturing",
+    "domains": [
+      {
+        "description": "Domain for recipe and kitchen capability matching",
+        "id": "cooking",
+        "name": "Cooking & Food Preparation"
+      },
+      {
+        "description": "Domain for OKH/OKW manufacturing capability matching",
+        "id": "manufacturing",
+        "name": "Manufacturing & Hardware Production"
+      }
+    ],
+    "processing_time": "<volatile>",
+    "validation_results": [
+      {
+        "errors": [],
+        "is_valid": true,
+        "metadata": null,
+        "score": 1.0,
+        "suggestions": [],
+        "warnings": []
+      }
+    ]
+  },
+  "message": "Domains retrieved successfully",
+  "metadata": {
+    "processing_time": "<volatile>",
+    "timestamp": "<volatile>"
+  },
+  "request_id": "<volatile>",
+  "status": "success",
+  "timestamp": "<volatile>"
+}

--- a/tests/api/golden/utility_metrics.json
+++ b/tests/api/golden/utility_metrics.json
@@ -1,0 +1,52 @@
+{
+  "data": {
+    "active_requests": 0,
+    "cache": {
+      "backend": "memory",
+      "deletes": 0,
+      "enabled": true,
+      "hit_rate": 0.0,
+      "hits": 0,
+      "key_prefix": "ohm",
+      "max_size": 1000,
+      "misses": 1,
+      "sets": 1,
+      "size": 1
+    },
+    "endpoints_tracked": 0,
+    "error_summary": {
+      "category_breakdown": {},
+      "component_errors": {},
+      "error_counts": {},
+      "error_rates": {},
+      "recent_errors": [],
+      "severity_breakdown": {},
+      "total_errors": 0
+    },
+    "llm_summary": {
+      "model_stats": {},
+      "overview": {
+        "avg_cost_per_request": 0,
+        "total_cost": 0,
+        "total_requests": "<volatile>",
+        "total_tokens": 0
+      },
+      "provider_stats": {},
+      "recent_costs": [],
+      "recent_usage": []
+    },
+    "performance_summary": {
+      "operation_stats": {},
+      "recent_performance": [],
+      "resource_usage": {},
+      "throughput_stats": {}
+    },
+    "recent_requests_1h": "<volatile>",
+    "total_requests": "<volatile>"
+  },
+  "message": "Metrics retrieved successfully",
+  "metadata": {},
+  "request_id": "<volatile>",
+  "status": "success",
+  "timestamp": "<volatile>"
+}

--- a/tests/api/test_filetypes_utility_contract.py
+++ b/tests/api/test_filetypes_utility_contract.py
@@ -1,0 +1,116 @@
+"""Contract: file-type and utility payloads are frozen before they gain models.
+
+Same reasoning as the taxonomy contract, one router over: these returned bare
+``SuccessResponse`` values annotated ``-> Any``, so codegen emitted nothing and
+the frontend guessed. ``response_model`` filters, so the goldens are captured
+BEFORE the models and the models are correct exactly when they still pass.
+
+``/api/utility/domains`` is the route behind #369: the frontend bound a
+selector to the display name because nothing told it there was an ``id``.
+
+``/api/utility/metrics`` is captured here but deliberately carries no response
+model: it returns four different shapes depending on its parameters — a
+Prometheus text body, per-endpoint metrics, a summary, or a detailed breakdown
+— and one model would filter three of them into nonsense. Freezing it anyway is
+worth it: the capture is what a later change splitting the route would be
+written against, and until then this notices if its shape moves.
+
+To change a contract deliberately:
+    BLESS_FILETYPES_UTILITY_CONTRACT=1 .venv/bin/python -m pytest \
+        tests/api/test_filetypes_utility_contract.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+GOLDEN_DIR = Path(__file__).parent / "golden"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+ROUTES = [
+    ("/v1/api/file-types", "file_types_index"),
+    ("/v1/api/file-types/validate", "file_types_validate"),
+    ("/v1/api/utility/domains", "utility_domains"),
+    ("/v1/api/utility/metrics", "utility_metrics"),
+]
+
+#: Counters and clocks that move between two calls in the same run. Frozen so
+#: the test fails on a contract change rather than on the passage of time.
+VOLATILE_KEYS = {
+    "timestamp",
+    "request_id",
+    "uptime_seconds",
+    "total_requests",
+    "recent_requests_1h",
+    "processing_time",
+    "memory_usage_mb",
+    "cpu_percent",
+}
+
+
+async def _app() -> FastAPI:
+    """The mounted app, with domains registered as startup would.
+
+    Without this the registry is empty and /domains returns `domains: []` —
+    a golden that pins the envelope and says nothing about the item shape,
+    which is the half most worth freezing. The frontend bug in #369 was in an
+    item field.
+    """
+    from src.core.main import api_v1, register_domain_components
+
+    await register_domain_components()
+    app = FastAPI()
+    app.mount("/v1", api_v1)
+    return app
+
+
+def _freeze(node):
+    """Replace values that legitimately differ run to run, at any depth."""
+    if isinstance(node, dict):
+        return {
+            k: ("<volatile>" if k in VOLATILE_KEYS else _freeze(v))
+            for k, v in node.items()
+        }
+    if isinstance(node, list):
+        return [_freeze(v) for v in node]
+    return node
+
+
+def _normalise(payload: dict) -> dict:
+    text = re.sub(re.escape(str(REPO_ROOT)), "<repo>", json.dumps(payload))
+    return _freeze(json.loads(text))
+
+
+@pytest.mark.asyncio
+@pytest.mark.contract
+@pytest.mark.parametrize("path,name", ROUTES)
+async def test_payload_is_field_identical_to_the_golden(path, name):
+    app = await _app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(path)
+
+    assert response.status_code == 200, response.text
+    body = _normalise(response.json())
+
+    golden = GOLDEN_DIR / f"{name}.json"
+    if os.getenv("BLESS_FILETYPES_UTILITY_CONTRACT"):
+        GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
+        golden.write_text(json.dumps(body, indent=2, sort_keys=True) + "\n")
+        pytest.skip(f"golden re-blessed: {golden.name}")
+
+    assert golden.exists(), (
+        f"No golden at {golden}. Capture one with "
+        "BLESS_FILETYPES_UTILITY_CONTRACT=1 BEFORE adding a response_model."
+    )
+    assert body == json.loads(golden.read_text()), (
+        f"GET {path} changed shape. If a response_model was just added, it is "
+        "filtering a field the route used to return."
+    )

--- a/tests/parity/test_response_models.py
+++ b/tests/parity/test_response_models.py
@@ -39,8 +39,6 @@ ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
     {
         ("DELETE", "/api/asset/{id}"),
         ("POST", "/api/convert/to-datasheet"),
-        ("GET", "/api/file-types"),
-        ("GET", "/api/file-types/validate"),
         ("GET", "/api/identity/security-policy"),
         ("POST", "/api/match"),
         ("POST", "/api/match/facility"),
@@ -66,7 +64,11 @@ ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
         ("GET", "/api/supply-tree/solution/{solution_id}/staleness"),
         ("GET", "/api/supply-tree/solution/{solution_id}/visualization"),
         ("GET", "/api/supply-tree/solutions"),
-        ("GET", "/api/utility/domains"),
+        # Cannot be typed as one model: /metrics returns four different shapes
+        # depending on its parameters — a Prometheus text body, per-endpoint
+        # metrics, a summary, or a detailed breakdown. A single response_model
+        # would filter three of them into nonsense. Splitting the route is the
+        # real fix, and is not this change.
         ("GET", "/api/utility/metrics"),
     }
 )


### PR DESCRIPTION
Second router group of #373. Three operations typed, one recorded as untypable with its reason.

> **Note on stacking:** branched from `main` alongside #398 rather than on top of it, to avoid the orphaned-base problem #385 hit. The two touch the same allowlist file and the generated schema, so whichever merges second needs a trivial rebase.

## Goldens first

Captured from the routes **before** the models existed, passing against them unmodelled, then unchanged once the models landed. Confirmed the lock bites by deleting `mime_types` from a model and watching the golden fail.

## `/api/utility/metrics` keeps its allowlist row

It returns **four different shapes** depending on its parameters — a Prometheus text body, per-endpoint metrics, a summary, or a detailed breakdown. A single `response_model` would filter three of them into nonsense. Splitting the route is the real fix and is not this change.

Its payload is frozen anyway: the capture is what that later change would be written against, and until then the contract test notices if the shape moves. This is the allowlist doing its job, not a gap in it.

## Capturing `/domains` needed the registry

Without running what startup runs, the route answers `domains: []` — a golden of an empty list pins the envelope and says nothing about the item shape, which is the half worth freezing given #369's bug was in an item field.

## Two things found in passing

**`models/utility/response.py` already declared a `DomainsResponse` that does not describe this route.** It puts `domains`/`default_domain` at the *top* level; the route nests them under `data`. Nothing uses it, and attaching it as a `response_model` would have filtered the real payload away. Left in place with a warning docstring pointing at the model that does match — `/contexts` lives in the same file and is not in this change's scope.

**Nullable fields first got Python defaults, which made them optional in the schema.** The generated type said `string | null | undefined` and the frontend stopped compiling. All 32 file-type items carry all seven keys, so they are *required but nullable*; dropping the defaults produced `string | null` and the call sites needed no changes.

## Clients

Both drop their hand-written interfaces and defensive unwrapping for generated types — **net 31 lines lighter**. `file-types.ts` carried a docstring explaining that its shapes were declared locally *because* the schema typed `data` as an open record; that is no longer true, so it now says what is.

## Verification

`make ready`: 14/14. `frontend-ready`: all stages — 735 unit, 237 e2e.

Refs #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qew1kZog2JA8AKCgLxzn5X
