### PR TITLE
Response models for the OKW template and network surface (#373, 3 of N)

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 652
+Total Python files: 653
 
 ├── deploy/
 │   ├── __init__.py
@@ -728,6 +728,9 @@ Total Python files: 652
 │       │   │   │           class OKWListResponse
 │       │   │   │           class OKWUploadResponse
 │       │   │   │           class OKWExportResponse
+│       │   │   │           class NetworkSpace
+│       │   │   │           class NetworkSpacesResponse
+│       │   │   │           class OKWTemplateResponse
 │       │   │   ├── package/
 │       │   │   │   ├── request.py
 │       │   │   │   │       class PackageBuildRequest
@@ -1999,6 +2002,7 @@ Total Python files: 652
     │   │       def _get_app()
     │   ├── test_filetypes_utility_contract.py
     │   │       def _freeze()
+    │   │       def _structure()
     │   │       def _normalise()
     │   ├── test_identity_routes.py
     │   │       def _get_app()
@@ -2327,6 +2331,11 @@ Total Python files: 652
     │   │       def _classify()
     │   │       def test_matching_ab_report_remote_okw()
     │   ├── test_matching_baseline.py
+    │   ├── test_okw_contract.py
+    │   │       def _shape()
+    │   │       def _check()
+    │   │       def test_template_payload_is_field_identical_to_the_golden()
+    │   │       def test_spaces_payload_keeps_every_field_it_declares()
     │   ├── test_okw_spaces_route.py
     │   │       def test_spaces_local_only_returns_unified_shape()
     │   │       def test_spaces_source_filter_excludes_local()
@@ -3454,7 +3463,7 @@ Total Python files: 652
 
 ## Overview
 
-Total files analyzed: 652
+Total files analyzed: 653
 
 ## Entry Points
 
@@ -4474,6 +4483,14 @@ This module provides Pydantic models for LLM API responses....
   - Response model for OKW file upload...
 - `OKWExportResponse` (inherits: BaseModel)
   - Response model for OKW schema export...
+- `NetworkSpace` (inherits: BaseModel)
+  - One space on the unified network surface — a local OKW facility or a
+Maps of Mak...
+- `NetworkSpacesResponse` (inherits: BaseModel)
+  - GET /api/okw/spaces. Not the SuccessResponse envelope — this route
+returns its p...
+- `OKWTemplateResponse` (inherits: BaseModel)
+  - GET /api/okw/template — a blank facility for a client to fill in....
 
 ### `src/core/api/models/package/request.py`
 
@@ -10931,6 +10948,17 @@ Requires:
 Uses a minima...
 
 **Internal Dependencies:** 4 imports
+
+### `tests/integration/test_okw_contract.py`
+> Contract: the OKW template and network-surface payloads, frozen before models.
+
+Lives here rather th...
+
+**Exports:** test_template_payload_is_field_identical_to_the_golden, test_spaces_payload_keeps_every_field_it_declares
+
+**Functions:**
+- `test_template_payload_is_field_identical_to_the_golden(client)`
+- `test_spaces_payload_keeps_every_field_it_declares(client)`
 
 ### `tests/integration/test_okw_spaces_route.py`
 > Integration test for GET /api/okw/spaces (unified network surface, #230).

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -6394,6 +6394,72 @@ export interface components {
             } | null;
         };
         /**
+         * NetworkSpace
+         * @description One space on the unified network surface — a local OKW facility or a
+         *     Maps of Making entry, projected to a common shape and source-labelled.
+         *
+         *     Every optional field here is required-but-nullable: the projection always
+         *     emits the key and may set it to null (a facility with no coordinates, an
+         *     owner with no website). Giving these defaults would mark them optional in
+         *     the schema, and clients would then handle an `undefined` the route never
+         *     sends.
+         *
+         *     Derived from the payload captured in
+         *     ``tests/api/golden/okw_spaces_shape.json`` before this model existed.
+         */
+        NetworkSpace: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Lat */
+            lat: number | null;
+            /** Lon */
+            lon: number | null;
+            /** City */
+            city: string | null;
+            /** Region */
+            region: string | null;
+            /** Country */
+            country: string | null;
+            /**
+             * Source
+             * @enum {string}
+             */
+            source: "local" | "mom";
+            /** Status */
+            status: string | null;
+            /** Processes */
+            processes: string[];
+            /** Access Type */
+            access_type: string | null;
+            /** Url */
+            url: string | null;
+            /** Ambiguous */
+            ambiguous: boolean;
+        };
+        /**
+         * NetworkSpacesResponse
+         * @description GET /api/okw/spaces. Not the SuccessResponse envelope — this route
+         *     returns its payload at the top level.
+         */
+        NetworkSpacesResponse: {
+            /** Success */
+            success: boolean;
+            /** Spaces */
+            spaces: components["schemas"]["NetworkSpace"][];
+            /** Total */
+            total: number;
+            /** Local Count */
+            local_count: number;
+            /** Mom Count */
+            mom_count: number;
+            /** Dropped No Coords */
+            dropped_no_coords: number;
+            /** Mom Available */
+            mom_available: boolean;
+        };
+        /**
          * OAuthBindRequest
          * @description Record an OAuth/OIDC external-subject binding (post-IdP verification).
          *
@@ -7482,6 +7548,20 @@ export interface components {
             processing_time: number;
             /** Validation Results */
             validation_results?: components["schemas"]["ValidationResult"][] | null;
