### PR TITLE
Response model for reverse facility matching (#373, 4 of N)

### DIFF
--- a/.repo-map.md
+++ b/.repo-map.md
@@ -3,7 +3,7 @@ REPOSITORY MAP (Aider Style)
 ================================================================================
 Repository: supply-graph-ai
 
-Total Python files: 653
+Total Python files: 654
 
 ├── deploy/
 │   ├── __init__.py
@@ -685,6 +685,8 @@ Total Python files: 653
 │       │   │   │   │       class ValidationResult
 │       │   │   │   │       class SimulateResponse
 │       │   │   │   │       class SimulationResult
+│       │   │   │   │       class FacilityDesignsData
+│       │   │   │   │       class FacilityDesignsResponse
 │       │   │   │   └── suggestion_codes.py
 │       │   │   ├── okh/
 │       │   │   │   ├── request.py
@@ -2321,6 +2323,9 @@ Total Python files: 653
     │   │       def invalid_auth_headers()
     │   │       def require_auth()
     │   │       def cleanup_created_resources()
+    │   ├── test_match_facility_contract.py
+    │   │       def _structure()
+    │   │       def test_reverse_match_payload_keeps_every_field_it_declares()
     │   ├── test_matching_ab_report.py
     │   │       def _base_url()
     │   │       def _auth_headers()
@@ -3463,7 +3468,7 @@ Total Python files: 653
 
 ## Overview
 
-Total files analyzed: 653
+Total files analyzed: 654
 
 ## Entry Points
 
@@ -4382,6 +4387,11 @@ This module provides Pydantic models for LLM API responses....
   - Response model for simulation results...
 - `SimulationResult` (inherits: BaseModel)
   - Response model for simulation results...
+- `FacilityDesignsData` (inherits: BaseModel)
+  - The ``data`` payload of POST /api/match/facility — reverse matching.
+
+Derived fr...
+- `FacilityDesignsResponse` (inherits: SuccessResponse)
 
 ### `src/core/api/models/match/suggestion_codes.py`
 > Canonical suggestion codes for match API responses....
@@ -10927,6 +10937,16 @@ This test suite validates all major API end...
   - Get headers with invalid authentication...
 - `require_auth(auth_headers)`
   - Helper to skip test if authentication is not available...
+
+### `tests/integration/test_match_facility_contract.py`
+> Contract: POST /api/match/facility is shape-frozen before it gains a model.
+
+Reverse matching: given...
+
+**Exports:** test_reverse_match_payload_keeps_every_field_it_declares
+
+**Functions:**
+- `test_reverse_match_payload_keeps_every_field_it_declares(client)`
 
 ### `tests/integration/test_matching_ab_report.py`
 > Integration A/B report for matching behavior classification.

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -5331,6 +5331,78 @@ export interface components {
             additional_days: number;
         };
         /**
+         * FacilityDesignsData
+         * @description The ``data`` payload of POST /api/match/facility — reverse matching.
+         *
+         *     Derived from the payload captured in
+         *     ``tests/api/golden/match_facility_shape.json`` before this model existed.
+         *
+         *     ``designs`` is deliberately left free-form. The committed fixtures produce
+         *     no matches, so no golden of a populated list exists, and constraining the
+         *     item shape from reading the code would risk filtering a field never
+         *     observed on the wire — the exact failure this whole exercise exists to
+         *     prevent. The frontend narrows the item for its own use. Tighten this when
+         *     a fixture that actually matches exists, and freeze the item shape first.
+         */
+        FacilityDesignsData: {
+            /** Okw Id */
+            okw_id: string;
+            /** Facility Name */
+            facility_name: string | null;
+            /** Designs */
+            designs: {
+                [key: string]: unknown;
+            }[];
+            /** Total Designs */
+            total_designs: number;
+            /** Designs Considered */
+            designs_considered: number;
+            /** Processing Time */
+            processing_time: number;
+        };
+        /**
+         * FacilityDesignsResponse
+         * @example {
+         *       "data": {},
+         *       "message": "Operation completed successfully",
+         *       "metadata": {},
+         *       "request_id": "req_123456789",
+         *       "status": "success",
+         *       "timestamp": "2024-01-01T12:00:00Z"
+         *     }
+         */
+        FacilityDesignsResponse: {
+            /**
+             * @description Success status
+             * @default success
+             */
+            status: components["schemas"]["APIStatus"];
+            /**
+             * Message
+             * @description Human-readable response message
+             */
+            message: string;
+            /**
+             * Timestamp
+             * Format: date-time
+             * @description Response timestamp
+             */
+            timestamp?: string;
+            /**
+             * Request Id
+             * @description Request identifier if provided
+             */
+            request_id?: string | null;
+            data: components["schemas"]["FacilityDesignsData"];
+            /**
+             * Metadata
+             * @description Additional response metadata
+             */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+        };
+        /**
          * FacilityMatchRequest
          * @description Reverse-match request: which designs can a given facility produce?
          * @example {
@@ -10393,9 +10465,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["FacilityDesignsResponse"];
                 };
             };
             /** @description Bad Request */

--- a/src/core/api/models/match/response.py
+++ b/src/core/api/models/match/response.py
@@ -163,3 +163,30 @@ class SimulationResult(BaseModel):
     critical_path: List[Dict[str, Any]] = []
     bottlenecks: List[Dict[str, Any]] = []
     resource_utilization: Dict[str, Any] = {}
+
+
+class FacilityDesignsData(BaseModel):
+    """The ``data`` payload of POST /api/match/facility — reverse matching.
+
+    Derived from the payload captured in
+    ``tests/api/golden/match_facility_shape.json`` before this model existed.
+
+    ``designs`` is deliberately left free-form. The committed fixtures produce
+    no matches, so no golden of a populated list exists, and constraining the
+    item shape from reading the code would risk filtering a field never
+    observed on the wire — the exact failure this whole exercise exists to
+    prevent. The frontend narrows the item for its own use. Tighten this when
+    a fixture that actually matches exists, and freeze the item shape first.
+    """
+
+    okw_id: str
+    facility_name: Optional[str]
+    designs: List[Dict[str, Any]]
+    total_designs: int
+    #: How many manifests were examined to produce `designs`.
+    designs_considered: int
+    processing_time: float
+
+
+class FacilityDesignsResponse(SuccessResponse):
+    data: FacilityDesignsData

--- a/src/core/api/routes/match.py
+++ b/src/core/api/routes/match.py
@@ -89,7 +89,7 @@ from ..models.match.request import (
     SimulateRequest,
     ValidateMatchRequest,
 )
-from ..models.match.response import SimulateResponse
+from ..models.match.response import FacilityDesignsResponse, SimulateResponse
 from ..models.match.suggestion_codes import MATCH_SUGGESTION_CODES
 
 # Create consolidated router
@@ -1031,6 +1031,7 @@ async def match_requirements_from_file(
 @router.post(
     "/facility",
     status_code=status.HTTP_200_OK,
+    response_model=FacilityDesignsResponse,
     summary="Reverse Match (Designs a Facility Can Produce)",
     description="""
     Reverse matching: given an OKW facility, return the OKH designs it can produce.

--- a/tests/api/golden/match_facility_shape.json
+++ b/tests/api/golden/match_facility_shape.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "designs": [],
+    "designs_considered": "*",
+    "facility_name": "*",
+    "okw_id": "*",
+    "processing_time": "*",
+    "total_designs": "*"
+  },
+  "message": "*",
+  "metadata": {
+    "processing_time": "*",
+    "timestamp": "*"
+  },
+  "request_id": "*",
+  "status": "*",
+  "timestamp": "*"
+}

--- a/tests/integration/test_match_facility_contract.py
+++ b/tests/integration/test_match_facility_contract.py
@@ -1,0 +1,82 @@
+"""Contract: POST /api/match/facility is shape-frozen before it gains a model.
+
+Reverse matching: given an OKW facility, which OKH designs can it produce.
+
+Frozen structurally rather than by value. The integration ``client`` fixture is
+session-scoped, so the designs this returns depend on which OKH records other
+tests created — value-freezing that would be a flaky test dressed as a strict
+one (see tests/api/test_filetypes_utility_contract.py, where exactly that had
+to be undone). Keys are what a ``response_model`` can drop, so keys are what
+this freezes.
+
+To change the contract deliberately:
+    BLESS_MATCH_CONTRACT=1 .venv/bin/python -m pytest \
+        tests/integration/test_match_facility_contract.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.record_fixtures import okh_manifest_dict, okw_facility_dict
+
+pytestmark = pytest.mark.integration
+
+GOLDEN = (
+    Path(__file__).resolve().parents[1] / "api" / "golden" / "match_facility_shape.json"
+)
+
+
+def _structure(node):
+    """Every key kept, every leaf reduced to a mark; lists merged to one item."""
+    if isinstance(node, dict):
+        return {k: _structure(v) for k, v in sorted(node.items())}
+    if isinstance(node, list):
+        merged: dict = {}
+        for item in node:
+            shaped = _structure(item)
+            if not isinstance(shaped, dict):
+                return ["*"]
+            for key, value in shaped.items():
+                merged.setdefault(key, value)
+        return [dict(sorted(merged.items()))] if merged else []
+    return "*"
+
+
+def test_reverse_match_payload_keeps_every_field_it_declares(client):
+    # A design as well as a facility: an empty `designs` list would freeze the
+    # envelope and say nothing about the item shape, which is what a client
+    # ranks over.
+    okh = client.post("/api/okh/create", json={"content": okh_manifest_dict()})
+    assert okh.status_code == 201, okh.text
+    created = client.post("/api/okw/create", json={"content": okw_facility_dict()})
+    assert created.status_code == 201, created.text
+
+    response = client.post(
+        "/api/match/facility",
+        json={
+            "okw_id": created.json()["okw"]["id"],
+            "min_confidence": 0.0,
+            "max_results": 5,
+        },
+    )
+    assert response.status_code == 200, response.text
+    body = _structure(response.json())
+
+    if os.getenv("BLESS_MATCH_CONTRACT"):
+        GOLDEN.parent.mkdir(parents=True, exist_ok=True)
+        GOLDEN.write_text(json.dumps(body, indent=2, sort_keys=True) + "\n")
+        pytest.skip("golden re-blessed")
+
+    assert GOLDEN.exists(), (
+        f"No golden at {GOLDEN}. Capture one with BLESS_MATCH_CONTRACT=1 BEFORE "
+        "adding a response_model."
+    )
+    assert body == json.loads(GOLDEN.read_text()), (
+        "POST /api/match/facility changed shape. If a response_model was just "
+        "added, it is filtering a field the route used to return."
+    )

--- a/tests/parity/test_response_models.py
+++ b/tests/parity/test_response_models.py
@@ -40,8 +40,16 @@ ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
         ("DELETE", "/api/asset/{id}"),
         ("POST", "/api/convert/to-datasheet"),
         ("GET", "/api/identity/security-policy"),
+        # Two structurally different payloads, chosen by matching_mode:
+        # single-level returns `solutions` (a list) with matching_metrics;
+        # nested returns `solution` (one) with match_summary, coverage_gaps and
+        # suggestions. One model would filter whichever branch it is not.
+        #
+        # Unlike /api/utility/metrics this IS typable — matching_mode is a
+        # literal discriminator, so a discriminated union fits — but it needs a
+        # golden for BOTH branches, and no in-process test exercises this route
+        # today. Deferred as its own change rather than guessed at here.
         ("POST", "/api/match"),
-        ("POST", "/api/match/facility"),
         ("POST", "/api/okh/diff-collection"),
         ("GET", "/api/okh/export-collection"),
         ("POST", "/api/okh/import-collection"),


### PR DESCRIPTION
Fourth router group of #373. **One operation off the debt list: 26 → 25.** The other match route is *scoped* rather than done, and its allowlist row now says why.

## What landed

`POST /api/match/facility` gets a typed envelope: `okw_id`, `facility_name`, `designs`, `total_designs`, `designs_considered`, `processing_time`.

Frozen structurally rather than by value — the integration `client` fixture is session-scoped and the designs depend on which OKH records other tests created. That is the same trap that had to be undone for `utility_metrics` in the previous group, applied deliberately this time rather than discovered.

## `designs` is left free-form, and that is the reviewable decision

The committed fixtures produce **no matches**, so there is no golden of a populated list. Writing an item model from reading the code would constrain a shape nobody has observed on the wire — and `response_model` filters, so anything I got wrong would be dropped silently.

That is precisely the failure this epic exists to close, and committing it while closing it would be perverse. The frontend keeps its own `FacilityDesign` narrowing; the model records what would be needed to tighten it (a fixture that actually matches, and a golden of the item shape first).

**Related, worth knowing:** the existing integration test asserts each design carries `okh_id`/`okh_title`/`confidence`/`rank` — but that loop never executes, because the list is always empty. The assertion has been vacuous.

## `POST /api/match` stays on the allowlist, annotated

Unlike `/api/utility/metrics`, it **is** typable. It returns two structurally different payloads:

| mode | payload |
|---|---|
| single-level | `solutions` (list) + `matching_metrics` + `validation_results` |
| nested | `solution` (one) + `match_summary` + `coverage_gaps` + suggestions |

and `matching_mode` is a literal discriminator, so a discriminated union fits cleanly.

What is missing is a golden for **both** branches and an in-process test to build one on — nothing exercises this route today except live-URL e2e. Deferred as its own change rather than guessed at, with the reasoning recorded in the row so whoever takes it starts from the right place.

## Verification

`make ready`: 14/14. `frontend-ready`: all stages — 746 unit, 237 e2e.

Refs #373. Remaining: `/api/match` (1, scoped above), okh (4), asset/convert/identity (3), supply-tree (6), package (10), plus `/metrics` recorded as untypable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qew1kZog2JA8AKCgLxzn5X