+        };
+        /**
+         * OKWTemplateResponse
+         * @description GET /api/okw/template — a blank facility for a client to fill in.
+         */
+        OKWTemplateResponse: {
+            /** Success */
+            success: boolean;
+            /** Template */
+            template: {
+                [key: string]: unknown;
+            };
+            /** Model Name */
+            model_name: string;
         };
         /**
          * OKWUpdateRequest
@@ -12403,7 +12483,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["OKWTemplateResponse"];
                 };
             };
             /** @description Bad Request */
@@ -12463,7 +12543,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["NetworkSpacesResponse"];
                 };
             };
             /** @description Bad Request */

--- a/frontend/src/api/ohm/network.ts
+++ b/frontend/src/api/ohm/network.ts
@@ -1,30 +1,30 @@
 import { apiBaseUrl, ApiError, errorMessage } from "./client";
+import type { components } from "../generated/schema";
 
-/** A space on the unified network surface (local OKW facility or MoM space). */
-export interface NetworkSpace {
-  id: string;
-  name: string;
-  lat: number;
-  lon: number;
-  source: "local" | "mom";
-  city: string | null;
-  region: string | null;
-  country: string | null;
-  status: string | null;
-  processes: string[]; // canonical OHM process ids
-  access_type: string | null;
-  url: string | null;
-  /** True when kept despite a local-only filter it can't express (sorted last). */
-  ambiguous?: boolean;
-}
+/**
+ * A space on the unified network surface (local OKW facility or MoM space).
+ *
+ * From the route's response model (#373). `lat`/`lon` are nullable there and
+ * were `number` here: local facilities without coordinates are dropped before
+ * the response (counted as `dropped_no_coords`), but MoM spaces are not
+ * filtered that way, so a null can arrive. `plottable` below is where that is
+ * dealt with once, rather than at each map call site.
+ */
+export type NetworkSpace = components["schemas"]["NetworkSpace"];
 
-export interface NetworkData {
-  spaces: NetworkSpace[];
-  total: number;
-  local_count: number;
-  mom_count: number;
-  dropped_no_coords: number;
-  mom_available: boolean;
+/** A space the map can actually place: coordinates present. */
+export type PlottableSpace = NetworkSpace & { lat: number; lon: number };
+
+export type NetworkData = Omit<
+  components["schemas"]["NetworkSpacesResponse"],
+  "success" | "spaces"
+> & { spaces: PlottableSpace[] };
+
+/** Spaces with coordinates. A space that cannot be placed is not a map pin. */
+export function plottable(spaces: NetworkSpace[]): PlottableSpace[] {
+  return spaces.filter(
+    (s): s is PlottableSpace => typeof s.lat === "number" && typeof s.lon === "number",
+  );
 }
 
 export interface NetworkFilters {
@@ -77,10 +77,13 @@ export async function fetchNetworkSpaces(
       ),
     );
   }
-  const d = (body ?? {}) as Partial<NetworkData>;
+  const d = (body ?? {}) as Partial<
+    components["schemas"]["NetworkSpacesResponse"]
+  >;
+  const spaces = plottable(d.spaces ?? []);
   return {
-    spaces: (d.spaces ?? []) as NetworkSpace[],
-    total: d.total ?? d.spaces?.length ?? 0,
+    spaces,
+    total: d.total ?? spaces.length,
     local_count: d.local_count ?? 0,
     mom_count: d.mom_count ?? 0,
     dropped_no_coords: d.dropped_no_coords ?? 0,

--- a/frontend/src/features/dashboard/networkStats.test.ts
+++ b/frontend/src/features/dashboard/networkStats.test.ts
@@ -19,6 +19,7 @@ function space(overrides: Partial<NetworkSpace> = {}): NetworkSpace {
     status: null,
     processes: [],
     access_type: null,
+    ambiguous: false,
     url: null,
     ...overrides,
   };

--- a/frontend/src/features/match/MatchView.nearMissTolerance.test.tsx
+++ b/frontend/src/features/match/MatchView.nearMissTolerance.test.tsx
@@ -48,6 +48,7 @@ const seededNetwork: NetworkData = {
       processes: [],
       access_type: null,
       url: null,
+      ambiguous: false,
     },
   ],
   total: 1,

--- a/frontend/src/features/match/MatchView.sharedCache.test.tsx
+++ b/frontend/src/features/match/MatchView.sharedCache.test.tsx
@@ -31,6 +31,7 @@ const seededNetwork: NetworkData = {
       processes: [],
       access_type: null,
       url: null,
+      ambiguous: false,
     },
   ],
   total: 1,

--- a/frontend/src/features/network/MapSpacesSheet.test.tsx
+++ b/frontend/src/features/network/MapSpacesSheet.test.tsx
@@ -17,6 +17,7 @@ function space(overrides: Partial<NetworkSpace>): NetworkSpace {
     status: null,
     access_type: null,
     url: "https://example.org",
+    ambiguous: false,
     processes: [],
     ...overrides,
   };

--- a/frontend/src/features/network/NetworkMap.tsx
+++ b/frontend/src/features/network/NetworkMap.tsx
@@ -12,7 +12,7 @@ import "leaflet.markercluster";
 import "leaflet.markercluster/dist/MarkerCluster.css";
 import "leaflet.markercluster/dist/MarkerCluster.Default.css";
 import "./networkMap.css";
-import type { NetworkSpace } from "../../api/ohm/network";
+import type { NetworkSpace, PlottableSpace } from "../../api/ohm/network";
 import { SOURCE_STYLES, sourceVar } from "./networkSummary";
 import { useSourceColors } from "./useSourceColors";
 import { denseBounds, fillZoom, fitPadding } from "./mapFraming";
@@ -172,7 +172,7 @@ function popupContent(space: NetworkSpace): HTMLElement {
  * plugin underneath react-leaflet-cluster), same icons, no React in the
  * per-space path.
  */
-function SpaceMarkers({ spaces }: { spaces: NetworkSpace[] }) {
+function SpaceMarkers({ spaces }: { spaces: PlottableSpace[] }) {
   const map = useMap();
 
   // Built when the data changes and at no other time. This used to depend on
@@ -213,7 +213,7 @@ function SpaceMarkers({ spaces }: { spaces: NetworkSpace[] }) {
 }
 
 /** Fit the viewport to the loaded spaces whenever the set changes. */
-function FitBounds({ spaces }: { spaces: NetworkSpace[] }) {
+function FitBounds({ spaces }: { spaces: PlottableSpace[] }) {
   const map = useMap();
   useEffect(() => {
     if (spaces.length === 0) return;
@@ -274,8 +274,8 @@ function ViewportReport({
   spaces,
   onChange,
 }: {
-  spaces: NetworkSpace[];
-  onChange: (visible: NetworkSpace[]) => void;
+  spaces: PlottableSpace[];
+  onChange: (visible: PlottableSpace[]) => void;
 }) {
   const map = useMap();
   useEffect(() => {
@@ -370,9 +370,11 @@ function useTransientFlag(ms: number): [boolean, () => void] {
 }
 
 interface NetworkMapProps {
-  spaces: NetworkSpace[];
+  /** Plottable only: fetchNetworkSpaces filters out anything without coordinates. */
+  spaces: PlottableSpace[];
   /** Called with the spaces inside the viewport each time it settles. */
-  onVisibleChange?: (visible: NetworkSpace[]) => void;
+  /** Reports what it plotted, so callers get the narrowed type back. */
+  onVisibleChange?: (visible: PlottableSpace[]) => void;
   /** Called on each gesture at the map — not on the initial fit. */
   onInteract?: () => void;
 }

--- a/frontend/src/features/network/NetworkView.map.test.tsx
+++ b/frontend/src/features/network/NetworkView.map.test.tsx
@@ -54,6 +54,7 @@ function space(overrides: Partial<NetworkSpace>): NetworkSpace {
     status: null,
     access_type: null,
     url: null,
+    ambiguous: false,
     processes: [],
     ...overrides,
   };

--- a/frontend/src/features/network/deriveFilterOptions.test.ts
+++ b/frontend/src/features/network/deriveFilterOptions.test.ts
@@ -5,7 +5,8 @@ import type { NetworkSpace } from "../../api/ohm/network";
 function space(p: Partial<NetworkSpace>): NetworkSpace {
   return {
     id: "x", name: "X", lat: 0, lon: 0, source: "local", city: null, region: null,
-    country: null, status: null, processes: [], access_type: null, url: null, ...p,
+    country: null, status: null, processes: [], access_type: null, url: null,
+    ambiguous: false, ...p,
   };
 }
 

--- a/src/core/api/models/okw/response.py
+++ b/src/core/api/models/okw/response.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
@@ -123,3 +123,62 @@ class OKWExportResponse(BaseModel):
 
     schema_version: Optional[str] = "http://json-schema.org/draft-07/schema#"
     model_name: Optional[str] = "ManufacturingFacility"
+
+
+class NetworkSpace(BaseModel):
+    """One space on the unified network surface — a local OKW facility or a
+    Maps of Making entry, projected to a common shape and source-labelled.
+
+    Every optional field here is required-but-nullable: the projection always
+    emits the key and may set it to null (a facility with no coordinates, an
+    owner with no website). Giving these defaults would mark them optional in
+    the schema, and clients would then handle an `undefined` the route never
+    sends.
+
+    Derived from the payload captured in
+    ``tests/api/golden/okw_spaces_shape.json`` before this model existed.
+    """
+
+    id: str
+    name: str
+    lat: Optional[float]
+    lon: Optional[float]
+    city: Optional[str]
+    region: Optional[str]
+    country: Optional[str]
+    #: "local" (an OKW facility on this node) or "mom" (Maps of Making). The
+    #: projection sets these literally, and the UI keys colour and labels off
+    #: them, so the union is part of the contract rather than an implementation
+    #: detail.
+    source: Literal["local", "mom"]
+    status: Optional[str]
+    processes: List[str]
+    access_type: Optional[str]
+    url: Optional[str]
+    #: Set when the country could not be resolved unambiguously; these sort last.
+    ambiguous: bool
+
+
+class NetworkSpacesResponse(BaseModel):
+    """GET /api/okw/spaces. Not the SuccessResponse envelope — this route
+    returns its payload at the top level."""
+
+    success: bool
+    spaces: List[NetworkSpace]
+    total: int
+    local_count: int
+    mom_count: int
+    dropped_no_coords: int
+    #: False when the Maps of Making fetch failed or was not requested; the
+    #: surface degrades to local-only rather than erroring.
+    mom_available: bool
+
+
+class OKWTemplateResponse(BaseModel):
+    """GET /api/okw/template — a blank facility for a client to fill in."""
+
+    success: bool
+    #: The blank facility itself. Free-form on purpose: it mirrors the OKW
+    #: model, and a strict copy here would filter whatever that model grows.
+    template: Dict[str, Any]
+    model_name: str

--- a/src/core/api/routes/okw.py
+++ b/src/core/api/routes/okw.py
@@ -66,10 +66,12 @@ from ..models.base import (
 from ..models.okw.request import OKWExtractRequest, OKWUpdateRequest, OKWValidateRequest
 from ..models.okw.response import (
     Capability,
+    NetworkSpacesResponse,
     OKWExportResponse,
     OKWExtractResponse,
     OKWListResponse,
     OKWResponse,
+    OKWTemplateResponse,
     OKWUploadResponse,
 )
 
@@ -398,6 +400,7 @@ async def export_okw_schema(http_request: Request = None) -> Any:
 
 @router.get(
     "/template",
+    response_model=OKWTemplateResponse,
     summary="Get blank OKW facility template",
     description="""
     Return a blank OKW facility template as a JSON object.
@@ -420,6 +423,7 @@ async def get_okw_template(http_request: Request = None) -> Any:
 
 @router.get(
     "/spaces",
+    response_model=NetworkSpacesResponse,
     summary="Unified network surface (local OKW ∪ Maps of Making), server-filtered",
     description="""
     Return the unified network surface for the map + list views: local OKW

--- a/tests/api/golden/okw_spaces_shape.json
+++ b/tests/api/golden/okw_spaces_shape.json
@@ -1,0 +1,27 @@
+{
+  "dropped_no_coords": "*",
+  "local_count": "*",
+  "mom_available": "*",
+  "mom_count": "*",
+  "spaces": [
+    {
+      "access_type": "*",
+      "ambiguous": "*",
+      "city": "*",
+      "country": "*",
+      "id": "*",
+      "lat": "*",
+      "lon": "*",
+      "name": "*",
+      "processes": [
+        "*"
+      ],
+      "region": "*",
+      "source": "*",
+      "status": "*",
+      "url": "*"
+    }
+  ],
+  "success": "*",
+  "total": "*"
+}

--- a/tests/api/golden/okw_template.json
+++ b/tests/api/golden/okw_template.json
@@ -1,0 +1,513 @@
+{
+  "model_name": "ManufacturingFacility",
+  "success": true,
+  "template": {
+    "access_type": "Restricted",
+    "affiliations": [
+      {
+        "bio": null,
+        "contact": {
+          "email": null,
+          "fax": null,
+          "landline": null,
+          "mobile": null,
+          "whatsapp": null
+        },
+        "contact_person": null,
+        "images": [],
+        "languages": [],
+        "location": {
+          "address": {
+            "city": null,
+            "country": null,
+            "district": null,
+            "number": null,
+            "postcode": null,
+            "region": null,
+            "street": null
+          },
+          "city": null,
+          "country": null,
+          "directions": null,
+          "gps_coordinates": null,
+          "region": null,
+          "what3words": {
+            "language": "",
+            "words": ""
+          }
+        },
+        "mailing_list": null,
+        "name": "",
+        "social_media": {
+          "facebook": null,
+          "instagram": null,
+          "other_urls": [],
+          "twitter": null
+        },
+        "website": null
+      }
+    ],
+    "backup_generator": null,
+    "certifications": [],
+    "circular_economy": {
+      "applies_principles": false,
+      "by_products": [],
+      "description": null
+    },
+    "contact": {
+      "bio": null,
+      "contact": {
+        "email": null,
+        "fax": null,
+        "landline": null,
+        "mobile": null,
+        "whatsapp": null
+      },
+      "contact_person": null,
+      "images": [],
+      "languages": [],
+      "location": {
+        "address": {
+          "city": null,
+          "country": null,
+          "district": null,
+          "number": null,
+          "postcode": null,
+          "region": null,
+          "street": null
+        },
+        "city": null,
+        "country": null,
+        "directions": null,
+        "gps_coordinates": null,
+        "region": null,
+        "what3words": {
+          "language": "",
+          "words": ""
+        }
+      },
+      "mailing_list": null,
+      "name": "",
+      "social_media": {
+        "facebook": null,
+        "instagram": null,
+        "other_urls": [],
+        "twitter": null
+      },
+      "website": null
+    },
+    "customer_reviews": [],
+    "date_founded": null,
+    "description": null,
+    "domain": null,
+    "equipment": [
+      {
+        "additional_properties": {},
+        "axes": null,
+        "bed_size": null,
+        "build_volume": null,
+        "computer_controlled": false,
+        "condition": null,
+        "current_firmware": null,
+        "equipment_type": "",
+        "extraction_system": false,
+        "laser_power": null,
+        "location": {
+          "address": {
+            "city": null,
+            "country": null,
+            "district": null,
+            "number": null,
+            "postcode": null,
+            "region": null,
+            "street": null
+          },
+          "city": null,
+          "country": null,
+          "directions": null,
+          "gps_coordinates": null,
+          "region": null,
+          "what3words": {
+            "language": "",
+            "words": ""
+          }
+        },
+        "maintenance_schedule": null,
+        "make": null,
+        "manufacturing_process": "",
+        "materials_worked": [
+          {
+            "brand": null,
+            "manufacturer": null,
+            "material_type": "",
+            "supplier_location": {
+              "address": {
+                "city": null,
+                "country": null,
+                "district": null,
+                "number": null,
+                "postcode": null,
+                "region": null,
+                "street": null
+              },
+              "city": null,
+              "country": null,
+              "directions": null,
+              "gps_coordinates": null,
+              "region": null,
+              "what3words": {
+                "language": "",
+                "words": ""
+              }
+            }
+          }
+        ],
+        "model": null,
+        "notes": null,
+        "nozzle_size": null,
+        "owner": {
+          "bio": null,
+          "contact": {
+            "email": null,
+            "fax": null,
+            "landline": null,
+            "mobile": null,
+            "whatsapp": null
+          },
+          "contact_person": null,
+          "images": [],
+          "languages": [],
+          "location": {
+            "address": {
+              "city": null,
+              "country": null,
+              "district": null,
+              "number": null,
+              "postcode": null,
+              "region": null,
+              "street": null
+            },
+            "city": null,
+            "country": null,
+            "directions": null,
+            "gps_coordinates": null,
+            "region": null,
+            "what3words": {
+              "language": "",
+              "words": ""
+            }
+          },
+          "mailing_list": null,
+          "name": "",
+          "social_media": {
+            "facebook": null,
+            "instagram": null,
+            "other_urls": [],
+            "twitter": null
+          },
+          "website": null
+        },
+        "power_rating": null,
+        "quantity": null,
+        "serial_number": null,
+        "throughput": null,
+        "tolerance_class": null,
+        "uninterrupted_power_supply": false,
+        "usage_levels": null,
+        "working_surface": null,
+        "x_travel": null,
+        "y_travel": null,
+        "z_travel": null
+      }
+    ],
+    "facility_status": "Active",
+    "floor_size": null,
+    "human_capacity": {
+      "headcount": null
+    },
+    "id": "",
+    "innovation_space": {
+      "footfall": null,
+      "learning_resources": [],
+      "residencies": false,
+      "services": [],
+      "staff": null
+    },
+    "loading_dock": null,
+    "location": {
+      "address": {
+        "city": null,
+        "country": null,
+        "district": null,
+        "number": null,
+        "postcode": null,
+        "region": null,
+        "street": null
+      },
+      "city": null,
+      "country": null,
+      "directions": null,
+      "gps_coordinates": null,
+      "region": null,
+      "what3words": {
+        "language": "",
+        "words": ""
+      }
+    },
+    "maintenance_schedule": null,
+    "manufacturing_processes": [],
+    "name": "",
+    "opening_hours": null,
+    "owner": {
+      "bio": null,
+      "contact": {
+        "email": null,
+        "fax": null,
+        "landline": null,
+        "mobile": null,
+        "whatsapp": null
+      },
+      "contact_person": null,
+      "images": [],
+      "languages": [],
+      "location": {
+        "address": {
+          "city": null,
+          "country": null,
+          "district": null,
+          "number": null,
+          "postcode": null,
+          "region": null,
+          "street": null
+        },
+        "city": null,
+        "country": null,
+        "directions": null,
+        "gps_coordinates": null,
+        "region": null,
+        "what3words": {
+          "language": "",
+          "words": ""
+        }
+      },
+      "mailing_list": null,
+      "name": "",
+      "social_media": {
+        "facebook": null,
+        "instagram": null,
+        "other_urls": [],
+        "twitter": null
+      },
+      "website": null
+    },
+    "partners_funders": [
+      {
+        "bio": null,
+        "contact": {
+          "email": null,
+          "fax": null,
+          "landline": null,
+          "mobile": null,
+          "whatsapp": null
+        },
+        "contact_person": null,
+        "images": [],
+        "languages": [],
+        "location": {
+          "address": {
+            "city": null,
+            "country": null,
+            "district": null,
+            "number": null,
+            "postcode": null,
+            "region": null,
+            "street": null
+          },
+          "city": null,
+          "country": null,
+          "directions": null,
+          "gps_coordinates": null,
+          "region": null,
+          "what3words": {
+            "language": "",
+            "words": ""
+          }
+        },
+        "mailing_list": null,
+        "name": "",
+        "social_media": {
+          "facebook": null,
+          "instagram": null,
+          "other_urls": [],
+          "twitter": null
+        },
+        "website": null
+      }
+    ],
+    "record_data": {
+      "created_by": {
+        "bio": null,
+        "contact": {
+          "email": null,
+          "fax": null,
+          "landline": null,
+          "mobile": null,
+          "whatsapp": null
+        },
+        "contact_person": null,
+        "images": [],
+        "languages": [],
+        "location": {
+          "address": {
+            "city": null,
+            "country": null,
+            "district": null,
+            "number": null,
+            "postcode": null,
+            "region": null,
+            "street": null
+          },
+          "city": null,
+          "country": null,
+          "directions": null,
+          "gps_coordinates": null,
+          "region": null,
+          "what3words": {
+            "language": "",
+            "words": ""
+          }
+        },
+        "mailing_list": null,
+        "name": "",
+        "social_media": {
+          "facebook": null,
+          "instagram": null,
+          "other_urls": [],
+          "twitter": null
+        },
+        "website": null
+      },
+      "data_collection_method": null,
+      "date_created": "",
+      "date_verified": null,
+      "last_updated": null,
+      "updated_by": {
+        "bio": null,
+        "contact": {
+          "email": null,
+          "fax": null,
+          "landline": null,
+          "mobile": null,
+          "whatsapp": null
+        },
+        "contact_person": null,
+        "images": [],
+        "languages": [],
+        "location": {
+          "address": {
+            "city": null,
+            "country": null,
+            "district": null,
+            "number": null,
+            "postcode": null,
+            "region": null,
+            "street": null
+          },
+          "city": null,
+          "country": null,
+          "directions": null,
+          "gps_coordinates": null,
+          "region": null,
+          "what3words": {
+            "language": "",
+            "words": ""
+          }
+        },
+        "mailing_list": null,
+        "name": "",
+        "social_media": {
+          "facebook": null,
+          "instagram": null,
+          "other_urls": [],
+          "twitter": null
+        },
+        "website": null
+      },
+      "verified_by": {
+        "bio": null,
+        "contact": {
+          "email": null,
+          "fax": null,
+          "landline": null,
+          "mobile": null,
+          "whatsapp": null
+        },
+        "contact_person": null,
+        "images": [],
+        "languages": [],
+        "location": {
+          "address": {
+            "city": null,
+            "country": null,
+            "district": null,
+            "number": null,
+            "postcode": null,
+            "region": null,
+            "street": null
+          },
+          "city": null,
+          "country": null,
+          "directions": null,
+          "gps_coordinates": null,
+          "region": null,
+          "what3words": {
+            "language": "",
+            "words": ""
+          }
+        },
+        "mailing_list": null,
+        "name": "",
+        "social_media": {
+          "facebook": null,
+          "instagram": null,
+          "other_urls": [],
+          "twitter": null
+        },
+        "website": null
+      }
+    },
+    "road_access": null,
+    "storage_capacity": null,
+    "typical_batch_size": null,
+    "typical_materials": [
+      {
+        "brand": null,
+        "manufacturer": null,
+        "material_type": "",
+        "supplier_location": {
+          "address": {
+            "city": null,
+            "country": null,
+            "district": null,
+            "number": null,
+            "postcode": null,
+            "region": null,
+            "street": null
+          },
+          "city": null,
+          "country": null,
+          "directions": null,
+          "gps_coordinates": null,
+          "region": null,
+          "what3words": {
+            "language": "",
+            "words": ""
+          }
+        }
+      }
+    ],
+    "typical_products": [],
+    "uninterrupted_power_supply": null,
+    "wheelchair_accessibility": null
+  }
+}

--- a/tests/api/golden/utility_metrics.json
+++ b/tests/api/golden/utility_metrics.json
@@ -1,52 +1,8 @@
 {
-  "data": {
-    "active_requests": 0,
-    "cache": {
-      "backend": "memory",
-      "deletes": 0,
-      "enabled": true,
-      "hit_rate": 0.0,
-      "hits": 0,
-      "key_prefix": "ohm",
-      "max_size": 1000,
-      "misses": 1,
-      "sets": 1,
-      "size": 1
-    },
-    "endpoints_tracked": 0,
-    "error_summary": {
-      "category_breakdown": {},
-      "component_errors": {},
-      "error_counts": {},
-      "error_rates": {},
-      "recent_errors": [],
-      "severity_breakdown": {},
-      "total_errors": 0
-    },
-    "llm_summary": {
-      "model_stats": {},
-      "overview": {
-        "avg_cost_per_request": 0,
-        "total_cost": 0,
-        "total_requests": "<volatile>",
-        "total_tokens": 0
-      },
-      "provider_stats": {},
-      "recent_costs": [],
-      "recent_usage": []
-    },
-    "performance_summary": {
-      "operation_stats": {},
-      "recent_performance": [],
-      "resource_usage": {},
-      "throughput_stats": {}
-    },
-    "recent_requests_1h": "<volatile>",
-    "total_requests": "<volatile>"
-  },
-  "message": "Metrics retrieved successfully",
-  "metadata": {},
-  "request_id": "<volatile>",
-  "status": "success",
-  "timestamp": "<volatile>"
+  "data": "*",
+  "message": "*",
+  "metadata": "*",
+  "request_id": "*",
+  "status": "*",
+  "timestamp": "*"
 }

--- a/tests/api/test_filetypes_utility_contract.py
+++ b/tests/api/test_filetypes_utility_contract.py
@@ -8,8 +8,13 @@ BEFORE the models and the models are correct exactly when they still pass.
 ``/api/utility/domains`` is the route behind #369: the frontend bound a
 selector to the display name because nothing told it there was an ``id``.
 
-``/api/utility/metrics`` is captured here but deliberately carries no response
-model: it returns four different shapes depending on its parameters — a
+``/api/utility/metrics`` is frozen STRUCTURALLY rather than by value: it is a
+counter payload, and its nested cache stats (hits, misses, size) move with
+whatever else has run in the same session. Freezing those made the golden
+order-dependent — it passed alone and failed inside the full suite. Keys are
+what a response model can drop, so keys are what this freezes.
+
+``/api/utility/metrics`` also deliberately carries no response model: it returns four different shapes depending on its parameters — a
 Prometheus text body, per-endpoint metrics, a summary, or a detailed breakdown
 — and one model would filter three of them into nonsense. Freezing it anyway is
 worth it: the capture is what a later change splitting the route would be
@@ -83,9 +88,27 @@ def _freeze(node):
     return node
 
 
-def _normalise(payload: dict) -> dict:
+#: Routes whose values legitimately move between runs; only their keys are
+#: frozen. Everything else is compared exactly.
+SHAPE_ONLY = {"utility_metrics"}
+
+
+def _structure(node: dict) -> dict:
+    """The top-level key set, and nothing below it.
+
+    Deliberately shallow. The sub-payloads here are keyed by things that come
+    and go — error codes seen, endpoints touched, cache entries — so descending
+    would make the signature depend on what else ran, which is the flakiness
+    this is meant to remove. The top-level keys are what a response model could
+    drop, and they are what a client reads.
+    """
+    return {k: "*" for k in sorted(node)}
+
+
+def _normalise(payload: dict, name: str) -> dict:
     text = re.sub(re.escape(str(REPO_ROOT)), "<repo>", json.dumps(payload))
-    return _freeze(json.loads(text))
+    body = json.loads(text)
+    return _structure(body) if name in SHAPE_ONLY else _freeze(body)
 
 
 @pytest.mark.asyncio
@@ -98,7 +121,7 @@ async def test_payload_is_field_identical_to_the_golden(path, name):
         response = await client.get(path)
 
     assert response.status_code == 200, response.text
-    body = _normalise(response.json())
+    body = _normalise(response.json(), name)
 
     golden = GOLDEN_DIR / f"{name}.json"
     if os.getenv("BLESS_FILETYPES_UTILITY_CONTRACT"):

--- a/tests/integration/test_okw_contract.py
+++ b/tests/integration/test_okw_contract.py
@@ -1,0 +1,89 @@
+"""Contract: the OKW template and network-surface payloads, frozen before models.
+
+Lives here rather than in tests/api/ because it needs real data: /spaces is
+assembled from stored facilities, and a golden captured against an empty
+registry would pin the envelope while saying nothing about the item shape —
+which is the half a client actually maps over.
+
+Two different kinds of freeze, deliberately:
+
+* ``/template`` is deterministic, so its golden is the payload itself.
+* ``/spaces`` is not. The ``client`` fixture is session-scoped and other
+  integration tests create facilities in the same storage, so the list content
+  and the counts vary with test order. Freezing those would buy flakiness, not
+  safety. Its golden is therefore a SHAPE signature — every key, with values
+  replaced by their type — which still fails if a response_model drops a field,
+  because a dropped field disappears from the signature.
+
+To change a contract deliberately:
+    BLESS_OKW_CONTRACT=1 .venv/bin/python -m pytest \
+        tests/integration/test_okw_contract.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.record_fixtures import okw_facility_dict
+
+pytestmark = pytest.mark.integration
+
+GOLDEN_DIR = Path(__file__).resolve().parents[1] / "api" / "golden"
+
+
+def _shape(node):
+    """A value-free description: every key kept, every leaf reduced to a mark.
+
+    Lists collapse to the UNION of their item shapes, so N facilities and one
+    facility describe the same contract, and a key present on any record counts
+    as present.
+    """
+    if isinstance(node, dict):
+        return {k: _shape(v) for k, v in sorted(node.items())}
+    if isinstance(node, list):
+        merged: dict = {}
+        for item in node:
+            shaped = _shape(item)
+            if not isinstance(shaped, dict):
+                return ["*"]
+            for key, value in shaped.items():
+                merged.setdefault(key, value)
+        return [dict(sorted(merged.items()))] if merged else []
+    return "*"
+
+
+def _check(name: str, body) -> None:
+    golden = GOLDEN_DIR / f"{name}.json"
+    if os.getenv("BLESS_OKW_CONTRACT"):
+        GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
+        golden.write_text(json.dumps(body, indent=2, sort_keys=True) + "\n")
+        pytest.skip(f"golden re-blessed: {golden.name}")
+    assert golden.exists(), (
+        f"No golden at {golden}. Capture one with BLESS_OKW_CONTRACT=1 BEFORE "
+        "adding a response_model."
+    )
+    assert body == json.loads(golden.read_text()), (
+        f"{name} changed shape. If a response_model was just added, it is "
+        "filtering a field the route used to return."
+    )
+
+
+def test_template_payload_is_field_identical_to_the_golden(client):
+    response = client.get("/api/okw/template")
+    assert response.status_code == 200, response.text
+    _check("okw_template", response.json())
+
+
+def test_spaces_payload_keeps_every_field_it_declares(client):
+    created = client.post("/api/okw/create", json={"content": okw_facility_dict()})
+    assert created.status_code == 201, created.text
+
+    # include_mom=false keeps this offline: the MoM union is unit-tested, and a
+    # SPARQL call would make the contract depend on someone else's uptime.
+    response = client.get("/api/okw/spaces", params={"include_mom": "false"})
+    assert response.status_code == 200, response.text
+    _check("okw_spaces_shape", _shape(response.json()))

--- a/tests/parity/test_response_models.py
+++ b/tests/parity/test_response_models.py
@@ -46,8 +46,6 @@ ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
         ("GET", "/api/okh/export-collection"),
         ("POST", "/api/okh/import-collection"),
         ("GET", "/api/okh/template"),
-        ("GET", "/api/okw/spaces"),
-        ("GET", "/api/okw/template"),
         ("POST", "/api/package/build/{manifest_id}"),
         ("POST", "/api/package/download-zip"),
         ("GET", "/api/package/remote"),


### PR DESCRIPTION
Third router group of #373. **Two operations off the debt list: 28 → 26.**

Scoped to `okw` alone rather than `okw` + `match` as I first sketched: the two `POST /match` routes do real matching work needing seeded storage, and they deserve their own pass with proper fixtures rather than being tacked onto this one.

## Two freeze styles, and the difference is the point

`/template` is deterministic, so its golden is the payload itself.

`/spaces` is not. The integration `client` fixture is session-scoped and other tests create facilities in the same storage, so content and counts vary with test order. Its golden is a **structural signature** — every key, values reduced to a mark — which still fails when a `response_model` drops a field, because the key disappears.

Both styles verified by deleting a field and watching each fail.

## It exposed a defect in a golden already on main

`utility_metrics`, which I added in #399, froze nested cache counters (`hit_rate`, `misses`, `sets`, `size`) **by value**. It passed then only because of the order the suite happened to run in; adding one integration test changed the order and it failed.

Freezing its structure *recursively* was not enough either — its sub-dicts are keyed by things that come and go (error codes seen, endpoints touched). It now freezes the **top-level key set**, which is stable and is exactly what a `response_model` can drop. Verified stable both in the full suite and alone.

Worth carrying into the remaining routers: **a golden is only as good as its determinism.** Deterministic payload → freeze values. Counters or shared-fixture data → freeze keys. A weaker assertion that holds beats a strict one people learn to re-bless without reading.

## Typing `/spaces` found two mismatches the frontend was carrying

**`source`** was `str` on the server while the UI had narrowed it to `"local" | "mom"` and used it to index a colour lookup. The projection only ever emits those two, so the model now says so — tightening the API to what the UI already believed, rather than loosening the UI.

**`lat`/`lon` are genuinely nullable** and the frontend declared them `number`. Local facilities without coordinates are dropped (counted as `dropped_no_coords`), but the **MoM branch appends without that check**, so a null can reach the response. Rather than null-check at each map call site, `fetchNetworkSpaces` filters once and returns `PlottableSpace` — a space the map can actually place — and the map components say so in their types, including what they report back.

**`ambiguous`** was optional in the frontend and is always sent; five fixtures omitted it and were describing a payload that does not occur.

## A miss worth recording

I underestimated the blast radius. Eight `lat`/`lon` call sites looked contained; types propagate through props and fixtures, and it came to fifteen errors across nine files. The count was right and the inference from it was wrong.

## Verification

`make ready`: 14/14. `frontend-ready`: all stages — 746 unit, 237 e2e.

Refs #373. Remaining after this: match (2), okh (4), asset/convert/identity (3), supply-tree (6), package (10), plus `/metrics` recorded as untypable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qew1kZog2JA8AKCgLxzn5X
